### PR TITLE
feat: set up client-side routing with react-router-dom

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "next-themes": "^0.4.6",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-router-dom": "^7.13.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
@@ -4088,6 +4089,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6151,6 +6165,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -6382,6 +6434,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "next-themes": "^0.4.6",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-router-dom": "^7.13.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,6 @@
-import { AppShell } from '@components/layout/AppShell'
-import { HomePage } from '@pages/HomePage'
+import { RouterProvider } from 'react-router-dom'
+import { router } from '@/router'
 
 export function App() {
-  return (
-    <AppShell>
-      <HomePage />
-    </AppShell>
-  )
+  return <RouterProvider router={router} />
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { PropsWithChildren } from 'react'
+import { NavLink } from 'react-router-dom'
 import { Menu, X, Wallet, LogOut, Recycle } from 'lucide-react'
 import { useWallet } from '@/context/WalletContext'
 import { useAuth } from '@/context/AuthContext'
@@ -34,14 +35,19 @@ export function AppShell({ children }: PropsWithChildren) {
         <span className="text-lg font-bold">Scavngr</span>
       </div>
       {links.map((link) => (
-        <a
+        <NavLink
           key={link.href}
-          href={link.href}
+          to={link.href}
           onClick={() => setSidebarOpen(false)}
-          className="rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          className={({ isActive }) =>
+            cn(
+              'rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground',
+              isActive ? 'bg-accent text-accent-foreground' : 'text-foreground'
+            )
+          }
         >
           {link.label}
-        </a>
+        </NavLink>
       ))}
       {user && (
         <button

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom'
+
+export function NotFoundPage() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="text-muted-foreground">Page not found.</p>
+      <Link to="/" className="text-primary underline underline-offset-4">
+        Go home
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,41 @@
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '@/context/AuthContext'
+import { AppShell } from '@/components/layout/AppShell'
+import { HomePage } from '@/pages/HomePage'
+import { NotFoundPage } from '@/pages/NotFoundPage'
+
+function ProtectedLayout() {
+  const { isAuthenticated, isLoading } = useAuth()
+  if (isLoading) return null
+  return isAuthenticated ? (
+    <AppShell>
+      <Outlet />
+    </AppShell>
+  ) : (
+    <Navigate to="/" replace />
+  )
+}
+
+export const router = createBrowserRouter([
+  {
+    // Public: home is accessible to everyone (wallet connect / login)
+    path: '/',
+    element: (
+      <AppShell>
+        <HomePage />
+      </AppShell>
+    ),
+  },
+  {
+    // Protected routes share AppShell and require authentication
+    element: <ProtectedLayout />,
+    children: [
+      { path: 'submit', element: <div>Submit Waste</div> },
+      { path: 'collect', element: <div>Collect</div> },
+      { path: 'incentives', element: <div>Incentives</div> },
+      { path: 'transfer', element: <div>Transfer</div> },
+      { path: 'history', element: <div>History</div> },
+    ],
+  },
+  { path: '*', element: <NotFoundPage /> },
+])


### PR DESCRIPTION
Title: feat: set up client-side routing with react-router-dom

Description:

## Summary
Adds client-side routing to the frontend using react-router-dom.

## Changes

- **Install** react-router-dom
- **src/router.tsx** — central route definitions:
  - / — public, HomePage wrapped in AppShell
  - /submit, /collect, /incentives, /transfer, /history — protected routes under ProtectedLayout
  - * — 404 fallback → NotFoundPage
- **ProtectedLayout** — redirects unauthenticated users to /, waits for auth isLoading to resolve before deciding
- **src/pages/NotFoundPage.tsx** — 404 page with a home link
- **src/App.tsx** — replaced static layout with <RouterProvider router={router} />
- **AppShell.tsx** — swapped <a href> for <NavLink to> with active state highlighting

## Notes
- Protected page routes currently render stub <div> placeholders, ready to be replaced with real page components
- Auth check uses existing useAuth() from AuthContext — no new dependencies
closes #189