### PR TITLE
feat: add useParticipantWastes hook with filtering support

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import {
   Participant,
   Incentive,
   Material,
+  Waste,
   WasteTransfer,
   ParticipantStats,
   GlobalMetrics,
@@ -394,5 +395,17 @@ export class ScavengerClient {
 
   async getSupplyChainStats(): Promise<[bigint, bigint, bigint]> {
     return this.invoke<[bigint, bigint, bigint]>('get_supply_chain_stats', [])
+  }
+
+  async getParticipantWastes(address: string): Promise<number[]> {
+    return this.invoke<number[]>('get_participant_wastes', [new Address(address).toScVal()])
+  }
+
+  async getParticipantWastesV2(address: string): Promise<bigint[]> {
+    return this.invoke<bigint[]>('get_participant_wastes_v2', [new Address(address).toScVal()])
+  }
+
+  async getWasteV2(wasteId: bigint): Promise<Waste | null> {
+    return this.invoke<Waste | null>('get_waste_v2', [nativeToScVal(wasteId, { type: 'u128' })])
   }
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -45,6 +45,19 @@ export interface Material {
   confirmer: string
 }
 
+export interface Waste {
+  waste_id: bigint
+  waste_type: WasteType
+  weight: bigint
+  current_owner: string
+  latitude: bigint
+  longitude: bigint
+  recycled_timestamp: number
+  is_active: boolean
+  is_confirmed: boolean
+  confirmer: string
+}
+
 export interface WasteTransfer {
   waste_id: number
   from: string

--- a/frontend/src/hooks/useParticipantWastes.ts
+++ b/frontend/src/hooks/useParticipantWastes.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query'
+import { ScavengerClient } from '@/api/client'
+import { Waste, WasteType } from '@/api/types'
+import { useWallet } from '@/context/WalletContext'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+
+export interface WasteFilters {
+  wasteType?: WasteType
+  isActive?: boolean
+  isConfirmed?: boolean
+}
+
+export function useParticipantWastes(filters?: WasteFilters) {
+  const { address } = useWallet()
+  const { config } = useContract()
+
+  const { data, isLoading, isError } = useQuery<Waste[]>({
+    queryKey: ['participant-wastes', address, filters],
+    queryFn: async () => {
+      if (!address) return []
+
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+
+      // Fetch the list of waste IDs owned by this participant (v2)
+      const wasteIds = await client.getParticipantWastesV2(address)
+
+      // Batch-fetch each waste record in parallel
+      const results = await Promise.all(wasteIds.map((id) => client.getWasteV2(id)))
+
+      // Drop nulls (deleted/missing records)
+      let wastes = results.filter((w): w is Waste => w !== null)
+
+      // Apply optional filters
+      if (filters?.wasteType !== undefined) {
+        wastes = wastes.filter((w) => w.waste_type === filters.wasteType)
+      }
+      if (filters?.isActive !== undefined) {
+        wastes = wastes.filter((w) => w.is_active === filters.isActive)
+      }
+      if (filters?.isConfirmed !== undefined) {
+        wastes = wastes.filter((w) => w.is_confirmed === filters.isConfirmed)
+      }
+
+      return wastes
+    },
+    enabled: !!address,
+  })
+
+  return {
+    wastes: data ?? [],
+    isLoading,
+    isError,
+  }
+}


### PR DESCRIPTION
What Adds a useParticipantWastes React Query hook that fetches and caches all waste records owned by the connected wallet, with support for client-side filtering.

Why Components need a reactive, cached way to display a participant's waste inventory — with the ability to filter by type and status without additional contract calls.

How

Calls get_participant_wastes_v2 to get the participant's waste ID list (u128, indexed)
Batch-fetches each waste record in parallel via Promise.all over get_waste_v2
Filters out null results (deleted/missing records)
Applies optional client-side filters: wasteType, isActive, isConfirmed
Query key is ['participant-wastes', address, filters] — auto-refetches on wallet or filter change
Query is disabled when no wallet is connected, returning []
Changes

types.ts
 — added Waste interface matching the contract's v2 struct
client.ts
 — added getParticipantWastesV2, getWasteV2, and getParticipantWastes methods
useParticipantWastes.ts
 — new hook
Usage

const { wastes, isLoading, isError } = useParticipantWastes({
  wasteType: WasteType.Plastic,
  isActive: true,
})
Testing

Connected wallet with wastes → returns filtered waste records
Connected wallet with no wastes → returns []
Switch wallets → query refetches automatically
Change filters → query refetches with new filter params
No wallet connected → query is skipped, returns []

close #208 