### PR TITLE
Fix/reward config single storage key

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -16,12 +16,28 @@ use soroban_sdk::{
 // Storage keys
 const ADMIN: Symbol = symbol_short!("ADMIN");
 const CHARITY: Symbol = symbol_short!("CHARITY");
-const COLLECTOR_PCT: Symbol = symbol_short!("COL_PCT");
-const OWNER_PCT: Symbol = symbol_short!("OWN_PCT");
+const REWARD_CFG: Symbol = symbol_short!("RWD_CFG");
 const TOTAL_WEIGHT: Symbol = symbol_short!("TOT_WGT");
 const TOTAL_TOKENS: Symbol = symbol_short!("TOT_TKN");
 const REENTRANCY_GUARD: Symbol = symbol_short!("RE_GUARD");
 const TOKEN_ADDR: Symbol = symbol_short!("TKN_ADDR");
+
+/// Reward distribution percentages stored as a single instance-storage entry.
+///
+/// Consolidating `collector_percentage` and `owner_percentage` into one struct
+/// means a single `storage.get` call fetches both values, halving the number
+/// of instance-storage lookups on every `_reward_tokens` invocation.
+///
+/// Migration note: contracts deployed with the old two-key layout
+/// (`COL_PCT` / `OWN_PCT`) should call `set_percentages` once after upgrade
+/// to write the new `RWD_CFG` key; the old keys are then unused and will
+/// expire with the instance TTL.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardConfig {
+    pub collector_percentage: u32,
+    pub owner_percentage: u32,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -219,7 +235,21 @@ impl ScavengerContract {
 
     // ========== Percentage Configuration Functions ==========
 
-    /// Set both collector and owner percentages (admin only)
+    /// Read the reward config in one storage lookup (internal helper).
+    fn get_reward_config(env: &Env) -> RewardConfig {
+        env.storage()
+            .instance()
+            .get(&REWARD_CFG)
+            .unwrap_or(RewardConfig {
+                collector_percentage: 5,
+                owner_percentage: 50,
+            })
+    }
+
+    /// Set both collector and owner percentages (admin only).
+    ///
+    /// Writes a single `RewardConfig` entry instead of two separate keys,
+    /// so every subsequent read costs one instance lookup instead of two.
     pub fn set_percentages(
         env: Env,
         admin: Address,
@@ -227,56 +257,49 @@ impl ScavengerContract {
         owner_percentage: u32,
     ) {
         Self::only_admin(&env, &admin);
-        
-        // Validate percentages sum
+
         if collector_percentage + owner_percentage > 100 {
             panic!("Total percentages cannot exceed 100");
         }
 
-        env.storage()
-            .instance()
-            .set(&COLLECTOR_PCT, &collector_percentage);
-        env.storage().instance().set(&OWNER_PCT, &owner_percentage);
+        env.storage().instance().set(
+            &REWARD_CFG,
+            &RewardConfig { collector_percentage, owner_percentage },
+        );
     }
 
-    /// Get the collector percentage
+    /// Get the collector percentage.
     pub fn get_collector_percentage(env: Env) -> Option<u32> {
-        env.storage().instance().get(&COLLECTOR_PCT)
+        Some(Self::get_reward_config(&env).collector_percentage)
     }
 
-    /// Get the owner percentage
+    /// Get the owner percentage.
     pub fn get_owner_percentage(env: Env) -> Option<u32> {
-        env.storage().instance().get(&OWNER_PCT)
+        Some(Self::get_reward_config(&env).owner_percentage)
     }
 
-    /// Update only the collector percentage (admin only)
+    /// Update only the collector percentage (admin only).
     pub fn set_collector_percentage(env: Env, admin: Address, new_percentage: u32) {
         Self::only_admin(&env, &admin);
-        
-        // Get current owner percentage to validate total
-        let owner_pct: u32 = env.storage().instance().get(&OWNER_PCT).unwrap_or(0);
 
-        if new_percentage + owner_pct > 100 {
+        let mut cfg = Self::get_reward_config(&env);
+        if new_percentage + cfg.owner_percentage > 100 {
             panic!("Total percentages cannot exceed 100");
         }
-
-        env.storage()
-            .instance()
-            .set(&COLLECTOR_PCT, &new_percentage);
+        cfg.collector_percentage = new_percentage;
+        env.storage().instance().set(&REWARD_CFG, &cfg);
     }
 
-    /// Update only the owner percentage (admin only)
+    /// Update only the owner percentage (admin only).
     pub fn set_owner_percentage(env: Env, admin: Address, new_percentage: u32) {
         Self::only_admin(&env, &admin);
-        
-        // Get current collector percentage to validate total
-        let collector_pct: u32 = env.storage().instance().get(&COLLECTOR_PCT).unwrap_or(0);
 
-        if collector_pct + new_percentage > 100 {
+        let mut cfg = Self::get_reward_config(&env);
+        if cfg.collector_percentage + new_percentage > 100 {
             panic!("Total percentages cannot exceed 100");
         }
-
-        env.storage().instance().set(&OWNER_PCT, &new_percentage);
+        cfg.owner_percentage = new_percentage;
+        env.storage().instance().set(&REWARD_CFG, &cfg);
     }
 
     // ========== Token Management Functions ==========
@@ -475,9 +498,10 @@ impl ScavengerContract {
             return;
         }
 
-        // Single read for each percentage (2 reads total, unchanged)
-        let collector_pct: u32 = env.storage().instance().get(&COLLECTOR_PCT).unwrap_or(5);
-        let owner_pct: u32 = env.storage().instance().get(&OWNER_PCT).unwrap_or(50);
+        // One storage lookup fetches both percentages (was two separate gets)
+        let cfg = Self::get_reward_config(env);
+        let collector_pct = cfg.collector_percentage;
+        let owner_pct = cfg.owner_percentage;
 
         let collector_share = (total_reward * (collector_pct as u128)) / 100;
         let owner_share = (total_reward * (owner_pct as u128)) / 100;

--- a/stellar-contract/tests/reward_tokens_bench_test.rs
+++ b/stellar-contract/tests/reward_tokens_bench_test.rs
@@ -160,3 +160,55 @@ fn regression_collector_still_rewarded() {
     let sp = client.get_participant(&submitter).unwrap();
     assert_eq!(sp.total_tokens_earned, 0);
 }
+
+// ---------------------------------------------------------------------------
+// RewardConfig single-read benchmarks
+// ---------------------------------------------------------------------------
+
+/// Confirm that get_collector_percentage and get_owner_percentage both return
+/// the values written by set_percentages (single-struct round-trip).
+#[test]
+fn bench_reward_config_single_read() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.set_percentages(&admin, &15, &35);
+
+    let before = env.budget().cpu_instruction_count();
+    let col = client.get_collector_percentage().unwrap();
+    let own = client.get_owner_percentage().unwrap();
+    let after = env.budget().cpu_instruction_count();
+
+    println!("[bench] reward_config reads cpu_instructions={}", after - before);
+    assert_eq!(col, 15);
+    assert_eq!(own, 35);
+}
+
+/// set_collector_percentage must not clobber owner_percentage.
+#[test]
+fn regression_partial_update_preserves_other_field() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.set_percentages(&admin, &10, &40);
+    client.set_collector_percentage(&admin, &20);
+
+    assert_eq!(client.get_collector_percentage().unwrap(), 20);
+    assert_eq!(client.get_owner_percentage().unwrap(), 40); // must be unchanged
+
+    client.set_owner_percentage(&admin, &30);
+
+    assert_eq!(client.get_collector_percentage().unwrap(), 20); // must be unchanged
+    assert_eq!(client.get_owner_percentage().unwrap(), 30);
+}
+
+/// Verify that reward_tokens_bench still works correctly after the
+/// RewardConfig migration (end-to-end smoke test).
+#[test]
+fn bench_reward_tokens_after_config_migration() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    // depth=3 exercises both the config read and the collector loop
+    let cpu = measure_verify(&env, &client, 3);
+    println!("[bench] post-migration depth=3 cpu_instructions={cpu}");
+}


### PR DESCRIPTION
Title: perf: consolidate reward config into single instance-storage key

Body:

## Problem

collector_percentage and owner_percentage were stored as two separate instance-storage keys (COL_PCT / OWN_PCT). Every
call to _reward_tokens (triggered on every verify_material) performed two independent storage.get lookups — two key 
deserialisations, two value deserialisations.

## Solution

Introduce a RewardConfig struct stored under a single key RWD_CFG. Both percentages are fetched in one lookup via a 
get_reward_config() helper.

Before:  storage.get(COL_PCT)  +  storage.get(OWN_PCT)  →  2 lookups
After:   storage.get(RWD_CFG)                            →  1 lookup


## Changes

- stellar-contract/src/lib.rs
  - Remove COLLECTOR_PCT / OWNER_PCT constants
  - Add REWARD_CFG constant and RewardConfig { collector_percentage, owner_percentage } contracttype
  - Add get_reward_config() private helper — single read, returns defaults if unset
  - set_percentages, set_collector_percentage, set_owner_percentage — read-modify-write the struct atomically (partial
updates no longer risk clobbering the other field)
  - get_collector_percentage / get_owner_percentage — delegate to get_reward_config()
  - _reward_tokens — one get_reward_config() call instead of two separate gets

- stellar-contract/tests/reward_tokens_bench_test.rs
  - bench_reward_config_single_read — measures CPU instructions for both percentage reads
  - regression_partial_update_preserves_other_field — guards against set_collector_percentage clobbering 
owner_percentage and vice versa
  - bench_reward_tokens_after_config_migration — end-to-end smoke test at depth=3

## Migration Note

Contracts already deployed with the old two-key layout must call set_percentages once after upgrading to populate the 
new RWD_CFG key. The old COL_PCT / OWN_PCT keys become unused and will expire naturally with the instance TTL — no 
explicit cleanup needed.

## Testing

bash
cargo test --test reward_tokens_bench_test -- --nocapture
cargo test


closes #184