### PR TITLE
feat: contract client wrapper and register_participant integration

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,15 @@
-import { Contract, rpc, xdr, scValToNative, nativeToScVal, Address } from '@stellar/stellar-sdk'
+import {
+  Contract,
+  rpc as SorobanRpc,
+  xdr,
+  scValToNative,
+  nativeToScVal,
+  Address,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+} from '@stellar/stellar-sdk'
+import { signTransaction } from '@stellar/freighter-api'
 import {
   Role,
   WasteType,
@@ -9,12 +20,8 @@ import {
   WasteTransfer,
   ParticipantStats,
   GlobalMetrics,
-  ContractError
+  ContractError,
 } from './types'
-
-// Constants
-const DEFAULT_RETRIES = 3
-const RETRY_DELAY_MS = 1000
 
 export interface ClientOptions {
   rpcUrl: string
@@ -24,197 +31,159 @@ export interface ClientOptions {
 
 export class ScavengerClient {
   private contract: Contract
-
-  // State for UI to hook into if desired
-  public isLoading: boolean = false
-  private stateChangeListeners: ((loading: boolean) => void)[] = []
+  private server: SorobanRpc.Server
+  private networkPassphrase: string
 
   constructor(options: ClientOptions) {
     this.contract = new Contract(options.contractId)
+    this.server = new SorobanRpc.Server(options.rpcUrl, { allowHttp: true })
+    this.networkPassphrase = options.networkPassphrase
   }
 
-  // --- State management for loading states ---
-  public subscribe(listener: (loading: boolean) => void) {
-    this.stateChangeListeners.push(listener)
-    return () => {
-      this.stateChangeListeners = this.stateChangeListeners.filter((l) => l !== listener)
-    }
-  }
-
-  private setLoading(loading: boolean) {
-    this.isLoading = loading
-    this.stateChangeListeners.forEach((listener) => listener(loading))
-  }
-
-  // --- Helper: Generic invoke with retry logic and error handling ---
+  /**
+   * Build, simulate, sign (via Freighter), and submit a Soroban transaction.
+   * For read-only calls (no signer), simulation result is returned directly.
+   */
   private async invoke<T>(
     method: string,
     args: xdr.ScVal[],
-    signer?: string, // user address for auth if this was a full transaction
-    retries = DEFAULT_RETRIES
+    signer?: string
   ): Promise<T> {
-    let attempt = 0
+    const operation = this.contract.call(method, ...args)
 
-    this.setLoading(true)
-
-    while (attempt < retries) {
-      try {
-        // MOCK implementation to satisfy TypeScript and provide structure
-        // In a real implementation this would build the transaction using the contract call:
-        // this.contract.call(method, ...args);
-
-        // Suppress unused variable warnings
-        console.debug(method, args, signer, rpc, this.contract)
-
-        const result = await Promise.resolve({
-          result: { retval: nativeToScVal('MOCK', { type: 'string' }) }
-        })
-
-        // Map Soroban Error
-        const resultAny = result as unknown as {
-          error?: string
-          errorCode?: number
-          result?: { retval?: ReturnType<typeof nativeToScVal> }
-        }
-        if (resultAny.error) {
-          throw new ContractError(resultAny.error, resultAny.errorCode)
-        }
-
-        const scVal = resultAny.result?.retval
-        if (!scVal) throw new ContractError('No return value from contract')
-
-        return scValToNative(scVal) as T
-      } catch (error: unknown) {
-        attempt++
-        if (attempt >= retries) {
-          this.setLoading(false)
-          const errorMsg = error instanceof Error ? error.message : 'Unknown Contract Error'
-          throw new ContractError(`Failed to invoke ${method}: ${errorMsg}`)
-        }
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * attempt))
-      }
+    if (!signer) {
+      // Read-only: simulate only
+      const sim = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase }
+        )
+          .addOperation(operation)
+          .setTimeout(30)
+          .build()
+      )
+      return this._extractSimResult<T>(sim)
     }
 
-    this.setLoading(false)
-    throw new ContractError('Exhausted retries')
+    // Mutating: build → simulate → assemble → sign → submit
+    const account = await this.server.getAccount(signer)
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(operation)
+      .setTimeout(30)
+      .build()
+
+    const sim = await this.server.simulateTransaction(tx)
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      throw this._parseError(sim.error)
+    }
+
+    const assembled = SorobanRpc.assembleTransaction(tx, sim).build()
+
+    const { signedTxXdr } = await signTransaction(assembled.toXDR(), {
+      networkPassphrase: this.networkPassphrase,
+    })
+
+    const signed = TransactionBuilder.fromXDR(signedTxXdr, this.networkPassphrase)
+    const sendResult = await this.server.sendTransaction(signed)
+
+    if (sendResult.status === 'ERROR') {
+      throw this._parseError(sendResult.errorResult?.toXDR('base64') ?? 'Transaction failed')
+    }
+
+    // Poll for confirmation
+    const hash = sendResult.hash
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 1500))
+      const status = await this.server.getTransaction(hash)
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        const retval = (status as SorobanRpc.Api.GetSuccessfulTransactionResponse).returnValue
+        if (!retval) return undefined as T
+        return scValToNative(retval) as T
+      }
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+        throw new ContractError('Transaction failed on-chain')
+      }
+    }
+    throw new ContractError('Transaction confirmation timeout')
+  }
+
+  private _extractSimResult<T>(sim: SorobanRpc.Api.SimulateTransactionResponse): T {
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      throw this._parseError(sim.error)
+    }
+    const result = (sim as SorobanRpc.Api.SimulateTransactionSuccessResponse).result
+    if (!result?.retval) return undefined as T
+    return scValToNative(result.retval) as T
+  }
+
+  private _parseError(raw: string): ContractError {
+    // Try to extract numeric error code from XDR or message
+    const match = raw.match(/Error\(Contract, #(\d+)\)/)
+    if (match) return new ContractError(`Contract error #${match[1]}`, Number(match[1]))
+    return new ContractError(raw)
   }
 
   // =======================================================
-  // Contract Methods wrapping
+  // Admin
   // =======================================================
 
-  async initialize(
-    admin: string,
-    tokenAddress: string,
-    charityAddress: string,
-    collectorPercentage: number,
-    ownerPercentage: number,
-    signer: string
-  ) {
-    return this.invoke<void>(
-      'initialize',
-      [
-        new Address(admin).toScVal(),
-        new Address(tokenAddress).toScVal(),
-        new Address(charityAddress).toScVal(),
-        nativeToScVal(collectorPercentage, { type: 'u32' }),
-        nativeToScVal(ownerPercentage, { type: 'u32' })
-      ],
-      signer
-    )
+  async initializeAdmin(admin: string) {
+    return this.invoke<void>('initialize_admin', [new Address(admin).toScVal()], admin)
   }
 
   async getAdmin(): Promise<string> {
     return this.invoke<string>('get_admin', [])
   }
 
-  async getTokenAddress(): Promise<string> {
-    return this.invoke<string>('get_token_address', [])
-  }
-
-  async getCharityAddress(): Promise<string> {
-    return this.invoke<string>('get_charity_address', [])
-  }
-
-  async getCollectorPercentage(): Promise<number> {
-    return this.invoke<number>('get_collector_percentage', [])
-  }
-
-  async getOwnerPercentage(): Promise<number> {
-    return this.invoke<number>('get_owner_percentage', [])
-  }
-
-  async getTotalEarned(): Promise<bigint> {
-    return this.invoke<bigint>('get_total_earned', [])
-  }
-
-  async getMetrics(): Promise<GlobalMetrics> {
-    return this.invoke<GlobalMetrics>('get_metrics', [])
-  }
-
-  async updateTokenAddress(admin: string, newAddress: string, signer: string) {
-    return this.invoke<void>(
-      'update_token_address',
-      [new Address(admin).toScVal(), new Address(newAddress).toScVal()],
-      signer
-    )
-  }
-
-  async updateCharityAddress(admin: string, newAddress: string, signer: string) {
-    return this.invoke<void>(
-      'update_charity_address',
-      [new Address(admin).toScVal(), new Address(newAddress).toScVal()],
-      signer
-    )
-  }
-
-  async updateCollectorPercentage(admin: string, newPercentage: number, signer: string) {
-    return this.invoke<void>(
-      'update_collector_percentage',
-      [new Address(admin).toScVal(), nativeToScVal(newPercentage, { type: 'u32' })],
-      signer
-    )
-  }
-
-  async updateOwnerPercentage(admin: string, newPercentage: number, signer: string) {
-    return this.invoke<void>(
-      'update_owner_percentage',
-      [new Address(admin).toScVal(), nativeToScVal(newPercentage, { type: 'u32' })],
-      signer
-    )
-  }
-
-  async updatePercentages(
-    admin: string,
-    collectorPercentage: number,
-    ownerPercentage: number,
-    signer: string
-  ) {
-    return this.invoke<void>(
-      'update_percentages',
-      [
-        new Address(admin).toScVal(),
-        nativeToScVal(collectorPercentage, { type: 'u32' }),
-        nativeToScVal(ownerPercentage, { type: 'u32' })
-      ],
-      signer
-    )
-  }
-
-  async transferAdmin(currentAdmin: string, newAdmin: string, signer: string) {
+  async transferAdmin(currentAdmin: string, newAdmin: string) {
     return this.invoke<void>(
       'transfer_admin',
       [new Address(currentAdmin).toScVal(), new Address(newAdmin).toScVal()],
-      signer
+      currentAdmin
     )
   }
+
+  async setCharityContract(admin: string, charityAddress: string) {
+    return this.invoke<void>(
+      'set_charity_contract',
+      [new Address(admin).toScVal(), new Address(charityAddress).toScVal()],
+      admin
+    )
+  }
+
+  async setTokenAddress(admin: string, tokenAddress: string) {
+    return this.invoke<void>(
+      'set_token_address',
+      [new Address(admin).toScVal(), new Address(tokenAddress).toScVal()],
+      admin
+    )
+  }
+
+  async setPercentages(admin: string, collectorPct: number, ownerPct: number) {
+    return this.invoke<void>(
+      'set_percentages',
+      [
+        new Address(admin).toScVal(),
+        nativeToScVal(collectorPct, { type: 'u32' }),
+        nativeToScVal(ownerPct, { type: 'u32' }),
+      ],
+      admin
+    )
+  }
+
+  // =======================================================
+  // Participants
+  // =======================================================
 
   async registerParticipant(
     address: string,
     role: Role,
     name: string,
-    latitude: number,
-    longitude: number,
+    lat: number,
+    lon: number,
     signer: string
   ): Promise<Participant> {
     return this.invoke<Participant>(
@@ -223,8 +192,8 @@ export class ScavengerClient {
         new Address(address).toScVal(),
         nativeToScVal(role),
         nativeToScVal(name, { type: 'string' }),
-        nativeToScVal(latitude, { type: 'i64' }),
-        nativeToScVal(longitude, { type: 'i64' })
+        nativeToScVal(lat, { type: 'i128' }),
+        nativeToScVal(lon, { type: 'i128' }),
       ],
       signer
     )
@@ -234,217 +203,282 @@ export class ScavengerClient {
     return this.invoke<Participant | null>('get_participant', [new Address(address).toScVal()])
   }
 
+  async getParticipantInfo(address: string): Promise<{ participant: Participant; stats: ParticipantStats } | null> {
+    return this.invoke<{ participant: Participant; stats: ParticipantStats } | null>(
+      'get_participant_info',
+      [new Address(address).toScVal()]
+    )
+  }
+
+  async updateRole(address: string, newRole: Role, signer: string) {
+    return this.invoke<void>(
+      'update_role',
+      [new Address(address).toScVal(), nativeToScVal(newRole)],
+      signer
+    )
+  }
+
+  async deregisterParticipant(address: string, signer: string) {
+    return this.invoke<void>(
+      'deregister_participant',
+      [new Address(address).toScVal()],
+      signer
+    )
+  }
+
   async isParticipantRegistered(address: string): Promise<boolean> {
     return this.invoke<boolean>('is_participant_registered', [new Address(address).toScVal()])
   }
 
-  async createIncentive(
-    rewarder: string,
-    wasteType: WasteType,
-    rewardPoints: bigint,
-    totalBudget: bigint,
-    signer: string
-  ): Promise<Incentive> {
-    return this.invoke<Incentive>(
-      'create_incentive',
-      [
-        new Address(rewarder).toScVal(),
-        nativeToScVal(wasteType),
-        nativeToScVal(rewardPoints, { type: 'u64' }),
-        nativeToScVal(totalBudget, { type: 'u64' })
-      ],
-      signer
-    )
-  }
-
-  async getIncentiveById(incentiveId: number): Promise<Incentive | null> {
-    return this.invoke<Incentive | null>('get_incentive_by_id', [
-      nativeToScVal(incentiveId, { type: 'u64' })
-    ])
-  }
-
-  async incentiveExists(incentiveId: number): Promise<boolean> {
-    return this.invoke<boolean>('incentive_exists', [nativeToScVal(incentiveId, { type: 'u64' })])
-  }
-
-  async getIncentivesByRewarder(rewarder: string): Promise<number[]> {
-    return this.invoke<number[]>('get_incentives_by_rewarder', [new Address(rewarder).toScVal()])
-  }
-
-  async getIncentivesByWasteType(wasteType: WasteType): Promise<number[]> {
-    return this.invoke<number[]>('get_incentives_by_waste_type', [nativeToScVal(wasteType)])
-  }
-
-  async getActiveIncentive(manufacturer: string, wasteType: WasteType): Promise<Incentive | null> {
-    return this.invoke<Incentive | null>('get_active_incentive', [
-      new Address(manufacturer).toScVal(),
-      nativeToScVal(wasteType)
-    ])
-  }
-
-  async getIncentives(wasteType: WasteType): Promise<Incentive[]> {
-    return this.invoke<Incentive[]>('get_incentives', [nativeToScVal(wasteType)])
-  }
-
-  async getAllActiveIncentives(): Promise<Incentive[]> {
-    return this.invoke<Incentive[]>('get_active_incentives', [])
-  }
-
-  async updateIncentive(
-    incentiveId: number,
-    newRewardPoints: bigint,
-    newTotalBudget: bigint,
-    signer: string
-  ): Promise<Incentive> {
-    return this.invoke<Incentive>(
-      'update_incentive',
-      [
-        nativeToScVal(incentiveId, { type: 'u64' }),
-        nativeToScVal(newRewardPoints, { type: 'u64' }),
-        nativeToScVal(newTotalBudget, { type: 'u64' })
-      ],
-      signer
-    )
-  }
-
-  async deactivateIncentive(rewarder: string, incentiveId: number, signer: string): Promise<void> {
-    return this.invoke<void>(
-      'deactivate_incentive',
-      [new Address(rewarder).toScVal(), nativeToScVal(incentiveId, { type: 'u64' })],
-      signer
-    )
-  }
+  // =======================================================
+  // Waste / Materials
+  // =======================================================
 
   async submitMaterial(
     submitter: string,
     wasteType: WasteType,
     weight: bigint,
+    lat: bigint,
+    lon: bigint,
     signer: string
   ): Promise<Material> {
     return this.invoke<Material>(
       'submit_material',
       [
         new Address(submitter).toScVal(),
-        nativeToScVal(wasteType),
-        nativeToScVal(weight, { type: 'u64' })
+        nativeToScVal(wasteType, { type: 'u32' }),
+        nativeToScVal(weight, { type: 'u128' }),
+        nativeToScVal(lat, { type: 'i128' }),
+        nativeToScVal(lon, { type: 'i128' }),
       ],
       signer
     )
   }
 
-  async getMaterial(materialId: number): Promise<Material | null> {
-    return this.invoke<Material | null>('get_material', [
-      nativeToScVal(materialId, { type: 'u64' })
-    ])
-  }
-
-  async getParticipantWastes(address: string): Promise<number[]> {
-    return this.invoke<number[]>('get_participant_wastes', [new Address(address).toScVal()])
-  }
-
-  async deactivateWaste(admin: string, wasteId: number, signer: string): Promise<void> {
-    return this.invoke<void>(
-      'deactivate_waste',
-      [new Address(admin).toScVal(), nativeToScVal(wasteId, { type: 'u64' })],
+  async submitMaterialsBatch(
+    submitter: string,
+    materials: { wasteType: WasteType; weight: bigint }[],
+    signer: string
+  ): Promise<Material[]> {
+    const vec = nativeToScVal(
+      materials.map((m) => ({
+        waste_type: nativeToScVal(m.wasteType, { type: 'u32' }),
+        weight: nativeToScVal(m.weight, { type: 'u128' }),
+      }))
+    )
+    return this.invoke<Material[]>(
+      'submit_materials_batch',
+      [new Address(submitter).toScVal(), vec],
       signer
     )
   }
 
-  async confirmWaste(wasteId: number, confirmer: string, signer: string): Promise<void> {
+  async verifyMaterial(materialId: bigint, verifier: string, signer: string) {
     return this.invoke<void>(
-      'confirm_waste',
-      [nativeToScVal(wasteId, { type: 'u64' }), new Address(confirmer).toScVal()],
+      'verify_material',
+      [nativeToScVal(materialId, { type: 'u64' }), new Address(verifier).toScVal()],
       signer
     )
   }
 
-  async resetWasteConfirmation(wasteId: number, owner: string, signer: string): Promise<void> {
-    return this.invoke<void>(
-      'reset_waste_confirmation',
-      [nativeToScVal(wasteId, { type: 'u64' }), new Address(owner).toScVal()],
-      signer
-    )
-  }
-
-  async transferWaste(wasteId: number, from: string, to: string, signer: string): Promise<void> {
+  async transferWaste(
+    wasteId: bigint,
+    from: string,
+    to: string,
+    lat: bigint,
+    lon: bigint,
+    note: string,
+    signer: string
+  ) {
     return this.invoke<void>(
       'transfer_waste',
       [
-        nativeToScVal(wasteId, { type: 'u64' }),
+        nativeToScVal(wasteId, { type: 'u128' }),
         new Address(from).toScVal(),
-        new Address(to).toScVal()
+        new Address(to).toScVal(),
+        nativeToScVal(lat, { type: 'i128' }),
+        nativeToScVal(lon, { type: 'i128' }),
+        nativeToScVal(note, { type: 'string' }),
       ],
       signer
     )
   }
 
-  async getTransferHistory(wasteId: number): Promise<WasteTransfer[]> {
-    return this.invoke<WasteTransfer[]>('get_transfer_history', [
-      nativeToScVal(wasteId, { type: 'u64' })
+  async confirmWasteDetails(wasteId: bigint, confirmer: string, signer: string) {
+    return this.invoke<void>(
+      'confirm_waste_details',
+      [nativeToScVal(wasteId, { type: 'u128' }), new Address(confirmer).toScVal()],
+      signer
+    )
+  }
+
+  async resetWasteConfirmation(wasteId: bigint, owner: string, signer: string) {
+    return this.invoke<void>(
+      'reset_waste_confirmation',
+      [nativeToScVal(wasteId, { type: 'u128' }), new Address(owner).toScVal()],
+      signer
+    )
+  }
+
+  async deactivateWaste(admin: string, wasteId: bigint, signer: string) {
+    return this.invoke<void>(
+      'deactivate_waste',
+      [new Address(admin).toScVal(), nativeToScVal(wasteId, { type: 'u128' })],
+      signer
+    )
+  }
+
+  async getWaste(wasteId: bigint): Promise<Waste | null> {
+    return this.invoke<Waste | null>('get_waste', [nativeToScVal(wasteId, { type: 'u128' })])
+  }
+
+  async getMaterial(materialId: bigint): Promise<Material | null> {
+    return this.invoke<Material | null>('get_material', [nativeToScVal(materialId, { type: 'u64' })])
+  }
+
+  async getParticipantWastes(address: string): Promise<bigint[]> {
+    return this.invoke<bigint[]>('get_participant_wastes', [new Address(address).toScVal()])
+  }
+
+  async getWasteTransferHistory(wasteId: bigint): Promise<WasteTransfer[]> {
+    return this.invoke<WasteTransfer[]>('get_waste_transfer_history', [
+      nativeToScVal(wasteId, { type: 'u128' }),
     ])
   }
 
-  async getWasteTransferHistoryV2(wasteId: bigint): Promise<WasteTransfer[]> {
-    return this.invoke<WasteTransfer[]>('get_waste_transfer_history_v2', [
-      nativeToScVal(wasteId, { type: 'u128' })
-    ])
-  }
+  // =======================================================
+  // Incentives
+  // =======================================================
 
-  async distributeRewards(
-    wasteId: number,
-    incentiveId: number,
-    manufacturer: string,
+  async createIncentive(
+    rewarder: string,
+    wasteType: WasteType,
+    rewardPoints: bigint,
+    budget: bigint,
     signer: string
-  ): Promise<bigint> {
-    return this.invoke<bigint>(
-      'distribute_rewards',
+  ): Promise<Incentive> {
+    return this.invoke<Incentive>(
+      'create_incentive',
       [
-        nativeToScVal(wasteId, { type: 'u64' }),
-        nativeToScVal(incentiveId, { type: 'u64' }),
-        new Address(manufacturer).toScVal()
+        new Address(rewarder).toScVal(),
+        nativeToScVal(wasteType, { type: 'u32' }),
+        nativeToScVal(rewardPoints, { type: 'u64' }),
+        nativeToScVal(budget, { type: 'u64' }),
       ],
       signer
     )
   }
 
-  async getParticipantStats(address: string): Promise<ParticipantStats> {
-    return this.invoke<ParticipantStats>('get_participant_stats', [new Address(address).toScVal()])
+  async updateIncentive(
+    incentiveId: bigint,
+    rewarder: string,
+    rewardPoints: bigint,
+    budget: bigint,
+    signer: string
+  ): Promise<Incentive> {
+    return this.invoke<Incentive>(
+      'update_incentive',
+      [
+        nativeToScVal(incentiveId, { type: 'u64' }),
+        new Address(rewarder).toScVal(),
+        nativeToScVal(rewardPoints, { type: 'u64' }),
+        nativeToScVal(budget, { type: 'u64' }),
+      ],
+      signer
+    )
   }
 
-  async getSupplyChainStats(): Promise<[bigint, bigint, bigint]> {
-    return this.invoke<[bigint, bigint, bigint]>('get_supply_chain_stats', [])
+  async deactivateIncentive(incentiveId: bigint, rewarder: string, signer: string) {
+    return this.invoke<void>(
+      'deactivate_incentive',
+      [nativeToScVal(incentiveId, { type: 'u64' }), new Address(rewarder).toScVal()],
+      signer
+    )
+  }
+
+  async getIncentiveById(incentiveId: bigint): Promise<Incentive | null> {
+    return this.invoke<Incentive | null>('get_incentive_by_id', [
+      nativeToScVal(incentiveId, { type: 'u64' }),
+    ])
+  }
+
+  async getIncentives(wasteType: WasteType): Promise<Incentive[]> {
+    return this.invoke<Incentive[]>('get_incentives', [nativeToScVal(wasteType, { type: 'u32' })])
   }
 
   async getActiveIncentives(): Promise<Incentive[]> {
     return this.invoke<Incentive[]>('get_active_incentives', [])
   }
 
-  async recycleWaste(
-    recycler: string,
-    wasteType: WasteType,
-    weight: bigint,
-    latitude: bigint,
-    longitude: bigint,
+  async getActiveMfrIncentive(manufacturer: string, wasteType: WasteType): Promise<Incentive | null> {
+    return this.invoke<Incentive | null>('get_active_mfr_incentive', [
+      new Address(manufacturer).toScVal(),
+      nativeToScVal(wasteType, { type: 'u32' }),
+    ])
+  }
+
+  async distributeRewards(
+    wasteId: bigint,
+    incentiveId: bigint,
+    manufacturer: string,
     signer: string
   ): Promise<bigint> {
     return this.invoke<bigint>(
-      'recycle_waste',
+      'distribute_rewards',
       [
-        nativeToScVal(wasteType),
-        nativeToScVal(weight, { type: 'u128' }),
-        new Address(recycler).toScVal(),
-        nativeToScVal(latitude, { type: 'i128' }),
-        nativeToScVal(longitude, { type: 'i128' }),
+        nativeToScVal(wasteId, { type: 'u128' }),
+        nativeToScVal(incentiveId, { type: 'u64' }),
+        new Address(manufacturer).toScVal(),
       ],
       signer
     )
   }
 
-  async getParticipantWastesV2(address: string): Promise<bigint[]> {
-    return this.invoke<bigint[]>('get_participant_wastes_v2', [new Address(address).toScVal()])
+  // =======================================================
+  // Stats & Metrics
+  // =======================================================
+
+  async getMetrics(): Promise<GlobalMetrics> {
+    return this.invoke<GlobalMetrics>('get_metrics', [])
   }
 
+  async getStats(participant: string): Promise<ParticipantStats> {
+    return this.invoke<ParticipantStats>('get_stats', [new Address(participant).toScVal()])
+  }
+
+  async getSupplyChainStats(): Promise<{ total_wastes: bigint; total_weight: bigint; total_tokens: bigint }> {
+    return this.invoke('get_supply_chain_stats', [])
+  }
+
+  // =======================================================
+  // Legacy aliases kept for backward compatibility
+  // =======================================================
+
+  /** @deprecated Use getWaste */
   async getWasteV2(wasteId: bigint): Promise<Waste | null> {
-    return this.invoke<Waste | null>('get_waste_v2', [nativeToScVal(wasteId, { type: 'u128' })])
+    return this.getWaste(wasteId)
+  }
+
+  /** @deprecated Use getParticipantWastes */
+  async getParticipantWastesV2(address: string): Promise<bigint[]> {
+    return this.getParticipantWastes(address)
+  }
+
+  /** @deprecated Use getWasteTransferHistory */
+  async getWasteTransferHistoryV2(wasteId: bigint): Promise<WasteTransfer[]> {
+    return this.getWasteTransferHistory(wasteId)
+  }
+
+  /** @deprecated Use submitMaterial */
+  async recycleWaste(
+    recycler: string,
+    wasteType: WasteType,
+    weightGrams: bigint,
+    latitude: bigint,
+    longitude: bigint,
+    signer: string
+  ): Promise<bigint> {
+    const material = await this.submitMaterial(recycler, wasteType, weightGrams, latitude, longitude, signer)
+    return BigInt(material.id)
   }
 }

--- a/frontend/src/hooks/useCollectorDashboard.ts
+++ b/frontend/src/hooks/useCollectorDashboard.ts
@@ -38,20 +38,20 @@ export function useCollectorDashboard(): CollectorDashboardData {
         networkPassphrase: NETWORK_CONFIGS[config.network].networkPassphrase,
       })
 
-      const [participantStats, totalEarned] = await Promise.all([
-        client.getParticipantStats(address),
-        client.getTotalEarned(),
+      const [participantStats, metrics] = await Promise.all([
+        client.getStats(address),
+        client.getMetrics(),
       ])
 
       setStats(participantStats)
-      setTokenBalance(totalEarned)
+      setTokenBalance(metrics.total_tokens_earned ?? 0n)
 
       // Fetch all materials owned by this collector
       const wasteIds: number[] = []
       for (let i = 1; i <= participantStats.materials_submitted; i++) wasteIds.push(i)
 
       const materials = (
-        await Promise.all(wasteIds.map((id) => client.getMaterial(id)))
+        await Promise.all(wasteIds.map((id) => client.getMaterial(BigInt(id))))
       ).filter((m): m is Material => m !== null && m.current_owner === address && m.is_active)
 
       // Pending = transferred to this collector but not yet confirmed

--- a/frontend/src/hooks/useIncentives.ts
+++ b/frontend/src/hooks/useIncentives.ts
@@ -1,25 +1,16 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Incentive, WasteType } from '@/api/types'
 import { useContract } from '@/context/ContractContext'
 import { networkConfig } from '@/lib/stellar'
-import { useState, useEffect, useCallback } from 'react'
 import { useWallet } from '@/context/WalletContext'
 import { ScavengerClient } from '@/api/client'
-import { getNetworkPassphrase } from '@/lib/stellar'
 
 const INCENTIVES_STALE_TIME = 30 * 1000 // 30 seconds
 
-const ALL_WASTE_TYPES = [
-  WasteType.Paper,
-  WasteType.PetPlastic,
-  WasteType.Plastic,
-  WasteType.Metal,
-  WasteType.Glass,
-]
-
-
 export function useIncentives(wasteType?: WasteType) {
   const { config } = useContract()
+  const { address } = useWallet()
+  const queryClient = useQueryClient()
 
   const { data, isLoading, isError } = useQuery<Incentive[]>({
     queryKey: ['incentives', wasteType ?? 'all'],
@@ -29,71 +20,56 @@ export function useIncentives(wasteType?: WasteType) {
         networkPassphrase: networkConfig.networkPassphrase,
         contractId: config.contractId,
       })
-
-      if (wasteType !== undefined) {
-        return client.getIncentives(wasteType)
-      }
-
-      return client.getAllActiveIncentives()
+      if (wasteType !== undefined) return client.getIncentives(wasteType)
+      return client.getActiveIncentives()
     },
     staleTime: INCENTIVES_STALE_TIME,
   })
-  
-    const client = new ScavengerClient({
-    rpcUrl: config.rpcUrl,
-    networkPassphrase: getNetworkPassphrase(config.network),
-    contractId: config.contractId,
+
+  const getClient = () =>
+    new ScavengerClient({
+      rpcUrl: config.rpcUrl,
+      networkPassphrase: networkConfig.networkPassphrase,
+      contractId: config.contractId,
+    })
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['incentives'] })
+
+  const createIncentive = useMutation({
+    mutationFn: ({ wt, rewardPoints, budget }: { wt: WasteType; rewardPoints: bigint; budget: bigint }) => {
+      if (!address) throw new Error('Wallet not connected')
+      return getClient().createIncentive(address, wt, rewardPoints, budget, address)
+    },
+    onSuccess: invalidate,
   })
 
-  const load = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const idSets = await Promise.all(
-        ALL_WASTE_TYPES.map((wt) => client.getIncentivesByWasteType(wt))
-      )
-      const allIds = [...new Set(idSets.flat())]
-      const results = await Promise.all(allIds.map((id) => client.getIncentiveById(id)))
-      setIncentives(results.filter((i): i is Incentive => i !== null && i.active))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load incentives')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [config])
-
-  useEffect(() => { load() }, [load])
-
-  const createIncentive = useCallback(
-    async (wasteType: WasteType, rewardPoints: bigint, budget: bigint) => {
-      if (!address) return
-      await client.createIncentive(address, wasteType, rewardPoints, budget, address)
-      await load()
+  const updateIncentive = useMutation({
+    mutationFn: ({ id, rewardPoints, budget }: { id: bigint; rewardPoints: bigint; budget: bigint }) => {
+      if (!address) throw new Error('Wallet not connected')
+      return getClient().updateIncentive(id, address, rewardPoints, budget, address)
     },
-    [address, config, load]
-  )
+    onSuccess: invalidate,
+  })
 
-  const updateIncentive = useCallback(
-    async (id: number, rewardPoints: bigint, budget: bigint) => {
-      if (!address) return
-      await client.updateIncentive(id, rewardPoints, budget, address)
-      await load()
+  const deactivateIncentive = useMutation({
+    mutationFn: ({ id }: { id: bigint }) => {
+      if (!address) throw new Error('Wallet not connected')
+      return getClient().deactivateIncentive(id, address, address)
     },
-    [address, config, load]
-  )
-
-  const deactivateIncentive = useCallback(
-    async (id: number) => {
-      if (!address) return
-      await client.deactivateIncentive(address, id, address)
-      await load()
-    },
-    [address, config, load]
-  )
+    onSuccess: invalidate,
+  })
 
   return {
     incentives: data ?? [],
     isLoading,
-    isError, isLoading, error, address, createIncentive, updateIncentive, deactivateIncentive
+    isError,
+    error: isError ? 'Failed to load incentives' : null,
+    address,
+    createIncentive: (wt: WasteType, rewardPoints: bigint, budget: bigint) =>
+      createIncentive.mutateAsync({ wt, rewardPoints, budget }),
+    updateIncentive: (id: number | bigint, rewardPoints: bigint, budget: bigint) =>
+      updateIncentive.mutateAsync({ id: BigInt(id), rewardPoints, budget }),
+    deactivateIncentive: (id: number | bigint) => deactivateIncentive.mutateAsync({ id: BigInt(id) }),
   }
 }

--- a/frontend/src/hooks/useManufacturerDashboard.ts
+++ b/frontend/src/hooks/useManufacturerDashboard.ts
@@ -33,26 +33,25 @@ export function useManufacturerDashboard() {
     setIsLoading(true)
     setError(null)
     try {
-      // Fetch active incentives created by this manufacturer
-      const incentiveIds = await client.getIncentivesByRewarder(address)
-      const incentiveResults = await Promise.all(
-        incentiveIds.map((id) => client.getIncentiveById(id))
-      )
-      const activeIncentives = incentiveResults.filter(
-        (i): i is Incentive => i !== null && i.active
-      )
-      setIncentives(activeIncentives)
-
-      // Fetch wastes transferred to this manufacturer pending confirmation
-      // We check each waste type for materials owned by this address
+      // Fetch active incentives for all waste types by this manufacturer
       const wasteTypeKeys = Object.values(WasteType).filter(
         (v): v is WasteType => typeof v === 'number'
       )
+      const incentiveResults = await Promise.all(
+        wasteTypeKeys.map((wt) => client.getActiveMfrIncentive(address, wt))
+      )
+      const activeIncentives = incentiveResults.filter((i): i is Incentive => i !== null)
+      setIncentives(activeIncentives)
+
+      // Fetch wastes transferred to this manufacturer pending confirmation
+      const wasteTypeKeys2 = Object.values(WasteType).filter(
+        (v): v is WasteType => typeof v === 'number'
+      )
       const allMaterials: Material[] = []
-      for (const wt of wasteTypeKeys) {
-        const ids = await client.getIncentivesByWasteType(wt)
-        for (const id of ids) {
-          const mat = await client.getMaterial(id)
+      for (const wt of wasteTypeKeys2) {
+        const incentives2 = await client.getIncentives(wt)
+        for (const inc of incentives2) {
+          const mat = await client.getMaterial(BigInt(inc.id))
           if (mat && mat.current_owner === address && !mat.is_confirmed && mat.is_active) {
             allMaterials.push(mat)
           }
@@ -61,7 +60,7 @@ export function useManufacturerDashboard() {
       setPendingWastes(allMaterials)
 
       // Reward history: use participant stats as a proxy (full history not in client)
-      const stats = await client.getParticipantStats(address)
+      const stats = await client.getStats(address)
       // Represent as a single summary entry if total_earned > 0
       if (stats.total_earned > 0n) {
         setRewardHistory([
@@ -94,9 +93,9 @@ export function useManufacturerDashboard() {
   )
 
   const confirmWaste = useCallback(
-    async (wasteId: number) => {
+    async (wasteId: number | bigint) => {
       if (!address) return
-      await client.confirmWaste(wasteId, address, address)
+      await client.confirmWasteDetails(BigInt(wasteId), address, address)
       await load()
     },
     [address, config, load]

--- a/frontend/src/hooks/useRegisterParticipant.ts
+++ b/frontend/src/hooks/useRegisterParticipant.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ScavengerClient } from '@/lib/contract'
+import { Role, Participant } from '@/api/types'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+import { useToast } from '@/hooks/useToast'
+import { roleLabel } from '@/lib/helpers'
+
+export interface RegisterParticipantParams {
+  address: string
+  role: Role
+  name: string
+  /** Latitude in microdegrees (default 0) */
+  lat?: number
+  /** Longitude in microdegrees (default 0) */
+  lon?: number
+}
+
+export function useRegisterParticipant() {
+  const { config } = useContract()
+  const queryClient = useQueryClient()
+  const toast = useToast()
+
+  return useMutation<Participant, Error, RegisterParticipantParams>({
+    mutationFn: ({ address, role, name, lat = 0, lon = 0 }) => {
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+      return client.registerParticipant(address, role, name, lat, lon, address)
+    },
+    onSuccess: (participant, { address }) => {
+      queryClient.invalidateQueries({ queryKey: ['participant', address] })
+      toast.success(
+        `Registered as ${roleLabel(participant.role)}. Welcome, ${String(participant.name)}!`
+      )
+    },
+    onError: (error) => {
+      toast.error(error)
+    },
+  })
+}

--- a/frontend/src/hooks/useSupplyChainStats.ts
+++ b/frontend/src/hooks/useSupplyChainStats.ts
@@ -18,10 +18,10 @@ export function useSupplyChainStats() {
   useEffect(() => {
     async function fetch() {
       setIsLoading(true)
-      const [wastes, weight, tokens] = await client.getSupplyChainStats()
-      setTotalWastes(wastes)
-      setTotalWeight(weight)
-      setTotalTokens(tokens)
+      const stats = await client.getSupplyChainStats()
+      setTotalWastes(stats.total_wastes)
+      setTotalWeight(stats.total_weight)
+      setTotalTokens(stats.total_tokens)
       setIsLoading(false)
     }
 

--- a/frontend/src/hooks/useTransferHistory.ts
+++ b/frontend/src/hooks/useTransferHistory.ts
@@ -15,12 +15,7 @@ export function useTransferHistory(wasteId: number | bigint | undefined) {
         networkPassphrase: networkConfig.networkPassphrase,
         contractId: config.contractId,
       })
-
-      if (typeof wasteId === 'bigint') {
-        return client.getWasteTransferHistoryV2(wasteId)
-      }
-
-      return client.getTransferHistory(wasteId as number)
+      return client.getWasteTransferHistory(BigInt(wasteId as number))
     },
     enabled: wasteId !== undefined,
   })

--- a/frontend/src/hooks/useWasteList.ts
+++ b/frontend/src/hooks/useWasteList.ts
@@ -35,15 +35,15 @@ export function useWasteList() {
 
   useEffect(() => { load() }, [load])
 
-  const confirmWaste = useCallback(async (wasteId: number) => {
+  const confirmWaste = useCallback(async (wasteId: number | bigint) => {
     if (!address) return
-    await client.confirmWaste(wasteId, address, address)
+    await client.confirmWasteDetails(BigInt(wasteId), address, address)
     await load()
   }, [address, config, load])
 
-  const transferWaste = useCallback(async (wasteId: number, to: string) => {
+  const transferWaste = useCallback(async (wasteId: number | bigint, to: string) => {
     if (!address) return
-    await client.transferWaste(wasteId, address, to, address)
+    await client.transferWaste(BigInt(wasteId), address, to, 0n, 0n, '', address)
     await load()
   }, [address, config, load])
 

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -1,0 +1,8 @@
+/**
+ * Contract client wrapper — re-exports ScavengerClient from the API layer.
+ *
+ * Import from here for all contract interactions:
+ *   import { ScavengerClient } from '@/lib/contract'
+ */
+export { ScavengerClient } from '@/api/client'
+export type { ClientOptions } from '@/api/client'

--- a/frontend/src/lib/contractErrors.ts
+++ b/frontend/src/lib/contractErrors.ts
@@ -1,33 +1,47 @@
 import { ContractError } from '@/api/types'
 
-// Maps contract error codes to user-friendly messages
+// Maps contract error codes to user-friendly messages (matches errors.rs)
 const ERROR_MESSAGES: Record<number, string> = {
-  1: 'You are not authorized to perform this action.',
-  2: 'Participant is already registered.',
-  3: 'Participant not found.',
-  4: 'Incentive not found.',
-  5: 'Incentive is no longer active.',
-  6: 'Insufficient budget for this incentive.',
-  7: 'Material not found.',
-  8: 'Material is not active.',
-  9: 'Material has already been confirmed.',
-  10: 'Invalid waste type.',
-  11: 'Invalid role for this operation.',
-  12: 'Transfer not allowed — you do not own this material.',
-  13: 'Reward distribution failed.',
-  14: 'Contract is not initialized.',
-  15: 'Percentages must add up to 100.'
+  1: 'Contract is already initialized.',
+  2: 'You are not authorized to perform this action.',
+  3: 'Participant is not registered.',
+  4: 'Participant is already registered.',
+  5: 'Only manufacturers can perform this action.',
+  6: 'You do not own this waste item.',
+  7: 'Waste not found.',
+  8: 'Material not found.',
+  9: 'Incentive not found.',
+  10: 'Participant not found.',
+  11: 'Invalid amount — must be greater than zero.',
+  12: 'Invalid weight — must be greater than zero.',
+  13: 'Invalid coordinates — latitude must be ±90° and longitude ±180°.',
+  14: 'Percentages must add up to 100.',
+  15: 'Insufficient token balance.',
+  16: 'Charity address has not been configured.',
+  17: 'Token address has not been configured.',
+  18: 'This waste item has been deactivated.',
+  19: 'Waste is already deactivated.',
+  20: 'Waste has already been confirmed.',
+  21: 'Waste has not been confirmed yet.',
+  22: 'You cannot confirm your own waste.',
+  23: 'This incentive is no longer active.',
+  24: 'Material must be verified before use.',
+  25: 'Waste type does not match the incentive.',
+  26: 'No reward available — budget may be exhausted.',
+  27: 'Invalid transfer route for your role.',
+  28: 'Source and destination addresses must differ.',
+  29: 'Arithmetic overflow detected.',
+  30: 'You are not the creator of this resource.',
+  31: 'Insufficient incentive budget.',
 }
 
 export function getErrorMessage(error: unknown): string {
   if (error instanceof ContractError) {
-    const code = error.code
-    if (code !== undefined && ERROR_MESSAGES[code]) {
-      return ERROR_MESSAGES[code]
+    if (error.code !== undefined && ERROR_MESSAGES[error.code]) {
+      return ERROR_MESSAGES[error.code]
     }
-    if (error.message && error.message !== 'Unknown Contract Error') {
-      return error.message
-    }
+    if (error.message) return error.message
   }
+  if (error instanceof Error) return error.message
   return 'Something went wrong. Please try again.'
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,8 @@ import {
 import { useWallet } from '@/context/WalletContext'
 import { useAuth } from '@/context/AuthContext'
 import { useAppTitle } from '@/hooks/useAppTitle'
-import { ScavengerClient } from '@/api/client'
+import { useRegisterParticipant } from '@/hooks/useRegisterParticipant'
+import { ScavengerClient } from '@/lib/contract'
 import { Role } from '@/api/types'
 import { config } from '@/config'
 import { networkConfig } from '@/lib/stellar'
@@ -36,6 +37,7 @@ export function LoginPage() {
   const navigate = useNavigate()
   const { address, isConnected, connect, isLoading: walletLoading, error: walletError } = useWallet()
   const { login } = useAuth()
+  const registerMutation = useRegisterParticipant()
 
   const [checking, setChecking] = useState(false)
   const [isRegistered, setIsRegistered] = useState<boolean | null>(null)
@@ -43,8 +45,6 @@ export function LoginPage() {
   // Registration form state
   const [name, setName] = useState('')
   const [role, setRole] = useState<Role>(Role.Recycler)
-  const [submitting, setSubmitting] = useState(false)
-  const [formError, setFormError] = useState<string | null>(null)
 
   // Once wallet connects, check registration status
   useEffect(() => {
@@ -69,17 +69,15 @@ export function LoginPage() {
   async function handleRegister(e: React.FormEvent) {
     e.preventDefault()
     if (!address || !name.trim()) return
-    setFormError(null)
-    setSubmitting(true)
-    try {
-      const participant = await client.registerParticipant(address, role, name.trim(), 0, 0, address)
-      login({ address, role: participant.role, name: participant.name })
-      navigate('/dashboard', { replace: true })
-    } catch (err: any) {
-      setFormError(err?.message ?? 'Registration failed. Please try again.')
-    } finally {
-      setSubmitting(false)
-    }
+    registerMutation.mutate(
+      { address, role, name: name.trim() },
+      {
+        onSuccess: (participant) => {
+          login({ address, role: participant.role, name: participant.name })
+          navigate('/dashboard', { replace: true })
+        },
+      }
+    )
   }
 
   const isbusy = walletLoading || checking
@@ -149,10 +147,12 @@ export function LoginPage() {
               </Select>
             </div>
 
-            {formError && <p className="text-sm text-destructive">{formError}</p>}
+            {registerMutation.isError && (
+              <p className="text-sm text-destructive">{registerMutation.error?.message ?? 'Registration failed. Please try again.'}</p>
+            )}
 
-            <Button type="submit" className="w-full" disabled={submitting || !name.trim()}>
-              {submitting ? 'Registering…' : 'Create Account'}
+            <Button type="submit" className="w-full" disabled={registerMutation.isPending || !name.trim()}>
+              {registerMutation.isPending ? 'Registering…' : 'Create Account'}
             </Button>
           </form>
         )}

--- a/frontend/src/pages/RecyclerDashboard.tsx
+++ b/frontend/src/pages/RecyclerDashboard.tsx
@@ -55,7 +55,7 @@ export function RecyclerDashboard() {
     setLoading(true)
     try {
       const [participantStats, wasteIds, activeIncentives] = await Promise.all([
-        client.getParticipantStats(address),
+        client.getStats(address),
         client.getParticipantWastes(address),
         client.getActiveIncentives(),
       ])


### PR DESCRIPTION
## Summary

Closes #199 — Contract client wrapper
Closes #200 — register_participant frontend integration

---

## Changes

 closes #199  — ScavengerClient typed contract wrapper (`src/lib/contract.ts`)

- Rewrote `ScavengerClient.invoke()` with a real Soroban transaction pipeline:
  - **Read-only calls**: simulate via `SorobanRpc.Server` and decode the return value
  - **Mutating calls**: build tx → simulate → assemble → sign via Freighter → submit → poll for ledger confirmation
- Added typed methods for every public contract function (admin, participants, waste/materials, incentives, stats)
- XDR encoding via `nativeToScVal` / `Address.toScVal`, decoding via `scValToNative`
- Typed error extraction: parses `Error(Contract, #N)` from XDR and maps to `ContractError` with numeric code
- Created `src/lib/contract.ts` as the canonical import path (`@/lib/contract`)
- Expanded `contractErrors.ts` to cover all 31 error codes from `errors.rs`
- Kept deprecated aliases (`recycleWaste`, `getWasteV2`, etc.) for backward compatibility

closes #200  — register_participant integration

- Added `useRegisterParticipant` mutation hook (`src/hooks/useRegisterParticipant.ts`):
  - Builds and signs the `register_participant` transaction via Freighter
  - Waits for ledger confirmation (handled by `ScavengerClient`)
  - Invalidates `['participant', address]` query cache on success
  - Shows success toast with role and name: _"Registered as Recycler. Welcome, Alice!"_
  - Shows typed error toast on failure
- Updated `LoginPage` to use `useRegisterParticipant` instead of inline try/catch logic

### Housekeeping

- Updated all hooks and pages to use the new client API signatures (`getStats`, `confirmWasteDetails`, `bigint` IDs, etc.)