### PR TITLE
feat: add RolePicker, TransferTimeline, StatCard, IncentiveCard compo…

### DIFF
--- a/frontend/src/components/ui/IncentiveCard.tsx
+++ b/frontend/src/components/ui/IncentiveCard.tsx
@@ -1,0 +1,109 @@
+import { Pencil, PowerOff } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Incentive } from '@/api/types'
+import { formatAddress, wasteTypeLabel, formatTokenAmount } from '@/lib/helpers'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/Card'
+
+export interface IncentiveCardProps {
+  incentive: Incentive
+  isManufacturer?: boolean
+  onEdit?: (incentive: Incentive) => void
+  onDeactivate?: (incentive: Incentive) => void
+  className?: string
+}
+
+export function IncentiveCard({
+  incentive,
+  isManufacturer,
+  onEdit,
+  onDeactivate,
+  className,
+}: IncentiveCardProps) {
+  const budgetPercent =
+    incentive.total_budget > 0
+      ? Math.round((incentive.remaining_budget / incentive.total_budget) * 100)
+      : 0
+
+  return (
+    <Card className={cn('flex flex-col', className)}>
+      <CardHeader className="flex flex-row items-start justify-between gap-2 pb-3">
+        <CardTitle className="text-base font-semibold">
+          {wasteTypeLabel(incentive.waste_type)}
+        </CardTitle>
+        <Badge variant={incentive.active ? 'default' : 'secondary'}>
+          {incentive.active ? 'Active' : 'Inactive'}
+        </Badge>
+      </CardHeader>
+
+      <CardContent className="flex-1 space-y-3 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Reward per gram</span>
+          <span className="font-medium">{formatTokenAmount(incentive.reward_points)} pts</span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Budget remaining</span>
+          <span className="font-medium">
+            {formatTokenAmount(incentive.remaining_budget)}{' '}
+            <span className="text-xs text-muted-foreground">/ {formatTokenAmount(incentive.total_budget)}</span>
+          </span>
+        </div>
+
+        {/* Budget progress bar */}
+        <div className="space-y-1">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn(
+                'h-full rounded-full transition-all',
+                budgetPercent > 50
+                  ? 'bg-primary'
+                  : budgetPercent > 20
+                  ? 'bg-yellow-500'
+                  : 'bg-destructive'
+              )}
+              style={{ width: `${budgetPercent}%` }}
+              role="progressbar"
+              aria-valuenow={budgetPercent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Budget remaining"
+            />
+          </div>
+          <p className="text-right text-xs text-muted-foreground">{budgetPercent}% remaining</p>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Rewarder</span>
+          <span className="font-mono text-xs">{formatAddress(incentive.rewarder)}</span>
+        </div>
+      </CardContent>
+
+      {isManufacturer && (
+        <CardFooter className="gap-2 pt-3">
+          <Button
+            size="sm"
+            variant="outline"
+            className="flex-1"
+            onClick={() => onEdit?.(incentive)}
+            disabled={!incentive.active}
+          >
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            className="flex-1"
+            onClick={() => onDeactivate?.(incentive)}
+            disabled={!incentive.active}
+          >
+            <PowerOff className="mr-1.5 h-3.5 w-3.5" />
+            Deactivate
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  )
+}

--- a/frontend/src/components/ui/RolePicker.tsx
+++ b/frontend/src/components/ui/RolePicker.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { Recycle, Truck, Factory } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Role } from '@/api/types'
+
+interface RoleOption {
+  role: Role
+  icon: React.ReactNode
+  title: string
+  description: string
+}
+
+const ROLE_OPTIONS: RoleOption[] = [
+  {
+    role: Role.Recycler,
+    icon: <Recycle className="h-8 w-8" />,
+    title: 'Recycler',
+    description: 'Submit and track waste materials for recycling',
+  },
+  {
+    role: Role.Collector,
+    icon: <Truck className="h-8 w-8" />,
+    title: 'Collector',
+    description: 'Collect and transfer waste between participants',
+  },
+  {
+    role: Role.Manufacturer,
+    icon: <Factory className="h-8 w-8" />,
+    title: 'Manufacturer',
+    description: 'Set incentives and confirm recycled materials',
+  },
+]
+
+export interface RolePickerProps {
+  value?: Role
+  onChange: (role: Role) => void
+  className?: string
+}
+
+export function RolePicker({ value, onChange, className }: RolePickerProps) {
+  return (
+    <div
+      className={cn('grid gap-4 sm:grid-cols-3', className)}
+      role="radiogroup"
+      aria-label="Select your role"
+    >
+      {ROLE_OPTIONS.map((option) => {
+        const selected = value === option.role
+        return (
+          <button
+            key={option.role}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.role)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onChange(option.role)
+              }
+            }}
+            className={cn(
+              'flex flex-col items-center gap-3 rounded-lg border p-6 text-center transition-all',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+              'hover:border-primary/60 hover:bg-accent',
+              selected
+                ? 'border-primary bg-primary/5 ring-2 ring-primary ring-offset-2'
+                : 'border-border bg-card'
+            )}
+          >
+            <span
+              className={cn(
+                'rounded-full p-3',
+                selected ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+              )}
+            >
+              {option.icon}
+            </span>
+            <span className="font-semibold">{option.title}</span>
+            <span className="text-sm text-muted-foreground">{option.description}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react'
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+
+type ColorVariant = 'default' | 'primary' | 'success' | 'warning' | 'destructive'
+
+const variantStyles: Record<ColorVariant, string> = {
+  default: '',
+  primary: 'border-primary/30 bg-primary/5',
+  success: 'border-green-500/30 bg-green-500/5',
+  warning: 'border-yellow-500/30 bg-yellow-500/5',
+  destructive: 'border-destructive/30 bg-destructive/5',
+}
+
+const iconVariantStyles: Record<ColorVariant, string> = {
+  default: 'text-muted-foreground',
+  primary: 'text-primary',
+  success: 'text-green-600 dark:text-green-400',
+  warning: 'text-yellow-600 dark:text-yellow-400',
+  destructive: 'text-destructive',
+}
+
+export interface StatCardProps {
+  icon: React.ReactNode
+  label: string
+  value: React.ReactNode
+  trend?: 'up' | 'down'
+  trendLabel?: string
+  isLoading?: boolean
+  variant?: ColorVariant
+  className?: string
+}
+
+export function StatCard({
+  icon,
+  label,
+  value,
+  trend,
+  trendLabel,
+  isLoading,
+  variant = 'default',
+  className,
+}: StatCardProps) {
+  return (
+    <Card className={cn(variantStyles[variant], className)}>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+        <span className={cn('h-4 w-4', iconVariantStyles[variant])}>{icon}</span>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            <div className="h-7 w-24 animate-pulse rounded bg-muted" />
+            {trendLabel && <div className="h-3 w-16 animate-pulse rounded bg-muted" />}
+          </div>
+        ) : (
+          <>
+            <p className="text-2xl font-bold">{value}</p>
+            {(trend || trendLabel) && (
+              <p
+                className={cn(
+                  'mt-1 flex items-center gap-1 text-xs',
+                  trend === 'up' && 'text-green-600 dark:text-green-400',
+                  trend === 'down' && 'text-destructive',
+                  !trend && 'text-muted-foreground'
+                )}
+              >
+                {trend === 'up' && <TrendingUp className="h-3 w-3" />}
+                {trend === 'down' && <TrendingDown className="h-3 w-3" />}
+                {trendLabel}
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/ui/TransferTimeline.tsx
+++ b/frontend/src/components/ui/TransferTimeline.tsx
@@ -1,0 +1,110 @@
+import { ArrowRight, MapPin, Clock, CheckCircle2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { WasteTransfer } from '@/api/types'
+import { formatAddress, formatDate } from '@/lib/helpers'
+
+export interface TransferTimelineProps {
+  history: WasteTransfer[]
+  currentOwner?: string
+  isLoading?: boolean
+  className?: string
+}
+
+export function TransferTimeline({
+  history,
+  currentOwner,
+  isLoading,
+  className,
+}: TransferTimelineProps) {
+  if (isLoading) {
+    return (
+      <div className={cn('space-y-4', className)}>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-4 animate-pulse">
+            <div className="flex flex-col items-center">
+              <div className="h-4 w-4 rounded-full bg-muted" />
+              {i < 3 && <div className="mt-1 h-12 w-px bg-muted" />}
+            </div>
+            <div className="mb-4 flex-1 space-y-2 pb-2">
+              <div className="h-4 w-1/2 rounded bg-muted" />
+              <div className="h-3 w-1/3 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className={cn('flex flex-col items-center gap-2 py-10 text-muted-foreground', className)}>
+        <Clock className="h-8 w-8 opacity-40" />
+        <p className="text-sm">No transfer history yet</p>
+      </div>
+    )
+  }
+
+  return (
+    <ol className={cn('relative space-y-0', className)} aria-label="Transfer history">
+      {history.map((transfer, idx) => {
+        const isLast = idx === history.length - 1
+        const isCurrent = currentOwner
+          ? transfer.to === currentOwner
+          : isLast
+
+        return (
+          <li key={`${transfer.waste_id}-${idx}`} className="flex gap-4">
+            {/* Timeline spine */}
+            <div className="flex flex-col items-center">
+              <span
+                className={cn(
+                  'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2',
+                  isCurrent
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-muted-foreground'
+                )}
+                aria-hidden="true"
+              >
+                {isCurrent ? (
+                  <CheckCircle2 className="h-3 w-3" />
+                ) : (
+                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                )}
+              </span>
+              {!isLast && <div className="mt-1 h-full min-h-[2.5rem] w-px bg-border" />}
+            </div>
+
+            {/* Content */}
+            <div className={cn('mb-4 flex-1 pb-1', isLast && 'mb-0')}>
+              <div className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {formatAddress(transfer.from)}
+                </span>
+                <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span
+                  className={cn(
+                    'font-mono text-xs',
+                    isCurrent ? 'font-semibold text-primary' : 'text-muted-foreground'
+                  )}
+                >
+                  {formatAddress(transfer.to)}
+                </span>
+                {isCurrent && (
+                  <span className="ml-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                    Current owner
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {formatDate(transfer.transferred_at)}
+                </span>
+              </div>
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}


### PR DESCRIPTION
PR 1 — RolePicker: Card-based role selector for registration

What Adds a RolePicker component to replace any plain dropdown/radio for role selection during registration.

Why A visual card layout makes the three roles (Recycler, Collector, Manufacturer) immediately scannable and reduces cognitive load compared to a select input.

Changes

Three cards rendered in a responsive sm:grid-cols-3 grid
Each card has a lucide icon, role title, and short description
Selected state shows a primary-colored ring + filled icon background
Fully keyboard navigable — role="radiogroup" / role="radio" with aria-checked, Enter and Space key support
Accepts value, onChange, and optional className props
Usage

closes #272 

<RolePicker value={selectedRole} onChange={setSelectedRole} />
PR 2 — TransferTimeline: Visual timeline for waste transfer history

What Adds a TransferTimeline component that renders waste transfer history as a vertical timeline.

Why A flat list of transfers is hard to follow. A timeline makes the chain of custody visually clear and highlights who currently owns the waste.

Changes

Vertical <ol> with a connecting spine line between steps
Each step shows truncated from → to addresses and a formatted timestamp
Current owner step is highlighted with a primary-colored dot and a "Current owner" pill — determined by currentOwner prop or falls back to the last entry
Pulse skeleton loading state (3 placeholder rows)
Empty state with a clock icon when no transfers exist
Consumes WasteTransfer[] from the existing useTransferHistory hook directly
Usage

<TransferTimeline
  history={history}
  currentOwner={address}
  isLoading={isLoading}
/>

closes #271 

PR 3 — StatCard: Reusable statistic display card

What Adds a StatCard component to standardize the repeated stat card pattern across all three dashboards.

Why The same Card + CardHeader + icon + value pattern is copy-pasted in RecyclerDashboard, CollectorDashboardPage, and ManufacturerDashboardPage. This extracts it into a single reusable component.

Changes

Props: icon, label, value, trend (up | down), trendLabel, isLoading, variant, className
trend renders a colored TrendingUp / TrendingDown icon with green/red text
isLoading shows an animated skeleton in place of the value
variant prop (default | primary | success | warning | destructive) tints the card border and icon color
Zero new dependencies — built entirely on existing Card primitives
Usage

<StatCard
  icon={<Coins className="h-4 w-4" />}
  label="Token Balance"
  value={formatTokenAmount(balance)}
  trend="up"
  trendLabel="+12% this week"
  isLoading={isLoading}
  variant="primary"
/>

closes #270 

PR 4 — IncentiveCard: Reusable card for displaying an incentive

What Adds an IncentiveCard component for displaying a single Incentive object.

Why Incentives are currently rendered as plain list rows in ManufacturerDashboardPage and RecyclerDashboard. A dedicated card gives them proper visual weight and surfaces all relevant data in one place.

Changes

Shows waste type, reward per gram (formatted), and budget remaining with a color-coded progress bar (blue → yellow → red as budget depletes)
Rewarder address truncated via existing formatAddress helper
Active/inactive Badge in the card header
Edit and Deactivate buttons only render when isManufacturer={true}, both disabled when incentive is inactive
Accepts onEdit and onDeactivate callbacks
Built on existing Card, Badge, Button primitives — no new dependencies
Usage


<IncentiveCard
  incentive={incentive}
  isManufacturer={role === Role.Manufacturer}
  onEdit={handleEdit}
  onDeactivate={handleDeactivate}
/>

closes #269 