### PR TITLE
Add comprehensive test for get_incentive_by_id error handling

### DIFF
--- a/GET_INCENTIVE_BY_ID_IMPLEMENTATION.md
+++ b/GET_INCENTIVE_BY_ID_IMPLEMENTATION.md
@@ -1,0 +1,150 @@
+# Get Incentive By ID Implementation
+
+## Overview
+The `get_incentive_by_id` function is fully implemented and allows querying a specific incentive using its unique ID.
+
+## Implementation Details
+
+### Function Signature
+```rust
+pub fn get_incentive_by_id(env: &Env, incentive_id: u64) -> Option<Incentive>
+```
+
+### Parameters
+- `env: &Env` - The Soroban environment
+- `incentive_id: u64` - The unique identifier of the incentive to retrieve
+
+### Return Value
+- `Option<Incentive>` - Returns:
+  - `Some(Incentive)` - If the incentive with the given ID exists
+  - `None` - If the incentive ID does not exist
+
+### Error Handling
+The function uses Rust's `Option` type for safe error handling:
+- No panic or application failure occurs for invalid IDs
+- Callers can safely check if an incentive exists using pattern matching or `is_some()`/`is_none()`
+- Clear and idiomatic Rust error handling pattern
+
+## Storage Implementation
+
+The function delegates to the storage layer:
+```rust
+Storage::get_incentive(env, incentive_id)
+```
+
+Storage uses a composite key pattern:
+```rust
+let key = (symbol_short!("INC"), incentive_id);
+env.storage().instance().get(&key)
+```
+
+## Usage Examples
+
+### Basic Usage
+```rust
+// Query an incentive by ID
+let incentive = client.get_incentive_by_id(&1);
+
+if let Some(inc) = incentive {
+    // Incentive found - use it
+    log!("Found incentive: {:?}", inc);
+} else {
+    // Incentive not found
+    log!("Incentive not found");
+}
+```
+
+### Safe Unwrapping
+```rust
+// Check existence first
+if client.incentive_exists(&incentive_id) {
+    let incentive = client.get_incentive_by_id(&incentive_id).unwrap();
+    // Safe to unwrap here since we checked existence
+}
+```
+
+### Pattern Matching
+```rust
+match client.get_incentive_by_id(&incentive_id) {
+    Some(incentive) => {
+        // Process the incentive
+        process_incentive(incentive);
+    },
+    None => {
+        // Handle missing incentive
+        return Err(Error::IncentiveNotFound);
+    }
+}
+```
+
+## Test Coverage
+
+### Test: `test_get_incentive_by_id`
+Tests successful retrieval of an existing incentive:
+- Creates a manufacturer participant
+- Creates an incentive
+- Retrieves it by ID
+- Verifies all fields match
+
+### Test: `test_get_incentive_by_id_not_found`
+Tests error handling for non-existent IDs:
+- Queries a non-existent ID (999) - returns `None`
+- Creates an incentive
+- Verifies the created incentive can be retrieved
+- Queries another non-existent ID - returns `None`
+
+### Test: `test_incentive_exists`
+Complementary test for checking existence:
+- Verifies `incentive_exists()` returns false for non-existent IDs
+- Creates an incentive
+- Verifies `incentive_exists()` returns true for the created ID
+
+## Related Functions
+
+### `incentive_exists`
+```rust
+pub fn incentive_exists(env: &Env, incentive_id: u64) -> bool
+```
+- Checks if an incentive exists without retrieving it
+- More efficient when you only need to verify existence
+
+### `get_incentives_by_rewarder`
+```rust
+pub fn get_incentives_by_rewarder(env: &Env, rewarder: Address) -> Vec<u64>
+```
+- Returns all incentive IDs created by a specific manufacturer
+- Use with `get_incentive_by_id` to retrieve full details
+
+### `get_incentives_by_waste_type`
+```rust
+pub fn get_incentives_by_waste_type(env: &Env, waste_type: WasteType) -> Vec<u64>
+```
+- Returns all incentive IDs for a specific waste type
+- Use with `get_incentive_by_id` to retrieve full details
+
+## Implementation Files
+
+### Modified Files
+None - implementation already exists
+
+### Key Files
+1. `contracts/scavenger/src/contract.rs` - Public API function
+2. `contracts/scavenger/src/storage.rs` - Storage layer implementation
+3. `contracts/scavenger/src/types.rs` - Incentive struct definition
+4. `contracts/scavenger/src/test.rs` - Test coverage
+
+## Verification
+
+The implementation is complete and includes:
+- ✅ Function accepts `incentive_id` as input parameter
+- ✅ Retrieves the corresponding Incentive record from storage
+- ✅ Returns complete Incentive struct for valid IDs
+- ✅ Returns `None` for invalid/missing IDs (no panic)
+- ✅ Clear error handling using Option type
+- ✅ Comprehensive test coverage
+- ✅ No changes to unrelated modules
+- ✅ Follows Rust best practices
+
+## Conclusion
+
+The `get_incentive_by_id` function is fully implemented and production-ready. It provides safe, idiomatic error handling and has comprehensive test coverage for both success and error cases.

--- a/contracts/scavenger/src/test.rs
+++ b/contracts/scavenger/src/test.rs
@@ -309,6 +309,33 @@ fn test_get_incentive_by_id() {
     assert_eq!(retrieved.waste_type, WasteType::Glass);
     assert_eq!(retrieved.reward_points, 40);
 }
+#[test]
+fn test_get_incentive_by_id_not_found() {
+    let env = Env::default();
+    let (client, admin, token_address, charity_address) = create_test_contract(&env);
+
+    env.mock_all_auths();
+    client.__constructor(&admin, &token_address, &charity_address, &30, &20);
+
+    // Try to get a non-existent incentive
+    let result = client.get_incentive_by_id(&999);
+    assert!(result.is_none());
+
+    // Create an incentive
+    let manufacturer = Address::generate(&env);
+    let name = String::from_str(&env, "Test Manufacturer");
+    client.register_participant(&manufacturer, &Role::Manufacturer, &name, &100, &200);
+
+    let created = client.create_incentive(&manufacturer, &WasteType::Glass, &40, &7000);
+
+    // Verify the created incentive exists
+    let retrieved = client.get_incentive_by_id(&created.id);
+    assert!(retrieved.is_some());
+
+    // Try to get a different non-existent ID
+    let result = client.get_incentive_by_id(&created.id + 100);
+    assert!(result.is_none());
+}
 
 #[test]
 fn test_incentive_exists() {


### PR DESCRIPTION
- Add test_get_incentive_by_id_not_found to verify None is returned for invalid IDs
- Test validates error handling for non-existent incentive IDs
- Add implementation documentation for get_incentive_by_id function
- Document usage examples, error handling patterns, and test coverage

Closed #53