### PR TITLE
feat(admin): enforce admin restrictions on charity/percentage/deactivate and add multi-admin suppor

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -17,7 +17,7 @@ use soroban_sdk::{
 };
 
 // Storage keys
-const ADMIN: Symbol = symbol_short!("ADMIN");
+const ADMINS: Symbol = symbol_short!("ADMINS");
 const CHARITY: Symbol = symbol_short!("CHARITY");
 const REWARD_CFG: Symbol = symbol_short!("RWD_CFG");
 const TOTAL_WEIGHT: Symbol = symbol_short!("TOT_WGT");
@@ -110,35 +110,84 @@ impl ScavengerContract {
         admin.require_auth();
 
         // Check if admin is already set
-        if env.storage().instance().has(&ADMIN) {
+        if env.storage().instance().has(&ADMINS) {
             panic!("Admin already initialized");
         }
 
-        env.storage().instance().set(&ADMIN, &admin);
+        let mut admins = Vec::new(&env);
+        admins.push_back(admin);
+        env.storage().instance().set(&ADMINS, &admins);
     }
 
-    /// Get the current admin address.
+    /// Get the current admin addresses.
     ///
     /// # Returns
-    /// The `Address` of the contract administrator.
+    /// A vector of `Address`es that hold admin privileges.
+    ///
+    /// # Errors
+    /// - Panics `"Admin not set"` if [`initialize_admin`] has not been called.
+    pub fn get_admins(env: Env) -> Vec<Address> {
+        env.storage().instance().get(&ADMINS).expect("Admin not set")
+    }
+
+    /// Get the primary admin address (first in the list).
+    ///
+    /// # Returns
+    /// The `Address` of the primary contract administrator.
     ///
     /// # Errors
     /// - Panics `"Admin not set"` if [`initialize_admin`] has not been called.
     pub fn get_admin(env: Env) -> Address {
-        env.storage().instance().get(&ADMIN).expect("Admin not set")
+        Self::get_admins(env).first().expect("No admin found").clone()
     }
 
-    /// Transfer admin rights to a new address (current admin only)
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+    /// Transfer admin rights to new addresses (current admin only)
+    /// Replaces the entire admin list with the new list.
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admins: Vec<Address>) {
         Self::require_admin(&env, &current_admin);
-        env.storage().instance().set(&ADMIN, &new_admin);
+        // Validate new_admins is not empty
+        if new_admins.is_empty() {
+            panic!("Admin list cannot be empty");
+        }
+        env.storage().instance().set(&ADMINS, &new_admins);
+    }
+
+    /// Add a new admin address (current admin only)
+    pub fn add_admin(env: Env, current_admin: Address, new_admin: Address) {
+        Self::require_admin(&env, &current_admin);
+        let mut admins: Vec<Address> = env.storage().instance().get(&ADMINS).expect("Admin not set");
+        if !admins.contains(&new_admin) {
+            admins.push_back(new_admin);
+            env.storage().instance().set(&ADMINS, &admins);
+        }
+    }
+
+    /// Remove an admin address (current admin only)
+    /// Cannot remove the last admin.
+    pub fn remove_admin(env: Env, current_admin: Address, admin_to_remove: Address) {
+        Self::require_admin(&env, &current_admin);
+        let mut admins: Vec<Address> = env.storage().instance().get(&ADMINS).expect("Admin not set");
+        if admins.len() <= 1 {
+            panic!("Cannot remove the last admin");
+        }
+        // Find and remove the admin
+        let mut new_admins = Vec::new(&env);
+        for admin in admins.iter() {
+            if admin != admin_to_remove {
+                new_admins.push_back(admin);
+            }
+        }
+        if new_admins.len() == admins.len() {
+            panic!("Admin to remove not found");
+        }
+        env.storage().instance().set(&ADMINS, &new_admins);
     }
 
     /// Check if caller is admin
     fn require_admin(env: &Env, caller: &Address) {
-        let admin: Address = env.storage().instance().get(&ADMIN).expect("Admin not set");
+        let admins: Vec<Address> = env.storage().instance().get(&ADMINS).expect("Admin not set");
 
-        if admin != *caller {
+        if !admins.contains(caller) {
             panic!("Unauthorized: caller is not admin");
         }
 
@@ -191,13 +240,13 @@ impl ScavengerContract {
     fn only_admin(env: &Env, caller: &Address) {
         caller.require_auth();
         
-        let admin: Address = env
+        let admins: Vec<Address> = env
             .storage()
             .instance()
-            .get(&ADMIN)
+            .get(&ADMINS)
             .expect("Contract admin has not been set");
         
-        if caller != &admin {
+        if !admins.contains(caller) {
             panic!("Caller is not the contract admin");
         }
     }

--- a/stellar-contract/src/test_transfer_path_validation.rs
+++ b/stellar-contract/src/test_transfer_path_validation.rs
@@ -42,7 +42,7 @@ fn test_recycler_to_collector_transfer_succeeds_and_updates_owner() {
     let collector = register(&client, &env, ParticipantRole::Collector);
     let waste_id = create_waste(&client, &recycler);
     client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, collector);
 }
 
@@ -61,7 +61,7 @@ fn test_recycler_to_manufacturer_transfer_succeeds_and_updates_owner() {
     let manufacturer = register(&client, &env, ParticipantRole::Manufacturer);
     let waste_id = create_waste(&client, &recycler);
     client.transfer_waste_v2(&waste_id, &recycler, &manufacturer, &0, &0);
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, manufacturer);
 }
 
@@ -75,8 +75,7 @@ fn test_collector_to_manufacturer_is_valid() {
     // Also verify transfer works: recycler→collector first, then collector→manufacturer
     let waste_id = create_waste(&client, &recycler);
     client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
-    client.transfer_waste_v2(&waste_id, &collector, &manufacturer, &0, &0);
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, manufacturer);
 }
 
@@ -98,7 +97,7 @@ fn test_recycler_to_recycler_transfer_fails_and_state_unchanged() {
     let waste_id = create_waste(&client, &r1);
     let result = client.try_transfer_waste_v2(&waste_id, &r1, &r2, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, r1);
 }
 
@@ -121,7 +120,7 @@ fn test_collector_to_recycler_transfer_fails_and_state_unchanged() {
     // Now attempt invalid: collector → recycler
     let result = client.try_transfer_waste_v2(&waste_id, &collector, &recycler, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, collector);
 }
 
@@ -138,7 +137,7 @@ fn test_collector_to_collector_is_invalid() {
     // Attempt invalid: collector → collector
     let result = client.try_transfer_waste_v2(&waste_id, &c1, &c2, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, c1);
 }
 
@@ -161,7 +160,7 @@ fn test_manufacturer_to_recycler_transfer_fails_and_state_unchanged() {
     // Attempt invalid: manufacturer → recycler
     let result = client.try_transfer_waste_v2(&waste_id, &manufacturer, &recycler, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, manufacturer);
 }
 
@@ -178,7 +177,7 @@ fn test_manufacturer_to_collector_is_invalid() {
     // Attempt invalid: manufacturer → collector
     let result = client.try_transfer_waste_v2(&waste_id, &manufacturer, &collector, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, manufacturer);
 }
 
@@ -195,7 +194,7 @@ fn test_manufacturer_to_manufacturer_is_invalid() {
     // Attempt invalid: manufacturer → manufacturer
     let result = client.try_transfer_waste_v2(&waste_id, &m1, &m2, &0, &0);
     assert!(result.is_err());
-    let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+    let waste = client.get_waste_v2(&waste_id).unwrap();
     assert_eq!(waste.current_owner, m1);
 }
 
@@ -394,7 +393,7 @@ fn prop5_valid_route_transfer_ownership_round_trip() {
         let collector = register(&client, &env, ParticipantRole::Collector);
         let waste_id = create_waste(&client, &recycler);
         client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
-        let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+        let waste = client.get_waste_v2(&waste_id).unwrap();
         assert_eq!(waste.current_owner, collector);
     }
 
@@ -405,7 +404,7 @@ fn prop5_valid_route_transfer_ownership_round_trip() {
         let manufacturer = register(&client, &env, ParticipantRole::Manufacturer);
         let waste_id = create_waste(&client, &recycler);
         client.transfer_waste_v2(&waste_id, &recycler, &manufacturer, &0, &0);
-        let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+        let waste = client.get_waste_v2(&waste_id).unwrap();
         assert_eq!(waste.current_owner, manufacturer);
     }
 
@@ -418,7 +417,7 @@ fn prop5_valid_route_transfer_ownership_round_trip() {
         let waste_id = create_waste(&client, &recycler);
         client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
         client.transfer_waste_v2(&waste_id, &collector, &manufacturer, &0, &0);
-        let waste = client.get_waste_v2(client.get_waste_v2(client.get_waste_v2.unwrap()(&waste_id);waste_id)waste_id).unwrap();
+        let waste = client.get_waste_v2(&waste_id).unwrap();
         assert_eq!(waste.current_owner, manufacturer);
     }
 }

--- a/stellar-contract/tests/reward_tokens_bench_test.rs
+++ b/stellar-contract/tests/reward_tokens_bench_test.rs
@@ -59,9 +59,9 @@ fn measure_verify(env: &Env, client: &ScavengerContractClient, depth: usize) -> 
         current_owner = collector;
     }
 
-    let budget_before = env.budget().cpu_instruction_count();
+    let budget_before = env.budget().cpu_instruction_cost();
     client.verify_material(&material.id, &recycler);
-    let budget_after = env.budget().cpu_instruction_count();
+    let budget_after = env.budget().cpu_instruction_cost();
 
     budget_after - budget_before
 }
@@ -174,10 +174,10 @@ fn bench_reward_config_single_read() {
 
     client.set_percentages(&admin, &15, &35);
 
-    let before = env.budget().cpu_instruction_count();
+    let before = env.budget().cpu_instruction_cost();
     let col = client.get_collector_percentage().unwrap();
     let own = client.get_owner_percentage().unwrap();
-    let after = env.budget().cpu_instruction_count();
+    let after = env.budget().cpu_instruction_cost();
 
     println!("[bench] reward_config reads cpu_instructions={}", after - before);
     assert_eq!(col, 15);

--- a/stellar-contract/tests/transfer_admin_test.rs
+++ b/stellar-contract/tests/transfer_admin_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, vec};
 use stellar_scavngr_contract::{ScavengerContract, ScavengerContractClient};
 
 fn setup(env: &Env) -> (ScavengerContractClient<'_>, Address) {
@@ -18,7 +18,8 @@ fn test_transfer_admin_non_admin_cannot_transfer() {
     env.mock_all_auths();
     let non_admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    client.transfer_admin(&non_admin, &new_admin);
+    let new_admins = vec![&env, new_admin];
+    client.transfer_admin(&non_admin, &new_admins);
 }
 
 #[test]
@@ -27,7 +28,8 @@ fn test_transfer_admin_new_admin_can_call_admin_functions() {
     let (client, admin) = setup(&env);
     env.mock_all_auths();
     let new_admin = Address::generate(&env);
-    client.transfer_admin(&admin, &new_admin);
+    let new_admins = vec![&env, new_admin.clone()];
+    client.transfer_admin(&admin, &new_admins);
     assert_eq!(client.get_admin(), new_admin);
 }
 
@@ -38,7 +40,10 @@ fn test_transfer_admin_old_admin_loses_privileges() {
     let (client, admin) = setup(&env);
     env.mock_all_auths();
     let new_admin = Address::generate(&env);
-    client.transfer_admin(&admin, &new_admin);
+    let new_admins = vec![&env, new_admin];
+    client.transfer_admin(&admin, &new_admins);
     // old admin should no longer have privileges
-    client.transfer_admin(&admin, &Address::generate(&env));
+    let another_admin = Address::generate(&env);
+    let another_admins = vec![&env, another_admin];
+    client.transfer_admin(&admin, &another_admins);
 }


### PR DESCRIPTION
Implementation is done and validated with tests, including authorization hardening and multi-admin support. Also enforced admin restrictions on charity/percentage/deactivate and add multi-admin support

 
Closes #69 