### PR TITLE
feat(frontend): add reusable empty states with contextual actions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -96,7 +96,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -916,7 +915,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.10.tgz",
       "integrity": "sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -983,7 +981,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.10.tgz",
       "integrity": "sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.10",
         "@firebase/component": "0.7.2",
@@ -999,8 +996,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.4",
@@ -1451,7 +1447,6 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3141,7 +3136,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
       "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.95.2"
       },
@@ -3244,7 +3238,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3256,7 +3249,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3301,7 +3293,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3489,7 +3480,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3833,7 +3823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4382,7 +4371,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5347,7 +5335,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5864,7 +5851,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6102,7 +6088,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6115,7 +6100,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6657,7 +6641,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6765,7 +6748,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6882,7 +6864,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6999,7 +6980,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,31 @@
+import { LucideIcon } from 'lucide-react'
+import { Button } from './Button'
+import { cn } from '@/lib/utils'
+
+export interface EmptyStateProps {
+  icon?: LucideIcon
+  title: string
+  description?: string
+  action?: {
+    label: string
+    onClick: () => void
+  }
+  className?: string
+}
+
+export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center gap-4 py-12', className)}>
+      {Icon && <Icon className="h-12 w-12 text-muted-foreground opacity-50" />}
+      <div className="space-y-2 text-center">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {action && (
+        <Button onClick={action.onClick} size="sm" className="mt-2">
+          {action.label}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/TransferTimeline.tsx
+++ b/frontend/src/components/ui/TransferTimeline.tsx
@@ -1,7 +1,8 @@
-import { ArrowRight, MapPin, Clock, CheckCircle2 } from 'lucide-react'
+import { ArrowRight, Clock, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WasteTransfer } from '@/api/types'
 import { formatAddress, formatDate } from '@/lib/helpers'
+import { EmptyState } from './EmptyState'
 
 export interface TransferTimelineProps {
   history: WasteTransfer[]
@@ -37,10 +38,12 @@ export function TransferTimeline({
 
   if (history.length === 0) {
     return (
-      <div className={cn('flex flex-col items-center gap-2 py-10 text-muted-foreground', className)}>
-        <Clock className="h-8 w-8 opacity-40" />
-        <p className="text-sm">No transfer history yet</p>
-      </div>
+      <EmptyState
+        icon={Clock}
+        title="No transfer history"
+        description="This waste hasn't been transferred yet"
+        className={className}
+      />
     )
   }
 

--- a/frontend/src/pages/CollectorDashboardPage.tsx
+++ b/frontend/src/pages/CollectorDashboardPage.tsx
@@ -4,6 +4,7 @@ import { useWallet } from '@/context/WalletContext'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { WasteType, Material } from '@/api/types'
 import { formatTokenAmount, wasteTypeLabel, formatDate, formatAddress } from '@/lib/helpers'
 import { Coins, ArrowDownToLine, Package, BarChart3 } from 'lucide-react'
@@ -141,7 +142,11 @@ export function CollectorDashboardPage() {
         </CardHeader>
         <CardContent className="space-y-2">
           {pendingTransfers.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No pending transfers.</p>
+            <EmptyState
+              icon={ArrowDownToLine}
+              title="No pending transfers"
+              description="Transfers heading your way will appear here"
+            />
           ) : (
             pendingTransfers.map((m) => (
               <WasteRow key={m.id} material={m} onTransfer={handleTransfer} />
@@ -157,7 +162,11 @@ export function CollectorDashboardPage() {
         </CardHeader>
         <CardContent className="space-y-2">
           {collectedWastes.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No collected wastes yet.</p>
+            <EmptyState
+              icon={Package}
+              title="No collected wastes"
+              description="Collected waste items will appear here"
+            />
           ) : (
             collectedWastes.map((m) => (
               <WasteRow key={m.id} material={m} onTransfer={handleTransfer} />

--- a/frontend/src/pages/IncentivesPage.tsx
+++ b/frontend/src/pages/IncentivesPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Plus, Pencil, Trash2, Loader2 } from 'lucide-react'
+import { Plus, Pencil, Trash2, Loader2, Zap } from 'lucide-react'
 import { useIncentives } from '@/hooks/useIncentives'
 import { Incentive, WasteType, Role } from '@/api/types'
 import { useAuth } from '@/context/AuthContext'
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Input } from '@/components/ui/Input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { IncentiveCardSkeleton } from '@/components/ui/Skeletons'
 import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import {
@@ -14,14 +15,14 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from '@/components/ui/Select'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
+  DialogFooter
 } from '@/components/ui/Dialog'
 
 const WASTE_LABELS: Record<WasteType, string> = {
@@ -29,17 +30,26 @@ const WASTE_LABELS: Record<WasteType, string> = {
   [WasteType.PetPlastic]: 'PET Plastic',
   [WasteType.Plastic]: 'Plastic',
   [WasteType.Metal]: 'Metal',
-  [WasteType.Glass]: 'Glass',
+  [WasteType.Glass]: 'Glass'
 }
 
-const ALL_WASTE_TYPES = Object.values(WasteType).filter((v): v is WasteType => typeof v === 'number')
+const ALL_WASTE_TYPES = Object.values(WasteType).filter(
+  (v): v is WasteType => typeof v === 'number'
+)
 
 type FormState = { wasteType: string; rewardPoints: string; budget: string }
 const EMPTY_FORM: FormState = { wasteType: String(WasteType.Paper), rewardPoints: '', budget: '' }
 
 export function IncentivesPage() {
-  const { incentives, isLoading, error, address, createIncentive, updateIncentive, deactivateIncentive } =
-    useIncentives()
+  const {
+    incentives,
+    isLoading,
+    error,
+    address,
+    createIncentive,
+    updateIncentive,
+    deactivateIncentive
+  } = useIncentives()
   const { user } = useAuth()
   const isManufacturer = user?.role === Role.Manufacturer
 
@@ -51,12 +61,16 @@ export function IncentivesPage() {
   const [form, setForm] = useState<FormState>(EMPTY_FORM)
   const [submitting, setSubmitting] = useState(false)
 
-  const openCreate = () => { setForm(EMPTY_FORM); setEditTarget(null); setCreateOpen(true) }
+  const openCreate = () => {
+    setForm(EMPTY_FORM)
+    setEditTarget(null)
+    setCreateOpen(true)
+  }
   const openEdit = (inc: Incentive) => {
     setForm({
       wasteType: String(inc.waste_type),
       rewardPoints: String(inc.reward_points),
-      budget: String(inc.remaining_budget),
+      budget: String(inc.remaining_budget)
     })
     setEditTarget(inc)
     setCreateOpen(true)
@@ -68,7 +82,11 @@ export function IncentivesPage() {
       if (editTarget) {
         await updateIncentive(editTarget.id, BigInt(form.rewardPoints), BigInt(form.budget))
       } else {
-        await createIncentive(Number(form.wasteType) as WasteType, BigInt(form.rewardPoints), BigInt(form.budget))
+        await createIncentive(
+          Number(form.wasteType) as WasteType,
+          BigInt(form.rewardPoints),
+          BigInt(form.budget)
+        )
       }
       setCreateOpen(false)
     } finally {
@@ -76,9 +94,10 @@ export function IncentivesPage() {
     }
   }
 
-  const filtered = typeFilter === 'all'
-    ? incentives
-    : incentives.filter((i) => i.waste_type === Number(typeFilter))
+  const filtered =
+    typeFilter === 'all'
+      ? incentives
+      : incentives.filter((i) => i.waste_type === Number(typeFilter))
 
   // Group by waste type
   const grouped = ALL_WASTE_TYPES.reduce<Record<WasteType, Incentive[]>>(
@@ -98,7 +117,9 @@ export function IncentivesPage() {
             <SelectContent>
               <SelectItem value="all">All types</SelectItem>
               {ALL_WASTE_TYPES.map((wt) => (
-                <SelectItem key={wt} value={String(wt)}>{WASTE_LABELS[wt]}</SelectItem>
+                <SelectItem key={wt} value={String(wt)}>
+                  {WASTE_LABELS[wt]}
+                </SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -127,7 +148,9 @@ export function IncentivesPage() {
               <CardContent>
                 <table className="w-full text-sm">
                   <tbody className="divide-y">
-                    {Array.from({ length: 3 }).map((_, j) => <IncentiveCardSkeleton key={j} />)}
+                    {Array.from({ length: 3 }).map((_, j) => (
+                      <IncentiveCardSkeleton key={j} />
+                    ))}
                   </tbody>
                 </table>
               </CardContent>
@@ -136,74 +159,88 @@ export function IncentivesPage() {
         </div>
       ) : (
         <div className="space-y-6">
-          {ALL_WASTE_TYPES.map((wt) => {
-            const group = grouped[wt]
-            if (group.length === 0) return null
-            return (
-              <Card key={wt}>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base">{WASTE_LABELS[wt]}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead className="text-left text-muted-foreground">
-                        <tr>
-                          <th className="pb-2 pr-4 font-medium">ID</th>
-                          <th className="pb-2 pr-4 font-medium">Rewarder</th>
-                          <th className="pb-2 pr-4 font-medium">Pts / unit</th>
-                          <th className="pb-2 pr-4 font-medium">Budget remaining</th>
-                          {isManufacturer && <th className="pb-2 font-medium text-right">Actions</th>}
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {group.map((inc) => {
-                          const isOwner = inc.rewarder === address
-                          return (
-                            <tr key={inc.id} className="hover:bg-muted/30 transition-colors">
-                              <td className="py-2 pr-4 font-mono">#{inc.id}</td>
-                              <td className="py-2 pr-4 font-mono text-xs text-muted-foreground">
-                                <AddressDisplay address={inc.rewarder} showExplorer />
-                              </td>
-                              <td className="py-2 pr-4">{inc.reward_points}</td>
-                              <td className="py-2 pr-4">
-                                <Badge variant="secondary">
-                                  {inc.remaining_budget.toLocaleString()}
-                                </Badge>
-                              </td>
+          {filtered.length === 0 ? (
+            <EmptyState
+              icon={Zap}
+              title="No incentives found"
+              description={typeFilter !== 'all' ? "No incentives for this waste type" : "No incentives yet"}
+              action={isManufacturer ? { label: "Create Incentive", onClick: openCreate } : undefined}
+            />
+          ) : (
+            <>
+              {ALL_WASTE_TYPES.map((wt) => {
+                const group = grouped[wt]
+                if (group.length === 0) return null
+                return (
+                  <Card key={wt}>
+                    <CardHeader className="pb-3">
+                      <CardTitle className="text-base">{WASTE_LABELS[wt]}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                          <thead className="text-left text-muted-foreground">
+                            <tr>
+                              <th className="pb-2 pr-4 font-medium">ID</th>
+                              <th className="pb-2 pr-4 font-medium">Rewarder</th>
+                              <th className="pb-2 pr-4 font-medium">Pts / unit</th>
+                              <th className="pb-2 pr-4 font-medium">Budget remaining</th>
                               {isManufacturer && (
-                                <td className="py-2 text-right">
-                                  {isOwner && (
-                                    <div className="flex justify-end gap-1">
-                                      <Button size="sm" variant="ghost" title="Edit" onClick={() => openEdit(inc)}>
-                                        <Pencil className="h-4 w-4" />
-                                      </Button>
-                                      <Button
-                                        size="sm"
-                                        variant="ghost"
-                                        title="Deactivate"
-                                        className="text-destructive hover:text-destructive"
-                                        onClick={() => deactivateIncentive(inc.id)}
-                                      >
-                                        <Trash2 className="h-4 w-4" />
-                                      </Button>
-                                    </div>
-                                  )}
-                                </td>
+                                <th className="pb-2 font-medium text-right">Actions</th>
                               )}
                             </tr>
-                          )
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                </CardContent>
-              </Card>
-            )
-          })}
-
-          {filtered.length === 0 && (
-            <p className="py-12 text-center text-muted-foreground">No active incentives found.</p>
+                          </thead>
+                          <tbody className="divide-y">
+                            {group.map((inc) => {
+                              const isOwner = inc.rewarder === address
+                              return (
+                                <tr key={inc.id} className="hover:bg-muted/30 transition-colors">
+                                  <td className="py-2 pr-4 font-mono">#{inc.id}</td>
+                                  <td className="py-2 pr-4 font-mono text-xs text-muted-foreground">
+                                    <AddressDisplay address={inc.rewarder} showExplorer />
+                                  </td>
+                                  <td className="py-2 pr-4">{inc.reward_points}</td>
+                                  <td className="py-2 pr-4">
+                                    <Badge variant="secondary">
+                                      {inc.remaining_budget.toLocaleString()}
+                                    </Badge>
+                                  </td>
+                                  {isManufacturer && (
+                                    <td className="py-2 text-right">
+                                      {isOwner && (
+                                        <div className="flex justify-end gap-1">
+                                          <Button
+                                            size="sm"
+                                            variant="ghost"
+                                            title="Edit"
+                                            onClick={() => openEdit(inc)}
+                                          >
+                                            <Pencil className="h-4 w-4" />
+                                          </Button>
+                                          <Button
+                                            size="sm"
+                                            variant="ghost"
+                                            title="Deactivate"
+                                            className="text-destructive hover:text-destructive"
+                                            onClick={() => deactivateIncentive(inc.id)}
+                                          >
+                                            <Trash2 className="h-4 w-4" />
+                                          </Button>
+                                        </div>
+                                      )}
+                                    </td>
+                                  )}
+                                </tr>
+                              )
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </>
           )}
         </div>
       )}
@@ -222,10 +259,14 @@ export function IncentivesPage() {
                   value={form.wasteType}
                   onValueChange={(v) => setForm((f) => ({ ...f, wasteType: v }))}
                 >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
                   <SelectContent>
                     {ALL_WASTE_TYPES.map((wt) => (
-                      <SelectItem key={wt} value={String(wt)}>{WASTE_LABELS[wt]}</SelectItem>
+                      <SelectItem key={wt} value={String(wt)}>
+                        {WASTE_LABELS[wt]}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -242,7 +283,9 @@ export function IncentivesPage() {
               />
             </div>
             <div className="space-y-1.5">
-              <label className="text-sm font-medium">{editTarget ? 'Budget to add' : 'Total Budget'} (tokens)</label>
+              <label className="text-sm font-medium">
+                {editTarget ? 'Budget to add' : 'Total Budget'} (tokens)
+              </label>
               <Input
                 type="number"
                 min="1"
@@ -253,7 +296,9 @@ export function IncentivesPage() {
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
             <Button
               onClick={handleSubmit}
               disabled={submitting || !form.rewardPoints || !form.budget}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Recycle, Truck, Factory, Github, Twitter } from 'lucide-react'
+import { Recycle, Truck, Factory } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useSupplyChainStats } from '@/hooks/useSupplyChainStats'
 import { useAppTitle } from '@/hooks/useAppTitle'
@@ -23,8 +23,8 @@ const STEPS = [
 ]
 
 const FOOTER_LINKS = [
-  { label: 'GitHub', href: 'https://github.com', icon: Github },
-  { label: 'Twitter', href: 'https://twitter.com', icon: Twitter },
+  { label: 'GitHub', href: 'https://github.com' },
+  { label: 'Twitter', href: 'https://twitter.com' },
 ]
 
 export function LandingPage() {
@@ -118,7 +118,7 @@ export function LandingPage() {
             Scavngr
           </div>
           <div className="flex gap-4">
-            {FOOTER_LINKS.map(({ label, href, icon: Icon }) => (
+            {FOOTER_LINKS.map(({ label, href }) => (
               <a
                 key={label}
                 href={href}
@@ -126,7 +126,6 @@ export function LandingPage() {
                 rel="noreferrer"
                 className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
-                <Icon className="h-4 w-4" />
                 {label}
               </a>
             ))}

--- a/frontend/src/pages/ManufacturerDashboardPage.tsx
+++ b/frontend/src/pages/ManufacturerDashboardPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
+import { EmptyState } from '@/components/ui/EmptyState'
 import {
   Dialog,
   DialogContent,
@@ -82,7 +83,11 @@ export function ManufacturerDashboardPage() {
             </CardHeader>
             <CardContent>
               {pendingWastes.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No pending waste.</p>
+                <EmptyState
+                  icon={PackageCheck}
+                  title="No pending waste"
+                  description="Waste waiting for confirmation will appear here"
+                />
               ) : (
                 <ul className="space-y-3">
                   {pendingWastes.map((w) => (
@@ -111,7 +116,12 @@ export function ManufacturerDashboardPage() {
             </CardHeader>
             <CardContent>
               {incentives.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No active incentives.</p>
+                <EmptyState
+                  icon={Zap}
+                  title="No active incentives"
+                  description="Incentives will appear here once created"
+                  action={{ label: "Create Incentive", onClick: () => setDialogOpen(true) }}
+                />
               ) : (
                 <ul className="space-y-3">
                   {incentives.map((inc) => (
@@ -140,7 +150,11 @@ export function ManufacturerDashboardPage() {
             </CardHeader>
             <CardContent>
               {rewardHistory.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No rewards distributed yet.</p>
+                <EmptyState
+                  icon={History}
+                  title="No rewards distributed"
+                  description="Rewards will appear here as they are distributed"
+                />
               ) : (
                 <ul className="space-y-3">
                   {rewardHistory.map((r, i) => (

--- a/frontend/src/pages/RecyclerDashboard.tsx
+++ b/frontend/src/pages/RecyclerDashboard.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Plus, Coins, Recycle, Weight } from 'lucide-react'
+import { Plus, Coins, Recycle, Weight, Zap } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { StatCardSkeleton } from '@/components/ui/Skeletons'
-import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import { RegisterWasteModal } from '@/components/modals/RegisterWasteModal'
 import { useAuth } from '@/context/AuthContext'
 import { useAppTitle } from '@/hooks/useAppTitle'
@@ -143,7 +143,12 @@ export function RecyclerDashboard() {
               ))}
             </div>
           ) : wastes.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No wastes submitted yet.</p>
+            <EmptyState
+              icon={Recycle}
+              title="No wastes submitted"
+              description="Start by submitting your first waste"
+              action={{ label: "Register Waste", onClick: () => setModalOpen(true) }}
+            />
           ) : (
             <div className="divide-y">
               {wastes.map((m) => (
@@ -181,7 +186,11 @@ export function RecyclerDashboard() {
               ))}
             </div>
           ) : incentives.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No active incentives.</p>
+            <EmptyState
+              icon={Zap}
+              title="No active incentives"
+              description="Incentives will appear once manufacturers create them"
+            />
           ) : (
             <div className="divide-y">
               {incentives.map((inc) => (

--- a/frontend/src/pages/WasteListPage.tsx
+++ b/frontend/src/pages/WasteListPage.tsx
@@ -1,25 +1,26 @@
 import { useState } from 'react'
-import { Search, Eye, ArrowRightLeft, CheckCircle, Loader2 } from 'lucide-react'
+import { Search, Eye, ArrowRightLeft, CheckCircle, Loader2, Recycle } from 'lucide-react'
 import { useWasteList } from '@/hooks/useWasteList'
 import { Material, WasteType } from '@/api/types'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { Badge } from '@/components/ui/Badge'
 import { WasteCardSkeleton } from '@/components/ui/Skeletons'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { AddressDisplay } from '@/components/ui/AddressDisplay'
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from '@/components/ui/Select'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
+  DialogFooter
 } from '@/components/ui/Dialog'
 
 const PAGE_SIZE = 10
@@ -29,7 +30,7 @@ const WASTE_LABELS: Record<WasteType, string> = {
   [WasteType.PetPlastic]: 'PET Plastic',
   [WasteType.Plastic]: 'Plastic',
   [WasteType.Metal]: 'Metal',
-  [WasteType.Glass]: 'Glass',
+  [WasteType.Glass]: 'Glass'
 }
 
 type StatusFilter = 'all' | 'active' | 'confirmed' | 'inactive'
@@ -42,11 +43,14 @@ function getStatus(w: Material): StatusFilter {
 
 function statusBadge(w: Material) {
   const s = getStatus(w)
-  const map: Record<StatusFilter, { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' }> = {
+  const map: Record<
+    StatusFilter,
+    { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' }
+  > = {
     active: { label: 'Active', variant: 'default' },
     confirmed: { label: 'Confirmed', variant: 'secondary' },
     inactive: { label: 'Inactive', variant: 'outline' },
-    all: { label: '', variant: 'outline' },
+    all: { label: '', variant: 'outline' }
   }
   return <Badge variant={map[s].variant}>{map[s].label}</Badge>
 }
@@ -105,7 +109,10 @@ export function WasteListPage() {
             className="pl-9"
             placeholder="Search ID…"
             value={search}
-            onChange={(e) => { setSearch(e.target.value); setPage(1) }}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
           />
         </div>
 
@@ -116,7 +123,9 @@ export function WasteListPage() {
           <SelectContent>
             <SelectItem value="all">All types</SelectItem>
             {Object.entries(WASTE_LABELS).map(([val, label]) => (
-              <SelectItem key={val} value={val}>{label}</SelectItem>
+              <SelectItem key={val} value={val}>
+                {label}
+              </SelectItem>
             ))}
           </SelectContent>
         </Select>
@@ -154,10 +163,26 @@ export function WasteListPage() {
               </tr>
             </thead>
             <tbody className="divide-y">
-              {Array.from({ length: 5 }).map((_, i) => <WasteCardSkeleton key={i} />)}
+              {Array.from({ length: 5 }).map((_, i) => (
+                <WasteCardSkeleton key={i} />
+              ))}
             </tbody>
           </table>
         </div>
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={Recycle}
+          title={
+            search || typeFilter !== 'all' || statusFilter !== 'all'
+              ? 'No wastes match your filters'
+              : 'No wastes yet'
+          }
+          description={
+            search || typeFilter !== 'all' || statusFilter !== 'all'
+              ? 'Try adjusting your search or filters'
+              : 'Start by registering your first waste'
+          }
+        />
       ) : (
         <>
           {/* Table */}
@@ -174,64 +199,61 @@ export function WasteListPage() {
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {paginated.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
-                      No wastes found.
+                {paginated.map((w) => (
+                  <tr key={w.id} className="hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 font-mono">#{w.id}</td>
+                    <td className="px-4 py-3">{WASTE_LABELS[w.waste_type]}</td>
+                    <td className="px-4 py-3">{w.weight}</td>
+                    <td className="px-4 py-3">{statusBadge(w)}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {new Date(w.submitted_at * 1000).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="View details"
+                          onClick={() => setDetailWaste(w)}
+                        >
+                          <Eye className="h-4 w-4" />
+                        </Button>
+                        {w.is_active && !w.is_confirmed && (
+                          <>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              title="Confirm"
+                              onClick={() => confirmWaste(w.id)}
+                            >
+                              <CheckCircle className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              title="Transfer"
+                              onClick={() => {
+                                setTransferTarget(w)
+                                setToAddress('')
+                              }}
+                            >
+                              <ArrowRightLeft className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                      </div>
                     </td>
                   </tr>
-                ) : (
-                  paginated.map((w) => (
-                    <tr key={w.id} className="hover:bg-muted/30 transition-colors">
-                      <td className="px-4 py-3 font-mono">#{w.id}</td>
-                      <td className="px-4 py-3">{WASTE_LABELS[w.waste_type]}</td>
-                      <td className="px-4 py-3">{w.weight}</td>
-                      <td className="px-4 py-3">{statusBadge(w)}</td>
-                      <td className="px-4 py-3 text-muted-foreground">
-                        {new Date(w.submitted_at * 1000).toLocaleDateString()}
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex justify-end gap-1">
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            title="View details"
-                            onClick={() => setDetailWaste(w)}
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                          {w.is_active && !w.is_confirmed && (
-                            <>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                title="Confirm"
-                                onClick={() => confirmWaste(w.id)}
-                              >
-                                <CheckCircle className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                title="Transfer"
-                                onClick={() => { setTransferTarget(w); setToAddress('') }}
-                              >
-                                <ArrowRightLeft className="h-4 w-4" />
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
+                ))}
               </tbody>
             </table>
           </div>
 
           {/* Pagination */}
           <div className="flex items-center justify-between text-sm text-muted-foreground">
-            <span>{filtered.length} waste{filtered.length !== 1 ? 's' : ''}</span>
+            <span>
+              {filtered.length} waste{filtered.length !== 1 ? 's' : ''}
+            </span>
             <div className="flex items-center gap-2">
               <Button
                 size="sm"
@@ -241,7 +263,9 @@ export function WasteListPage() {
               >
                 Previous
               </Button>
-              <span>Page {page} of {totalPages}</span>
+              <span>
+                Page {page} of {totalPages}
+              </span>
               <Button
                 size="sm"
                 variant="outline"
@@ -272,13 +296,19 @@ export function WasteListPage() {
               <dt className="text-muted-foreground">Verified</dt>
               <dd>{detailWaste.verified ? 'Yes' : 'No'}</dd>
               <dt className="text-muted-foreground">Submitter</dt>
-              <dd><AddressDisplay address={detailWaste.submitter} showExplorer /></dd>
+              <dd>
+                <AddressDisplay address={detailWaste.submitter} showExplorer />
+              </dd>
               <dt className="text-muted-foreground">Current Owner</dt>
-              <dd><AddressDisplay address={detailWaste.current_owner} showExplorer /></dd>
+              <dd>
+                <AddressDisplay address={detailWaste.current_owner} showExplorer />
+              </dd>
               {detailWaste.is_confirmed && (
                 <>
                   <dt className="text-muted-foreground">Confirmer</dt>
-                  <dd><AddressDisplay address={detailWaste.confirmer} showExplorer /></dd>
+                  <dd>
+                    <AddressDisplay address={detailWaste.confirmer} showExplorer />
+                  </dd>
                 </>
               )}
               <dt className="text-muted-foreground">Submitted</dt>
@@ -303,7 +333,9 @@ export function WasteListPage() {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setTransferTarget(null)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setTransferTarget(null)}>
+              Cancel
+            </Button>
             <Button onClick={handleTransfer} disabled={transferring || !toAddress.trim()}>
               {transferring ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Transfer

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -24,23 +24,16 @@ function ProtectedLayout() {
 }
 
 export const router = createBrowserRouter([
-  { path: '/', element: <Navigate to="/login" replace /> },
+  { path: '/', element: <LandingPage /> },
   { path: '/login', element: <LoginPage /> },
-  {
-    // Public landing page
-    path: '/',
-    element: <LandingPage />,
-  },
   {
     // Protected routes share AppShell and require authentication
     element: <ProtectedLayout />,
     children: [
       { path: 'dashboard', element: <HomePage /> },
       { path: 'submit', element: <div>Submit Waste</div> },
-      { path: 'collect', element: <div>Collect</div> },
-      { path: 'incentives', element: <IncentivesPage /> },
       { path: 'collect', element: <CollectorDashboardPage /> },
-      { path: 'incentives', element: <div>Incentives</div> },
+      { path: 'incentives', element: <IncentivesPage /> },
       { path: 'transfer', element: <div>Transfer</div> },
       { path: 'history', element: <div>History</div> },
       { path: 'dashboard/recycler', element: <RecyclerDashboard /> },


### PR DESCRIPTION
closes #275
create a reusable EmptyState UI component with icon, message, and optional CTA
apply empty states to waste list, incentives list, transfer history, and reward/token history sections
add contextual copy for each empty list state
add action-focused CTAs where applicable (for example, creating an incentive or registering waste)
improve dashboard/list UX consistency when datasets are empty