### PR TITLE
Add shared helper utilities for formatting addresses, token amounts, …

### DIFF
--- a/frontend/src/lib/helpers.ts
+++ b/frontend/src/lib/helpers.ts
@@ -1,0 +1,18 @@
+import { Role, WasteType } from '../api/types';
+
+export const formatAddress = (addr: string): string =>
+  `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+
+export const formatTokenAmount = (amount: bigint | number, decimals = 7): string => {
+  const num = Number(amount) / 10 ** decimals;
+  return num.toLocaleString(undefined, { maximumFractionDigits: decimals });
+};
+
+export const wasteTypeLabel = (type: WasteType): string =>
+  ({ [WasteType.Paper]: 'Paper', [WasteType.PetPlastic]: 'PET Plastic', [WasteType.Plastic]: 'Plastic', [WasteType.Metal]: 'Metal', [WasteType.Glass]: 'Glass' })[type] ?? 'Unknown';
+
+export const roleLabel = (role: Role): string =>
+  ({ [Role.Recycler]: 'Recycler', [Role.Collector]: 'Collector', [Role.Manufacturer]: 'Manufacturer' })[role] ?? 'Unknown';
+
+export const formatDate = (timestamp: number): string =>
+  new Date(timestamp * 1000).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });


### PR DESCRIPTION
Closes #195

> Add shared frontend helper utilities

Introduces src/lib/helpers.ts with common formatting functions used across the app.

Changes
- formatAddress(addr) — truncates a Stellar address to ABCD...WXYZ
- formatTokenAmount(amount, decimals) — converts raw token amount (default 7 decimals) to a locale-formatted string
- wasteTypeLabel(type) — maps WasteType enum to a human-readable string
- roleLabel(role) — maps Role enum to a human-readable string
- formatDate(timestamp) — converts a Unix timestamp to a readable date (e.g. Mar 24, 2026)

Notes
- All helpers are typed against the existing enums in api/types.ts
- No new dependencies introduced