### PR TITLE
feat: allow participants to transfer waste from the frontend

### DIFF
--- a/frontend/src/components/modals/TransferWasteModal.tsx
+++ b/frontend/src/components/modals/TransferWasteModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { useTransferWaste } from '@/hooks/useTransferWaste'
+import { useToast } from '@/hooks/useToast'
+
+interface Props {
+  open: boolean
+  wasteId: bigint
+  onClose: () => void
+}
+
+export function TransferWasteModal({ open, wasteId, onClose }: Props) {
+  const [recipient, setRecipient] = useState('')
+  const { mutateAsync, isPending } = useTransferWaste()
+  const toast = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      const to = await mutateAsync({ wasteId, to: recipient.trim() })
+      toast.success(`Waste transferred to ${to}`)
+      setRecipient('')
+      onClose()
+    } catch (err) {
+      toast.error(err)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Transfer Waste #{wasteId.toString()}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Recipient address</label>
+            <Input
+              placeholder="G…"
+              value={recipient}
+              onChange={(e) => setRecipient(e.target.value)}
+              required
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || !recipient}>
+              {isPending ? 'Transferring…' : 'Transfer'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/hooks/useTransferWaste.ts
+++ b/frontend/src/hooks/useTransferWaste.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ScavengerClient } from '@/api/client'
+import { useWallet } from '@/context/WalletContext'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+import { isValidAddress } from '@stellar/stellar-sdk'
+
+export interface TransferWasteParams {
+  wasteId: bigint
+  to: string
+}
+
+export function useTransferWaste() {
+  const { address } = useWallet()
+  const { config } = useContract()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ wasteId, to }: TransferWasteParams) => {
+      if (!address) throw new Error('Wallet not connected.')
+      if (!isValidAddress(to)) throw new Error('Invalid recipient address.')
+      if (to === address) throw new Error('Cannot transfer waste to yourself.')
+
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+
+      await client.transferWaste(Number(wasteId), address, to, address)
+      return to
+    },
+    onSuccess: (_to, { wasteId }) => {
+      queryClient.invalidateQueries({ queryKey: ['participant-wastes'] })
+      queryClient.invalidateQueries({ queryKey: ['transfer-history', wasteId.toString()] })
+    },
+  })
+}

--- a/frontend/src/pages/RecyclerDashboard.tsx
+++ b/frontend/src/pages/RecyclerDashboard.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { RegisterWasteModal } from '@/components/modals/RegisterWasteModal'
+import { TransferWasteModal } from '@/components/modals/TransferWasteModal'
 import { useAuth } from '@/context/AuthContext'
 import { useAppTitle } from '@/hooks/useAppTitle'
 import { ScavengerClient } from '@/api/client'
@@ -49,6 +50,7 @@ export function RecyclerDashboard() {
   const [incentives, setIncentives] = useState<Incentive[]>([])
   const [loading, setLoading] = useState(true)
   const [modalOpen, setModalOpen] = useState(false)
+  const [transferWasteId, setTransferWasteId] = useState<bigint | null>(null)
 
   const load = useCallback(async () => {
     if (!address) return
@@ -142,7 +144,18 @@ export function RecyclerDashboard() {
                     </p>
                     <p className="text-xs text-muted-foreground">{m.weight} kg</p>
                   </div>
-                  <Badge variant={statusVariant(m)}>{statusLabel(m)}</Badge>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={statusVariant(m)}>{statusLabel(m)}</Badge>
+                    {m.is_active && !m.is_confirmed && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setTransferWasteId(BigInt(m.id))}
+                      >
+                        Transfer
+                      </Button>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>
@@ -186,6 +199,14 @@ export function RecyclerDashboard() {
         onClose={() => setModalOpen(false)}
         onSuccess={() => load()}
       />
+
+      {transferWasteId !== null && (
+        <TransferWasteModal
+          open
+          wasteId={transferWasteId}
+          onClose={() => { setTransferWasteId(null); load() }}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Description

- Add useTransferWaste mutation hook with client-side validation (invalid address, self-transfer guard) and cache invalidation for participant-wastes and transfer-history queries on success
- Add TransferWasteModal component wired to the hook; shows success toast with recipient address on completion
- Wire TransferWasteModal into RecyclerDashboard with a Transfer button on each active, unconfirmed waste row

Closes #202