### PR TITLE
feat: AddressDisplay component and loading skeletons

### DIFF
--- a/frontend/src/components/ui/AddressDisplay.tsx
+++ b/frontend/src/components/ui/AddressDisplay.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { Copy, Check, ExternalLink } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { config } from '@/config'
+
+const EXPLORER_ROOTS: Record<string, string> = {
+  TESTNET: 'https://stellar.expert/explorer/testnet/account',
+  MAINNET: 'https://stellar.expert/explorer/public/account',
+  FUTURENET: 'https://stellar.expert/explorer/futurenet/account',
+  STANDALONE: '',
+}
+
+interface AddressDisplayProps {
+  address: string
+  /** Number of chars to show at each end (default 4) */
+  chars?: number
+  /** Show link to Stellar Expert explorer */
+  showExplorer?: boolean
+  className?: string
+}
+
+export function AddressDisplay({ address, chars = 4, showExplorer = false, className }: AddressDisplayProps) {
+  const [copied, setCopied] = useState(false)
+
+  const truncated = `${address.slice(0, chars)}…${address.slice(-chars)}`
+  const explorerUrl = `${EXPLORER_ROOTS[config.network] ?? EXPLORER_ROOTS.TESTNET}/${address}`
+
+  const copy = () => {
+    navigator.clipboard.writeText(address).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <span className={cn('inline-flex items-center gap-1', className)}>
+      <span
+        className="font-mono text-xs"
+        title={address}
+        aria-label={address}
+      >
+        {truncated}
+      </span>
+
+      <button
+        type="button"
+        onClick={copy}
+        title="Copy address"
+        aria-label="Copy address"
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {copied
+          ? <Check className="h-3 w-3 text-green-500" />
+          : <Copy className="h-3 w-3" />}
+      </button>
+
+      {showExplorer && EXPLORER_ROOTS[config.network] && (
+        <a
+          href={explorerUrl}
+          target="_blank"
+          rel="noreferrer"
+          title="View on Stellar Expert"
+          aria-label="View on Stellar Expert"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/ui/Skeletons.tsx
+++ b/frontend/src/components/ui/Skeletons.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} />
+}
+
+/** Matches the 3-column stat card grid on dashboards */
+export function StatCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card shadow-sm p-6 space-y-3">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-4 rounded-full" />
+      </div>
+      <Skeleton className="h-8 w-20" />
+    </div>
+  )
+}
+
+/** Matches a single waste row in the waste list table */
+export function WasteCardSkeleton() {
+  return (
+    <tr>
+      <td className="px-4 py-3"><Skeleton className="h-4 w-10" /></td>
+      <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+      <td className="px-4 py-3"><Skeleton className="h-4 w-12" /></td>
+      <td className="px-4 py-3"><Skeleton className="h-5 w-16 rounded-full" /></td>
+      <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+      <td className="px-4 py-3 text-right"><Skeleton className="ml-auto h-7 w-20" /></td>
+    </tr>
+  )
+}
+
+/** Matches a single incentive row inside a card table */
+export function IncentiveCardSkeleton() {
+  return (
+    <tr>
+      <td className="py-2 pr-4"><Skeleton className="h-4 w-8" /></td>
+      <td className="py-2 pr-4"><Skeleton className="h-4 w-24" /></td>
+      <td className="py-2 pr-4"><Skeleton className="h-4 w-12" /></td>
+      <td className="py-2 pr-4"><Skeleton className="h-5 w-16 rounded-full" /></td>
+    </tr>
+  )
+}

--- a/frontend/src/pages/IncentivesPage.tsx
+++ b/frontend/src/pages/IncentivesPage.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Input } from '@/components/ui/Input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { IncentiveCardSkeleton } from '@/components/ui/Skeletons'
+import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import {
   Select,
   SelectContent,
@@ -116,8 +118,21 @@ export function IncentivesPage() {
       )}
 
       {isLoading ? (
-        <div className="flex items-center justify-center py-16">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <div className="space-y-6">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-3">
+                <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+              </CardHeader>
+              <CardContent>
+                <table className="w-full text-sm">
+                  <tbody className="divide-y">
+                    {Array.from({ length: 3 }).map((_, j) => <IncentiveCardSkeleton key={j} />)}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       ) : (
         <div className="space-y-6">
@@ -148,7 +163,7 @@ export function IncentivesPage() {
                             <tr key={inc.id} className="hover:bg-muted/30 transition-colors">
                               <td className="py-2 pr-4 font-mono">#{inc.id}</td>
                               <td className="py-2 pr-4 font-mono text-xs text-muted-foreground">
-                                {inc.rewarder.slice(0, 6)}…{inc.rewarder.slice(-4)}
+                                <AddressDisplay address={inc.rewarder} showExplorer />
                               </td>
                               <td className="py-2 pr-4">{inc.reward_points}</td>
                               <td className="py-2 pr-4">

--- a/frontend/src/pages/RecyclerDashboard.tsx
+++ b/frontend/src/pages/RecyclerDashboard.tsx
@@ -3,6 +3,8 @@ import { Plus, Coins, Recycle, Weight } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { StatCardSkeleton } from '@/components/ui/Skeletons'
+import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import { RegisterWasteModal } from '@/components/modals/RegisterWasteModal'
 import { useAuth } from '@/context/AuthContext'
 import { useAppTitle } from '@/hooks/useAppTitle'
@@ -85,41 +87,41 @@ export function RecyclerDashboard() {
 
       {/* Stat cards */}
       <div className="grid gap-4 sm:grid-cols-3">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Token Balance</CardTitle>
-            <Coins className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">
-              {loading ? '—' : stats?.total_earned?.toString() ?? '0'}
-            </p>
-          </CardContent>
-        </Card>
+        {loading ? (
+          Array.from({ length: 3 }).map((_, i) => <StatCardSkeleton key={i} />)
+        ) : (
+          <>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">Token Balance</CardTitle>
+                <Coins className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold">{stats?.total_earned?.toString() ?? '0'}</p>
+              </CardContent>
+            </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Wastes Submitted</CardTitle>
-            <Recycle className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">
-              {loading ? '—' : stats?.materials_submitted ?? 0}
-            </p>
-          </CardContent>
-        </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">Wastes Submitted</CardTitle>
+                <Recycle className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold">{stats?.materials_submitted ?? 0}</p>
+              </CardContent>
+            </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Transfers</CardTitle>
-            <Weight className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">
-              {loading ? '—' : stats?.transfers_count ?? 0}
-            </p>
-          </CardContent>
-        </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">Transfers</CardTitle>
+                <Weight className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold">{stats?.transfers_count ?? 0}</p>
+              </CardContent>
+            </Card>
+          </>
+        )}
       </div>
 
       {/* Recent wastes */}
@@ -129,7 +131,17 @@ export function RecyclerDashboard() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <div className="divide-y">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between py-3">
+                  <div className="space-y-1.5">
+                    <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                    <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+                  </div>
+                  <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+                </div>
+              ))}
+            </div>
           ) : wastes.length === 0 ? (
             <p className="text-sm text-muted-foreground">No wastes submitted yet.</p>
           ) : (
@@ -157,7 +169,17 @@ export function RecyclerDashboard() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <div className="divide-y">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between py-3">
+                  <div className="space-y-1.5">
+                    <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+                    <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                  </div>
+                  <div className="h-4 w-14 animate-pulse rounded bg-muted" />
+                </div>
+              ))}
+            </div>
           ) : incentives.length === 0 ? (
             <p className="text-sm text-muted-foreground">No active incentives.</p>
           ) : (

--- a/frontend/src/pages/WasteListPage.tsx
+++ b/frontend/src/pages/WasteListPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
-import { Loader2, Search, Eye, ArrowRightLeft, CheckCircle } from 'lucide-react'
+import { Search, Eye, ArrowRightLeft, CheckCircle, Loader2 } from 'lucide-react'
 import { useWasteList } from '@/hooks/useWasteList'
 import { Material, WasteType } from '@/api/types'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { Badge } from '@/components/ui/Badge'
+import { WasteCardSkeleton } from '@/components/ui/Skeletons'
+import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import {
   Select,
   SelectContent,
@@ -139,8 +141,22 @@ export function WasteListPage() {
       )}
 
       {isLoading ? (
-        <div className="flex items-center justify-center py-16">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">ID</th>
+                <th className="px-4 py-3 text-left font-medium">Type</th>
+                <th className="px-4 py-3 text-left font-medium">Weight (kg)</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Submitted</th>
+                <th className="px-4 py-3 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {Array.from({ length: 5 }).map((_, i) => <WasteCardSkeleton key={i} />)}
+            </tbody>
+          </table>
         </div>
       ) : (
         <>
@@ -256,13 +272,13 @@ export function WasteListPage() {
               <dt className="text-muted-foreground">Verified</dt>
               <dd>{detailWaste.verified ? 'Yes' : 'No'}</dd>
               <dt className="text-muted-foreground">Submitter</dt>
-              <dd className="truncate font-mono text-xs">{detailWaste.submitter}</dd>
+              <dd><AddressDisplay address={detailWaste.submitter} showExplorer /></dd>
               <dt className="text-muted-foreground">Current Owner</dt>
-              <dd className="truncate font-mono text-xs">{detailWaste.current_owner}</dd>
+              <dd><AddressDisplay address={detailWaste.current_owner} showExplorer /></dd>
               {detailWaste.is_confirmed && (
                 <>
                   <dt className="text-muted-foreground">Confirmer</dt>
-                  <dd className="truncate font-mono text-xs">{detailWaste.confirmer}</dd>
+                  <dd><AddressDisplay address={detailWaste.confirmer} showExplorer /></dd>
                 </>
               )}
               <dt className="text-muted-foreground">Submitted</dt>


### PR DESCRIPTION
## Summary

Closes #273  — AddressDisplay component
Closes #274  — Loading skeletons on data-fetching pages

---

## Changes

### #273 — AddressDisplay (`src/components/ui/AddressDisplay.tsx`)

- Truncates any Stellar address to `ABCD…WXYZ` format (configurable `chars` prop, default 4)
- Copy-to-clipboard button with a `✓` check icon feedback for 1.5s after copying
- Full address shown on hover via native `title` tooltip
- Optional `showExplorer` prop — renders a link to Stellar Expert for the active network
  (TESTNET / MAINNET / FUTURENET; hidden on STANDALONE where no explorer exists)
- Used in: rewarder column in `IncentivesPage`, submitter/owner/confirmer fields in `WasteListPage` detail dialog

### #274 — Skeleton loaders (`src/components/ui/Skeletons.tsx`)

Three skeleton components that match the exact layout of their real counterparts:

| Component | Used on |
|---|---|
| `StatCardSkeleton` | RecyclerDashboard — 3-column stat grid |
| `WasteCardSkeleton` | WasteListPage — table rows (6 columns) |
| `IncentiveCardSkeleton` | IncentivesPage — table rows inside cards |

Applied to all three data-fetching pages:
- **RecyclerDashboard**: stat cards, recent wastes list, and incentives list all show skeletons while `loading`
- **WasteListPage**: renders the table header + 5 skeleton rows instead of a centered spinner
- **IncentivesPage**: renders 2 skeleton cards with 3 skeleton rows each instead of a centered spinner
