### PR TITLE
feat: add useTransferHistory hook for waste transfer history

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -371,6 +371,12 @@ export class ScavengerClient {
     ])
   }
 
+  async getWasteTransferHistoryV2(wasteId: bigint): Promise<WasteTransfer[]> {
+    return this.invoke<WasteTransfer[]>('get_waste_transfer_history_v2', [
+      nativeToScVal(wasteId, { type: 'u128' })
+    ])
+  }
+
   async distributeRewards(
     wasteId: number,
     incentiveId: number,

--- a/frontend/src/hooks/useTransferHistory.ts
+++ b/frontend/src/hooks/useTransferHistory.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+import { ScavengerClient } from '@/api/client'
+import { WasteTransfer } from '@/api/types'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+
+export function useTransferHistory(wasteId: number | bigint | undefined) {
+  const { config } = useContract()
+
+  const { data, isLoading, isError } = useQuery<WasteTransfer[]>({
+    queryKey: ['transfer-history', wasteId?.toString()],
+    queryFn: async () => {
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+
+      if (typeof wasteId === 'bigint') {
+        return client.getWasteTransferHistoryV2(wasteId)
+      }
+
+      return client.getTransferHistory(wasteId as number)
+    },
+    enabled: wasteId !== undefined,
+  })
+
+  return {
+    history: data ?? [],
+    isLoading,
+    isError,
+  }
+}


### PR DESCRIPTION
What Adds a useTransferHistory React Query hook that fetches the full transfer log for a given waste ID, with support for both v1 (u64) and v2 (u128) ID types.

Why Components need a clean, conditional way to load transfer history for a specific waste item — only when a waste ID is actually selected or available.

How

Accepts wasteId: number | bigint | undefined
Query is disabled (enabled: wasteId !== undefined) when no ID is provided — no unnecessary contract calls
Routes to get_waste_transfer_history_v2 for bigint IDs (v2 wastes) and get_transfer_history for number IDs (v1 wastes)
Query key is ['transfer-history', wasteId.toString()] — refetches automatically when the ID changes
Returns { history, isLoading, isError } — history defaults to []
Changes

client.ts
 — added getWasteTransferHistoryV2(wasteId: bigint) calling get_waste_transfer_history_v2
useTransferHistory.ts
 — new hook
Usage

// Only fetches when wasteId is defined
const { history, isLoading, isError } = useTransferHistory(wasteId)
Testing

Valid number ID → fetches via v1 contract call
Valid bigint ID → fetches via v2 contract call
undefined → query is skipped, history returns []
Change wasteId → query refetches for the new ID
Waste with no transfers → returns []

close #210 