### PR TITLE
[Contract/Bug] Fix transfer_waste v1/v2 inconsistency (#165)

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -961,6 +961,16 @@ impl ScavengerContract {
     }
 
     /// Transfer waste ownership from one participants to another
+    /// Transfer waste ownership (v1 — u64 waste IDs, String note).
+    ///
+    /// # Deprecated
+    /// Use [`transfer_waste_v2`] instead. v2 uses u128 waste IDs, records
+    /// GPS coordinates, validates transfer routes, and maintains the
+    /// `participant_wastes` index. This function is kept for backward
+    /// compatibility and will be removed in a future release.
+    ///
+    /// Migration: replace `transfer_waste(id, from, to, note)` with
+    /// `transfer_waste_v2(id as u128, from, to, latitude, longitude)`.
     pub fn transfer_waste(
         env: Env,
         waste_id: u64,
@@ -970,28 +980,29 @@ impl ScavengerContract {
     ) -> Material {
         from.require_auth();
 
-        // Verify both participants are registered
-        if !Self::is_participant_registered(env.clone(), from.clone()) {
-            panic!("Sender not registered");
-        }
-        if !Self::is_participant_registered(env.clone(), to.clone()) {
-            panic!("Receiver not registered");
-        }
+        Self::require_registered(&env, &from);
+        Self::require_registered(&env, &to);
 
-        // Get and update material
         let mut material: Material =
             Self::get_waste_internal(&env, waste_id).expect("Waste not found");
 
-        // Verify sender owns the waste
         if material.submitter != from {
             panic!("Only waste owner can transfer");
         }
 
-        // Update ownership
+        // Align with v2: reject transfers on deactivated waste
+        if !material.is_active {
+            panic!("Cannot transfer deactivated waste");
+        }
+
+        // Align with v2: enforce valid transfer routes
+        if !Self::is_valid_transfer(env.clone(), from.clone(), to.clone()) {
+            panic!("Invalid transfer: role combination not allowed");
+        }
+
         material.submitter = to.clone();
         Self::set_waste(&env, waste_id, &material);
 
-        // Record transfer in history
         events::emit_waste_transferred(&env, waste_id, &from, &to);
         Self::record_transfer(&env, waste_id, from, to, note);
 

--- a/stellar-contract/tests/transfer_waste_consistency_test.rs
+++ b/stellar-contract/tests/transfer_waste_consistency_test.rs
@@ -1,0 +1,150 @@
+/// Tests verifying consistent behavior between transfer_waste (v1) and transfer_waste_v2.
+///
+/// Key behavioral differences documented here:
+/// - v1: waste_id u64, note String, returns Material, history under ("transfers", id)
+/// - v2: waste_id u128, lat/lon i128, returns WasteTransfer, history under ("transfer_history", id)
+/// - Both now: require registered participants, reject deactivated waste, enforce role routes
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, String};
+use stellar_scavngr_contract::{ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType};
+
+fn setup(env: &Env) -> (ScavengerContractClient, Address, Address, Address) {
+    let contract_id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(env, &contract_id);
+    let recycler = Address::generate(env);
+    let collector = Address::generate(env);
+    let manufacturer = Address::generate(env);
+    env.mock_all_auths();
+    client.register_participant(&recycler, &ParticipantRole::Recycler, &symbol_short!("Rec"), &0, &0);
+    client.register_participant(&collector, &ParticipantRole::Collector, &symbol_short!("Col"), &0, &0);
+    client.register_participant(&manufacturer, &ParticipantRole::Manufacturer, &symbol_short!("Mfr"), &0, &0);
+    (client, recycler, collector, manufacturer)
+}
+
+// ── Consistent: both versions transfer ownership ──────────────────────────────
+
+#[test]
+fn test_v1_transfers_ownership() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+    let note = String::from_str(&env, "test");
+
+    let material = client.submit_material(&WasteType::Plastic, &1000, &recycler, &note);
+    let result = client.transfer_waste(&material.id, &recycler, &collector, &note);
+
+    assert_eq!(result.submitter, collector);
+}
+
+#[test]
+fn test_v2_transfers_ownership() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000, &recycler, &0, &0);
+    let transfer = client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
+
+    assert_eq!(transfer.from, recycler);
+    assert_eq!(transfer.to, collector);
+}
+
+// ── Consistent: both reject unregistered sender ───────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_v1_rejects_unregistered_sender() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+    let note = String::from_str(&env, "test");
+    let stranger = Address::generate(&env);
+    env.mock_all_auths();
+
+    let material = client.submit_material(&WasteType::Plastic, &1000, &recycler, &note);
+    client.transfer_waste(&material.id, &stranger, &collector, &note);
+}
+
+#[test]
+#[should_panic]
+fn test_v2_rejects_unregistered_sender() {
+    let env = Env::default();
+    let (client, recycler, _, _) = setup(&env);
+    let stranger = Address::generate(&env);
+    env.mock_all_auths();
+
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000, &recycler, &0, &0);
+    client.transfer_waste_v2(&waste_id, &stranger, &recycler, &0, &0);
+}
+
+// ── Consistent: v2 rejects deactivated waste ─────────────────────────────────
+// Note: v1 Material.is_active is set at creation and has no public deactivation
+// path via the current API — deactivate_waste only operates on v2 (Waste) storage.
+
+#[test]
+#[should_panic(expected = "Cannot transfer deactivated waste")]
+fn test_v2_rejects_deactivated_waste() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+
+    client.initialize_admin(&recycler);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000, &recycler, &0, &0);
+    client.deactivate_waste(&waste_id, &recycler);
+    client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
+}
+
+// ── Consistent: both enforce valid role routes ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Invalid transfer")]
+fn test_v1_rejects_invalid_role_route() {
+    let env = Env::default();
+    let (client, recycler, _, manufacturer) = setup(&env);
+    // collector -> recycler is not a valid route
+    let note = String::from_str(&env, "test");
+
+    let material = client.submit_material(&WasteType::Plastic, &1000, &recycler, &note);
+    // recycler -> manufacturer is valid, but manufacturer -> recycler is not
+    client.transfer_waste(&material.id, &recycler, &manufacturer, &note);
+    // now manufacturer tries to send back to recycler (invalid)
+    client.transfer_waste(&material.id, &manufacturer, &recycler, &note);
+}
+
+#[test]
+#[should_panic(expected = "Invalid transfer")]
+fn test_v2_rejects_invalid_role_route() {
+    let env = Env::default();
+    let (client, recycler, _, manufacturer) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000, &recycler, &0, &0);
+    client.transfer_waste_v2(&waste_id, &recycler, &manufacturer, &0, &0);
+    // manufacturer -> recycler is not a valid route
+    client.transfer_waste_v2(&waste_id, &manufacturer, &recycler, &0, &0);
+}
+
+// ── v2-only: records GPS coordinates ─────────────────────────────────────────
+
+#[test]
+fn test_v2_records_coordinates() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Metal, &2000, &recycler, &0, &0);
+    let transfer = client.transfer_waste_v2(&waste_id, &recycler, &collector, &40_000_000, &-74_000_000);
+
+    assert_eq!(transfer.latitude, 40_000_000);
+    assert_eq!(transfer.longitude, -74_000_000);
+}
+
+// ── v2-only: updates participant_wastes index ─────────────────────────────────
+
+#[test]
+fn test_v2_updates_participant_wastes_index() {
+    let env = Env::default();
+    let (client, recycler, collector, _) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Metal, &2000, &recycler, &0, &0);
+    client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
+
+    let recycler_wastes = client.get_participant_wastes_v2(&recycler);
+    let collector_wastes = client.get_participant_wastes_v2(&collector);
+
+    assert!(!recycler_wastes.contains(&waste_id));
+    assert!(collector_wastes.contains(&waste_id));
+}


### PR DESCRIPTION
## Summary

Closes #165

Documents, aligns, and deprecates `transfer_waste` (v1) in favor of `transfer_waste_v2`.

## Differences documented

| | `transfer_waste` (v1) | `transfer_waste_v2` (v2) |
|---|---|---|
| waste_id type | `u64` | `u128` |
| extra params | `note: String` | `latitude, longitude: i128` |
| return type | `Material` | `WasteTransfer` |
| GPS recorded | ❌ | ✅ |
| participant_wastes index | ❌ | ✅ |
| storage key | `("waste", id)` | `("waste_v2", id)` |
| history key | `("transfers", id)` | `("transfer_history", id)` |

## Changes

### `stellar-contract/src/lib.rs`
- Added deprecation doc comment to `transfer_waste` with migration path
- Aligned v1 with v2 behavior:
  - Replaced inline registration checks with `require_registered()`
  - Added `is_active` check (rejects deactivated waste)
  - Added `is_valid_transfer()` role route enforcement

### `stellar-contract/tests/transfer_waste_consistency_test.rs` (new)
- Both versions transfer ownership
- Both reject unregistered senders
- v2 rejects deactivated waste
- Both enforce valid role routes (Recycler→Collector, Recycler→Manufacturer, Collector→Manufacturer)
- v2-only: GPS coordinates recorded in transfer record
- v2-only: `participant_wastes` index updated after transfer

## Migration path

```rust
// Before (v1)
client.transfer_waste(&waste_id, &from, &to, &note);

// After (v2)
client.transfer_waste_v2(&(waste_id as u128), &from, &to, &latitude, &longitude);
```

v1 will be removed after all callers have migrated.