### PR TITLE
feat(frontend): upgrade RegisterWasteModal with icons, grams, GPS, succcess state (#264)Upgrades the existing RegisterWasteModal to meet all ticket requirement

### DIFF
--- a/frontend/src/components/modals/RegisterWasteModal.tsx
+++ b/frontend/src/components/modals/RegisterWasteModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
@@ -17,14 +18,20 @@ import {
 } from '@/components/ui/Select'
 import { WasteType } from '@/api/types'
 import { useRecycleWaste } from '@/hooks/useRecycleWaste'
+import { Newspaper, Recycle, Package, Wrench, GlassWater, LocateFixed, CheckCircle2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-const WASTE_TYPES = [
-  { value: WasteType.Paper, label: 'Paper' },
-  { value: WasteType.PetPlastic, label: 'PET Plastic' },
-  { value: WasteType.Plastic, label: 'Plastic' },
-  { value: WasteType.Metal, label: 'Metal' },
-  { value: WasteType.Glass, label: 'Glass' },
+// ── Waste type config with icons ─────────────────────────────────────────────
+
+const WASTE_TYPES: { value: WasteType; label: string; icon: React.ReactNode; color: string }[] = [
+  { value: WasteType.Paper,      label: 'Paper',       icon: <Newspaper  className="h-4 w-4" />, color: 'text-yellow-600' },
+  { value: WasteType.PetPlastic, label: 'PET Plastic', icon: <Recycle    className="h-4 w-4" />, color: 'text-blue-600'   },
+  { value: WasteType.Plastic,    label: 'Plastic',     icon: <Package    className="h-4 w-4" />, color: 'text-purple-600' },
+  { value: WasteType.Metal,      label: 'Metal',       icon: <Wrench     className="h-4 w-4" />, color: 'text-slate-600'  },
+  { value: WasteType.Glass,      label: 'Glass',       icon: <GlassWater className="h-4 w-4" />, color: 'text-cyan-600'   },
 ]
+
+// ── Props ─────────────────────────────────────────────────────────────────────
 
 interface Props {
   open: boolean
@@ -33,21 +40,53 @@ interface Props {
   onSuccess?: (wasteId: bigint) => void
 }
 
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export function RegisterWasteModal({ open, address, onClose, onSuccess }: Props) {
-  const [wasteType, setWasteType] = useState<WasteType>(WasteType.Paper)
-  const [weight, setWeight] = useState('')
-  const [latitude, setLatitude] = useState('')
-  const [longitude, setLongitude] = useState('')
+  const [wasteType, setWasteType]   = useState<WasteType>(WasteType.Paper)
+  const [weight, setWeight]         = useState('')
+  const [latitude, setLatitude]     = useState('')
+  const [longitude, setLongitude]   = useState('')
+  const [locating, setLocating]     = useState(false)
+  const [locError, setLocError]     = useState<string | null>(null)
+  const [successId, setSuccessId]   = useState<bigint | null>(null)
 
   const { mutate: recycleWaste, isPending } = useRecycleWaste()
 
-  function handleClose() {
-    if (isPending) return
+  function reset() {
     setWeight('')
     setLatitude('')
     setLongitude('')
     setWasteType(WasteType.Paper)
+    setLocError(null)
+    setSuccessId(null)
+  }
+
+  function handleClose() {
+    if (isPending) return
+    reset()
     onClose()
+  }
+
+  function useCurrentLocation() {
+    if (!navigator.geolocation) {
+      setLocError('Geolocation is not supported by your browser.')
+      return
+    }
+    setLocating(true)
+    setLocError(null)
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setLatitude(pos.coords.latitude.toFixed(6))
+        setLongitude(pos.coords.longitude.toFixed(6))
+        setLocating(false)
+      },
+      () => {
+        setLocError('Could not get location. Enter coordinates manually.')
+        setLocating(false)
+      },
+      { timeout: 8000 }
+    )
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -55,8 +94,8 @@ export function RegisterWasteModal({ open, address, onClose, onSuccess }: Props)
     const w = parseFloat(weight)
     if (!w || w <= 0) return
 
-    // Convert kg → grams for the contract
-    const weightGrams = BigInt(Math.round(w * 1000))
+    // Weight input is in grams — pass directly to contract
+    const weightGrams = BigInt(Math.round(w))
     // Convert decimal degrees → microdegrees (contract expects i128 microdegrees)
     const lat = BigInt(Math.round(parseFloat(latitude || '0') * 1_000_000))
     const lng = BigInt(Math.round(parseFloat(longitude || '0') * 1_000_000))
@@ -65,77 +104,148 @@ export function RegisterWasteModal({ open, address, onClose, onSuccess }: Props)
       { recycler: address, wasteType, weightGrams, latitude: lat, longitude: lng },
       {
         onSuccess: (wasteId) => {
+          setSuccessId(wasteId)
           onSuccess?.(wasteId)
-          handleClose()
         },
       }
     )
   }
+
+  // ── Success state ───────────────────────────────────────────────────────
+  if (successId !== null) {
+    return (
+      <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+        <DialogContent className="sm:max-w-md">
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <CheckCircle2 className="h-12 w-12 text-green-500" />
+            <div>
+              <p className="text-lg font-semibold">Waste registered</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your waste item has been recorded on-chain.
+              </p>
+            </div>
+            <div className="rounded-md border bg-muted/40 px-6 py-3">
+              <p className="text-xs text-muted-foreground">Waste ID</p>
+              <p className="font-mono text-xl font-bold">#{successId.toString()}</p>
+            </div>
+            <Button className="w-full" onClick={handleClose}>Done</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  const selectedType = WASTE_TYPES.find((t) => t.value === wasteType)
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Register Waste</DialogTitle>
+          <DialogDescription>
+            Record a new waste item on the supply chain.
+          </DialogDescription>
         </DialogHeader>
+
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Waste type with icons */}
           <div className="space-y-1">
-            <label className="text-sm font-medium">Waste type</label>
+            <label htmlFor="waste-type-trigger" className="text-sm font-medium">
+              Waste type
+            </label>
             <Select
               value={String(wasteType)}
               onValueChange={(v) => setWasteType(Number(v) as WasteType)}
             >
-              <SelectTrigger className="w-full">
-                <SelectValue />
+              <SelectTrigger id="waste-type-trigger" className="w-full">
+                <SelectValue>
+                  {selectedType && (
+                    <span className="flex items-center gap-2">
+                      <span className={selectedType.color}>{selectedType.icon}</span>
+                      {selectedType.label}
+                    </span>
+                  )}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {WASTE_TYPES.map((t) => (
                   <SelectItem key={t.value} value={String(t.value)}>
-                    {t.label}
+                    <span className="flex items-center gap-2">
+                      <span className={t.color}>{t.icon}</span>
+                      {t.label}
+                    </span>
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
 
+          {/* Weight in grams */}
           <div className="space-y-1">
-            <label className="text-sm font-medium">Weight (kg)</label>
+            <label htmlFor="weight-input" className="text-sm font-medium">
+              Weight (grams)
+            </label>
             <Input
+              id="weight-input"
               type="number"
-              min="0.001"
-              step="0.001"
-              placeholder="e.g. 2.5"
+              min="1"
+              step="1"
+              placeholder="e.g. 500"
               value={weight}
               onChange={(e) => setWeight(e.target.value)}
               required
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Latitude</label>
-              <Input
-                type="number"
-                min="-90"
-                max="90"
-                step="0.000001"
-                placeholder="e.g. 40.714"
-                value={latitude}
-                onChange={(e) => setLatitude(e.target.value)}
-              />
+          {/* Location */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Location</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={useCurrentLocation}
+                disabled={locating || isPending}
+              >
+                <LocateFixed className={cn('h-3.5 w-3.5', locating && 'animate-pulse')} />
+                {locating ? 'Locating…' : 'Use current location'}
+              </Button>
             </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Longitude</label>
-              <Input
-                type="number"
-                min="-180"
-                max="180"
-                step="0.000001"
-                placeholder="e.g. -74.006"
-                value={longitude}
-                onChange={(e) => setLongitude(e.target.value)}
-              />
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label htmlFor="lat-input" className="text-xs text-muted-foreground">Latitude</label>
+                <Input
+                  id="lat-input"
+                  type="number"
+                  min="-90"
+                  max="90"
+                  step="0.000001"
+                  placeholder="e.g. 40.714"
+                  value={latitude}
+                  onChange={(e) => setLatitude(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label htmlFor="lng-input" className="text-xs text-muted-foreground">Longitude</label>
+                <Input
+                  id="lng-input"
+                  type="number"
+                  min="-180"
+                  max="180"
+                  step="0.000001"
+                  placeholder="e.g. -74.006"
+                  value={longitude}
+                  onChange={(e) => setLongitude(e.target.value)}
+                />
+              </div>
             </div>
+
+            {locError && (
+              <p className="text-xs text-destructive">{locError}</p>
+            )}
           </div>
 
           <DialogFooter>
@@ -143,7 +253,7 @@ export function RegisterWasteModal({ open, address, onClose, onSuccess }: Props)
               Cancel
             </Button>
             <Button type="submit" disabled={isPending || !weight}>
-              {isPending ? 'Submitting…' : 'Submit'}
+              {isPending ? 'Submitting…' : 'Register'}
             </Button>
           </DialogFooter>
         </form>


### PR DESCRIPTION
Upgrades the existing RegisterWasteModal to meet all ticket requirements.

What changed:

Waste type selector now shows icons (Newspaper, Recycle, Package, Wrench, GlassWater) with per-type colors in both the trigger and dropdown items
Weight input switched from kg to grams — value is passed directly to the contract as weightGrams with no conversion
Location section now has a "Use current location" button that calls navigator.geolocation.getCurrentPosition and populates lat/lng fields; shows an error message if geolocation is unavailable or denied
On success, the form transitions to a success screen showing the new waste ID (#<id>) prominently, with a "Done" button to close — instead of immediately closing and relying solely on the toast
Closes #264