### PR TITLE
Feature/max weight validation 174

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -26,6 +26,9 @@ const TOKEN_ADDR: Symbol = symbol_short!("TKN_ADDR");
 const PART_INDEX: Symbol = symbol_short!("PART_IDX");
 const PAUSED: Symbol = symbol_short!("PAUSED");
 
+/// Maximum allowed waste weight per submission (1 000 000 kg in grams).
+const MAX_WASTE_WEIGHT: u128 = 1_000_000_000;
+
 /// Reward distribution percentages stored as a single instance-storage entry.
 ///
 /// Consolidating `collector_percentage` and `owner_percentage` into one struct
@@ -1494,6 +1497,10 @@ impl ScavengerContract {
         Self::require_not_paused(&env);
         Self::only_registered(&env, &submitter);
 
+        if weight as u128 > MAX_WASTE_WEIGHT {
+            panic!("Waste weight exceeds maximum allowed");
+        }
+
         // Get next waste ID using the new storage system
         let waste_id = Self::next_waste_id(&env);
 
@@ -1562,6 +1569,10 @@ impl ScavengerContract {
 
         if weight == 0 {
             panic!("Waste weight must be greater than zero");
+        }
+
+        if weight > MAX_WASTE_WEIGHT {
+            panic!("Waste weight exceeds maximum allowed");
         }
 
         let waste_id = Self::next_waste_id(&env) as u128;

--- a/stellar-contract/tests/edge_cases_test.rs
+++ b/stellar-contract/tests/edge_cases_test.rs
@@ -77,7 +77,8 @@ fn test_max_u64_weight() {
     let (client, _, recycler, _) = setup_contract(&env);
 
     let desc = String::from_str(&env, "Max weight");
-    let max_weight = u64::MAX;
+    // MAX_WASTE_WEIGHT is 1_000_000_000 grams; use that as the ceiling
+    let max_weight: u64 = 1_000_000_000;
 
     let material = client.submit_material(&WasteType::Metal, &max_weight, &recycler, &desc);
 
@@ -89,7 +90,8 @@ fn test_max_u128_waste_weight() {
     let env = Env::default();
     let (client, _, recycler, _) = setup_contract(&env);
 
-    let max_weight = u128::MAX;
+    // MAX_WASTE_WEIGHT is 1_000_000_000 grams; values above it are rejected
+    let max_weight: u128 = 1_000_000_000;
     let waste_id = client.recycle_waste(
         &WasteType::Glass,
         &max_weight,

--- a/stellar-contract/tests/max_weight_validation_test.rs
+++ b/stellar-contract/tests/max_weight_validation_test.rs
@@ -1,0 +1,57 @@
+#![cfg(test)]
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, String};
+use stellar_scavngr_contract::{ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType};
+
+const MAX_WASTE_WEIGHT: u128 = 1_000_000_000;
+
+fn setup(env: &Env) -> (ScavengerContractClient<'_>, Address) {
+    env.mock_all_auths();
+    let client = ScavengerContractClient::new(env, &env.register_contract(None, ScavengerContract));
+    let recycler = Address::generate(env);
+    client.register_participant(&recycler, &ParticipantRole::Recycler, &symbol_short!("r"), &0, &0);
+    (client, recycler)
+}
+
+// ── recycle_waste ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_recycle_waste_at_max_weight_succeeds() {
+    let env = Env::default();
+    let (client, recycler) = setup(&env);
+    client.recycle_waste(&WasteType::Plastic, &MAX_WASTE_WEIGHT, &recycler, &0, &0);
+}
+
+#[test]
+#[should_panic(expected = "Waste weight exceeds maximum allowed")]
+fn test_recycle_waste_above_max_weight_rejected() {
+    let env = Env::default();
+    let (client, recycler) = setup(&env);
+    client.recycle_waste(&WasteType::Plastic, &(MAX_WASTE_WEIGHT + 1), &recycler, &0, &0);
+}
+
+#[test]
+fn test_recycle_waste_below_max_weight_succeeds() {
+    let env = Env::default();
+    let (client, recycler) = setup(&env);
+    client.recycle_waste(&WasteType::Plastic, &(MAX_WASTE_WEIGHT - 1), &recycler, &0, &0);
+}
+
+// ── submit_material ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_submit_material_at_max_weight_succeeds() {
+    let env = Env::default();
+    let (client, recycler) = setup(&env);
+    let weight = MAX_WASTE_WEIGHT as u64;
+    client.submit_material(&WasteType::Plastic, &weight, &recycler, &String::from_str(&env, ""));
+}
+
+#[test]
+#[should_panic(expected = "Waste weight exceeds maximum allowed")]
+fn test_submit_material_above_max_weight_rejected() {
+    let env = Env::default();
+    let (client, recycler) = setup(&env);
+    let weight = (MAX_WASTE_WEIGHT + 1) as u64;
+    client.submit_material(&WasteType::Plastic, &weight, &recycler, &String::from_str(&env, ""));
+}


### PR DESCRIPTION

## Summary

Closes #174 

 Without an upper bound on waste weight, a malicious actor could submit an astronomically large weight to inflate reward 
calculations. This PR caps submissions at 1,000,000,000 grams (1,000 tonnes).

## Changes

### src/lib.rs
- Added const MAX_WASTE_WEIGHT: u128 = 1_000_000_000
- recycle_waste — panics "Waste weight exceeds maximum allowed" if weight > MAX_WASTE_WEIGHT
- submit_material — same guard (weight as u128 > MAX_WASTE_WEIGHT)

### tests/max_weight_validation_test.rs (new)
5 boundary tests covering both functions:
- at max → accepted
- one below max → accepted
- one above max → rejected

### tests/edge_cases_test.rs
Updated test_max_u64_weight and test_max_u128_waste_weight — previously asserted that u64::MAX / u128::MAX were accepted (the exact 
vulnerability). Now use MAX_WASTE_WEIGHT as the ceiling.

## Test Results
39 test suites — 0 failed
