### PR TITLE
fix: remove unused formatAddress import in WalletModal to fix build

### DIFF
--- a/frontend/src/components/ui/WalletModal.tsx
+++ b/frontend/src/components/ui/WalletModal.tsx
@@ -1,7 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useWallet } from '@/context/WalletContext';
-import { formatAddress } from '@/lib/helpers';
 import { Button } from '@/components/ui/Button';
 
 const WALLETS = [


### PR DESCRIPTION
Title: feat: verify and fix base frontend project setup

Description:

## Summary
Audited the base frontend setup against all requirements — everything was already in place. Fixed one blocking build 
error discovered during verification.

## Verified (already implemented)
- Vite + React + TypeScript with @vitejs/plugin-react
- Tailwind CSS with postcss and autoprefixer
- Folder structure: src/pages/, src/components/, src/hooks/, src/lib/ with path aliases (@, @pages, @components, 
@hooks, @lib)
- ESLint with TypeScript, react-hooks, react-refresh, and prettier plugins
- Prettier config (.prettierrc, .prettierignore)

## Fix
- Removed unused formatAddress import in WalletModal.tsx that was causing tsc --noEmit to fail and blocking 
npm run build

## Result
npm run build passes clean — 1806 modules transformed, no errors.
closes #187