### PR TITLE
[Contract/Bug] Deprecate redundant get_waste_by_id (#166)

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -1495,6 +1495,10 @@ impl ScavengerContract {
     }
 
     /// Get waste by ID (alias for backward compatibility)
+    ///
+    /// # Deprecated
+    /// Use [`get_waste`] instead. This function is an exact alias and will be
+    /// removed in a future release.
     pub fn get_waste_by_id(env: Env, waste_id: u64) -> Option<Material> {
         Self::get_waste(env, waste_id)
     }

--- a/stellar-contract/tests/get_waste_test.rs
+++ b/stellar-contract/tests/get_waste_test.rs
@@ -240,23 +240,21 @@ fn test_get_waste_alias_compatibility() {
     // Submit material
     let material = client.submit_material(&WasteType::Glass, &6000, &user, &description);
 
-    // All three functions should return the same data
+    // get_waste and get_material are aliases — both must return identical data.
+    // get_waste_by_id is deprecated; callers should use get_waste directly.
     let w1 = client.get_waste(&material.id);
-    let w2 = client.get_waste_by_id(&material.id);
-    let w3 = client.get_material(&material.id);
+    let w2 = client.get_material(&material.id);
 
     assert!(w1.is_some());
     assert!(w2.is_some());
-    assert!(w3.is_some());
 
     let waste1 = w1.unwrap();
     let waste2 = w2.unwrap();
-    let waste3 = w3.unwrap();
 
     assert_eq!(waste1.id, waste2.id);
-    assert_eq!(waste2.id, waste3.id);
     assert_eq!(waste1.waste_type, waste2.waste_type);
-    assert_eq!(waste2.waste_type, waste3.waste_type);
+    assert_eq!(waste1.weight, waste2.weight);
+    assert_eq!(waste1.submitter, waste2.submitter);
 }
 
 #[test]

--- a/stellar-contract/tests/query_functions_test.rs
+++ b/stellar-contract/tests/query_functions_test.rs
@@ -467,7 +467,7 @@ fn test_get_waste_by_id_v1() {
 
     let material = client.submit_material(&WasteType::Metal, &3000, &recycler, &soroban_sdk::String::from_str(&env, "test"));
 
-    let retrieved = client.get_waste_by_id(&material.id).unwrap();
+    let retrieved = client.get_waste(&material.id).unwrap();
 
     assert_eq!(retrieved.id, material.id);
     assert_eq!(retrieved.waste_type, WasteType::Metal);


### PR DESCRIPTION
## Summary

Closes #166

## Confirmation

Both functions are identical — `get_waste_by_id` has always been a one-line delegate to `get_waste`:

```rust
pub fn get_waste_by_id(env: Env, waste_id: u64) -> Option<Material> {
    Self::get_waste(env, waste_id)
}
```

## Changes

- **`src/lib.rs`**: Added deprecation doc comment to `get_waste_by_id` pointing to `get_waste`
- **`tests/query_functions_test.rs`**: Replaced `get_waste_by_id` call with `get_waste`
- **`tests/get_waste_test.rs`** (`test_get_waste_alias_compatibility`): Removed `get_waste_by_id` call; test now asserts `get_waste` and `get_material` return identical results

## Migration

```rust
// Before
client.get_waste_by_id(&id)

// After
client.get_waste(&id)
```