### PR TITLE
feat: add useSupplyChainStats hook

### DIFF
--- a/frontend/src/hooks/useSupplyChainStats.ts
+++ b/frontend/src/hooks/useSupplyChainStats.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+import { ScavengerClient } from '@/api/client'
+import { config } from '@/config'
+import { networkConfig } from '@/lib/stellar'
+
+const client = new ScavengerClient({
+  rpcUrl: networkConfig.rpcUrl,
+  networkPassphrase: networkConfig.networkPassphrase,
+  contractId: config.contractId,
+})
+
+export function useSupplyChainStats() {
+  const [totalWastes, setTotalWastes] = useState<bigint>(0n)
+  const [totalWeight, setTotalWeight] = useState<bigint>(0n)
+  const [totalTokens, setTotalTokens] = useState<bigint>(0n)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetch() {
+      setIsLoading(true)
+      const [wastes, weight, tokens] = await client.getSupplyChainStats()
+      setTotalWastes(wastes)
+      setTotalWeight(weight)
+      setTotalTokens(tokens)
+      setIsLoading(false)
+    }
+
+    fetch()
+    const interval = setInterval(fetch, 60_000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return { totalWastes, totalWeight, totalTokens, isLoading }
+}


### PR DESCRIPTION
## What
Adds a new React hook that fetches global supply chain stats from the Soroban contract and 
keeps them fresh with a 60-second polling interval.

## Changes
- frontend/src/hooks/useSupplyChainStats.ts — new hook that calls get_supply_chain_stats 
and returns { totalWastes, totalWeight, totalTokens, isLoading }

## Behaviour
- Fetches on mount
- Refetches every 60 seconds via setInterval
- isLoading is true on the initial fetch and each subsequent refetch

## Usage
ts
const { totalWastes, totalWeight, totalTokens, isLoading } = useSupplyChainStats()

close #211 