### PR TITLE
feat: implement get_metrics for global waste and token tracking (#55)

### DIFF
--- a/contracts/scavenger/src/contract.rs
+++ b/contracts/scavenger/src/contract.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
 
 use crate::events;
 use crate::storage::Storage;
-use crate::types::{Incentive, Material, Participant, Role, WasteTransfer, WasteType};
+use crate::types::{GlobalMetrics, Incentive, Material, Participant, Role, WasteTransfer, WasteType};
 
 #[contract]
 pub struct ScavengerContract;
@@ -64,6 +64,22 @@ impl ScavengerContract {
     pub fn get_total_earned(env: &Env) -> i128 {
         Storage::get_total_earned(env)
     }
+
+    // ========== Global Metrics (Issue #55) ==========
+
+    /// Retrieve global contract metrics (total wastes and total tokens earned)
+    pub fn get_metrics(env: &Env) -> GlobalMetrics {
+        // We use the Material counter (MAT_CNT) to determine total waste items logged.
+        // This calculates the metric efficiently from storage without iteration.
+        let waste_count = env.storage().instance().get(&soroban_sdk::symbol_short!("MAT_CNT")).unwrap_or(0);
+        
+        GlobalMetrics {
+            total_wastes_count: waste_count,
+            total_tokens_earned: Storage::get_total_earned(env),
+        }
+    }
+
+    // ===============================================
 
     /// Update the token address (admin only)
     pub fn update_token_address(env: &Env, admin: Address, new_address: Address) {

--- a/contracts/scavenger/src/lib.rs
+++ b/contracts/scavenger/src/lib.rs
@@ -3,5 +3,10 @@
 mod contract;
 mod storage;
 mod test;
+mod events;
+mod types;
 
 pub use contract::*;
+// This ensures that all types, including the new GlobalMetrics, 
+// are exported and available for tests and external queries.
+pub use types::*;

--- a/contracts/scavenger/src/types.rs
+++ b/contracts/scavenger/src/types.rs
@@ -181,3 +181,12 @@ impl ParticipantStats {
         }
     }
 }
+/// Global contract metrics
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalMetrics {
+    /// Total number of waste items logged in the system
+    pub total_wastes_count: u64,
+    /// Total amount of tokens earned across all participants
+    pub total_tokens_earned: i128,
+}


### PR DESCRIPTION
## Overview
This PR implements the `get_metrics` query function as required by Issue #55. It provides a real-time, gas-efficient way to retrieve global contract statistics.

## Tasks Completed
- [x] Created `GlobalMetrics` struct in `types.rs` to encapsulate total waste and token counts.
- [x] Implemented `get_metrics` in `contract.rs` using an O(1) storage lookup strategy.
- [x] Updated `lib.rs` to ensure proper module exports and visibility of new metrics types.

## Technical Details
- **Efficiency:** Instead of iterating over materials (which is expensive in Soroban), the function reads the `MAT_CNT` counter and the `TOTAL_EARNED` state directly from instance storage.
- **Accuracy:** Data is fetched directly from the persistent storage keys updated during the material submission and reward distribution lifecycles.

## Files Modified
- `contracts/scavenger/src/types.rs`
- `contracts/scavenger/src/contract.rs`
- `contracts/scavenger/src/lib.rs`

Closes #55