### PR TITLE
feat: add useParticipant hook with React Query

### DIFF
--- a/frontend/src/hooks/useParticipant.ts
+++ b/frontend/src/hooks/useParticipant.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import { ScavengerClient } from '@/api/client'
+import { Participant } from '@/api/types'
+import { useWallet } from '@/context/WalletContext'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+
+export function useParticipant() {
+  const { address } = useWallet()
+  const { config } = useContract()
+
+  const { data, isLoading, isError } = useQuery<Participant | null>({
+    queryKey: ['participant', address],
+    queryFn: async () => {
+      if (!address) return null
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+      return client.getParticipant(address)
+    },
+    enabled: !!address,
+  })
+
+  return {
+    participant: data ?? null,
+    isLoading,
+    isError,
+  }
+}


### PR DESCRIPTION
What Adds a useParticipant React Query hook that fetches and caches participant data for the currently connected wallet.
Why Components need a consistent, reactive way to access the connected wallet's participant state without manually managing loading/error states or re-fetching logic.

How

Calls get_participant via ScavengerClient using the wallet address from useWallet()
Query key is ['participant', address] — auto-refetches whenever the wallet address changes
Query is disabled (enabled: !!address) when no wallet is connected, returning null
Returns { participant, isLoading, isError } — participant is null if wallet is disconnected or address is not registered
Changes

useParticipant.ts
 — new hook
Testing

Connect a registered wallet → participant returns the participant data
Connect an unregistered wallet → participant returns null
Switch wallets → query refetches automatically
No wallet connected → query is skipped, participant is null

close #207 