### PR TITLE
feat(#362): implement split_waste functionality

### DIFF
--- a/stellar-contract/src/errors.rs
+++ b/stellar-contract/src/errors.rs
@@ -171,4 +171,13 @@ pub enum Error {
 
     /// (31) Insufficient budget for the reward.
     InsufficientBudget = 31,
+
+    /// (32) The number of splits exceeds the maximum allowed (10).
+    TooManySplits = 32,
+
+    /// (33) The sum of split weights does not equal the original waste weight.
+    WeightMismatch = 33,
+
+    /// (34) At least two split weights are required.
+    TooFewSplits = 34,
 }

--- a/stellar-contract/src/events.rs
+++ b/stellar-contract/src/events.rs
@@ -115,3 +115,16 @@ pub fn emit_contract_paused(env: &Env, admin: &Address) {
 pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
     env.events().publish((symbol_short!("unpaused"),), admin);
 }
+
+/// Emit event when a waste item is split into multiple child items
+pub fn emit_waste_split(
+    env: &Env,
+    parent_id: u128,
+    owner: &Address,
+    child_ids: &soroban_sdk::Vec<u128>,
+) {
+    env.events().publish(
+        (symbol_short!("waste_spl"), parent_id),
+        (owner, child_ids),
+    );
+}

--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -2843,4 +2843,146 @@ impl ScavengerContract {
 
         total_reward
     }
+
+    /// Split a v2 waste item into multiple smaller items.
+    ///
+    /// The owner provides a list of weights that must sum to the original weight.
+    /// The original waste is deactivated and new child waste items are created,
+    /// inheriting the type, location, and owner. Transfer history is preserved
+    /// by copying the parent's history to each child. A `WasteSplit` event is emitted.
+    ///
+    /// # Parameters
+    /// - `waste_id`: ID of the v2 waste to split.
+    /// - `owner`: Current owner. Must sign and own the waste.
+    /// - `weights`: Vec of weights (in grams) for each child. Must sum to original weight.
+    ///
+    /// # Returns
+    /// `Vec<u128>` of the newly created child waste IDs.
+    ///
+    /// # Errors
+    /// - [`Error::WasteNotFound`] if no waste record exists for `waste_id`.
+    /// - [`Error::NotWasteOwner`] if `owner` does not own the waste.
+    /// - [`Error::WasteDeactivated`] if the waste is already deactivated.
+    /// - [`Error::TooFewSplits`] if fewer than 2 weights are provided.
+    /// - [`Error::TooManySplits`] if more than 10 weights are provided.
+    /// - [`Error::WeightMismatch`] if the weights do not sum to the original weight.
+    pub fn split_waste(
+        env: Env,
+        waste_id: u128,
+        owner: Address,
+        weights: Vec<u128>,
+    ) -> Result<Vec<u128>, Error> {
+        owner.require_auth();
+        Self::require_not_paused(&env);
+
+        // Load and validate the parent waste
+        let mut parent: types::Waste = match env
+            .storage()
+            .instance()
+            .get(&("waste_v2", waste_id))
+        {
+            Some(w) => w,
+            None => return Err(Error::WasteNotFound),
+        };
+
+        if parent.current_owner != owner {
+            return Err(Error::NotWasteOwner);
+        }
+
+        if !parent.is_active {
+            return Err(Error::WasteDeactivated);
+        }
+
+        let n = weights.len();
+        if n < 2 {
+            return Err(Error::TooFewSplits);
+        }
+        if n > 10 {
+            return Err(Error::TooManySplits);
+        }
+
+        // Validate weights sum equals parent weight
+        let mut total: u128 = 0;
+        for w in weights.iter() {
+            total = total.checked_add(w).ok_or(Error::Overflow)?;
+        }
+        if total != parent.weight {
+            return Err(Error::WeightMismatch);
+        }
+
+        // Load parent transfer history once
+        let parent_history: Vec<WasteTransfer> = env
+            .storage()
+            .instance()
+            .get(&("transfer_history", waste_id))
+            .unwrap_or(Vec::new(&env));
+
+        let timestamp = env.ledger().timestamp();
+        let mut child_ids: Vec<u128> = Vec::new(&env);
+
+        for w in weights.iter() {
+            let child_id = Self::next_waste_id(&env) as u128;
+
+            let child = types::Waste::new(
+                child_id,
+                parent.waste_type,
+                w,
+                owner.clone(),
+                parent.latitude,
+                parent.longitude,
+                timestamp,
+                true,
+                false,
+                owner.clone(),
+            );
+
+            env.storage()
+                .instance()
+                .set(&("waste_v2", child_id), &child);
+
+            // Copy parent transfer history to child
+            env.storage()
+                .instance()
+                .set(&("transfer_history", child_id), &parent_history);
+
+            // Add child to owner's waste list
+            let mut owner_list: Vec<u128> = env
+                .storage()
+                .instance()
+                .get(&("participant_wastes", owner.clone()))
+                .unwrap_or(Vec::new(&env));
+            owner_list.push_back(child_id);
+            env.storage()
+                .instance()
+                .set(&("participant_wastes", owner.clone()), &owner_list);
+
+            child_ids.push_back(child_id);
+        }
+
+        // Deactivate parent
+        parent.deactivate();
+        env.storage()
+            .instance()
+            .set(&("waste_v2", waste_id), &parent);
+
+        // Remove parent from owner's waste list
+        let owner_list: Vec<u128> = env
+            .storage()
+            .instance()
+            .get(&("participant_wastes", owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut new_owner_list = Vec::new(&env);
+        for id in owner_list.iter() {
+            if id != waste_id {
+                new_owner_list.push_back(id);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&("participant_wastes", owner.clone()), &new_owner_list);
+
+        events::emit_waste_split(&env, waste_id, &owner, &child_ids);
+
+        Ok(child_ids)
+    }
 }

--- a/stellar-contract/tests/split_waste_test.rs
+++ b/stellar-contract/tests/split_waste_test.rs
@@ -1,0 +1,297 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
+use stellar_scavngr_contract::{Error, ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType};
+
+fn setup(env: &Env) -> (ScavengerContractClient, Address, Address) {
+    let contract_id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+
+    let owner = Address::generate(env);
+    client.register_participant(
+        &owner,
+        &ParticipantRole::Recycler,
+        &soroban_sdk::symbol_short!("owner"),
+        &0,
+        &0,
+    );
+
+    (client, admin, owner)
+}
+
+fn register_waste(client: &ScavengerContractClient, owner: &Address, weight: u128) -> u128 {
+    client.recycle_waste(&WasteType::Plastic, &weight, owner, &0, &0)
+}
+
+// ── Happy-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_split_into_two_equal_parts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 500u128, 500u128];
+
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    assert_eq!(child_ids.len(), 2);
+
+    // Parent must be deactivated
+    let parent = client.get_waste_v2(&waste_id).unwrap();
+    assert!(!parent.is_active);
+
+    // Children must be active with correct weights
+    let c1 = client.get_waste_v2(&child_ids.get(0).unwrap()).unwrap();
+    let c2 = client.get_waste_v2(&child_ids.get(1).unwrap()).unwrap();
+    assert!(c1.is_active);
+    assert!(c2.is_active);
+    assert_eq!(c1.weight, 500);
+    assert_eq!(c2.weight, 500);
+}
+
+#[test]
+fn test_split_into_unequal_parts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 300u128, 700u128];
+
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    assert_eq!(child_ids.len(), 2);
+    let c1 = client.get_waste_v2(&child_ids.get(0).unwrap()).unwrap();
+    let c2 = client.get_waste_v2(&child_ids.get(1).unwrap()).unwrap();
+    assert_eq!(c1.weight, 300);
+    assert_eq!(c2.weight, 700);
+}
+
+#[test]
+fn test_children_inherit_waste_type_and_location() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Metal, &2000u128, &owner, &10_000_000i128, &20_000_000i128);
+
+    let weights = vec![&env, 1000u128, 1000u128];
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    for i in 0..child_ids.len() {
+        let child = client.get_waste_v2(&child_ids.get(i).unwrap()).unwrap();
+        assert_eq!(child.waste_type, WasteType::Metal);
+        assert_eq!(child.latitude, 10_000_000);
+        assert_eq!(child.longitude, 20_000_000);
+        assert_eq!(child.current_owner, owner);
+    }
+}
+
+#[test]
+fn test_children_appear_in_owner_waste_list() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 900);
+    let weights = vec![&env, 300u128, 300u128, 300u128];
+
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    let owner_wastes = client.get_participant_wastes_v2(&owner);
+
+    // Parent should be gone, all 3 children should be present
+    assert!(!owner_wastes.contains(&waste_id));
+    for i in 0..child_ids.len() {
+        assert!(owner_wastes.contains(&child_ids.get(i).unwrap()));
+    }
+}
+
+#[test]
+fn test_parent_removed_from_owner_waste_list() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 500);
+    let weights = vec![&env, 250u128, 250u128];
+
+    client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    let owner_wastes = client.get_participant_wastes_v2(&owner);
+    assert!(!owner_wastes.contains(&waste_id));
+}
+
+#[test]
+fn test_transfer_history_copied_to_children() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    // Register a second participant and transfer to them first to build history
+    let collector = Address::generate(&env);
+    client.register_participant(
+        &collector,
+        &ParticipantRole::Collector,
+        &soroban_sdk::symbol_short!("col"),
+        &0,
+        &0,
+    );
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    // Transfer: Recycler -> Collector
+    client.transfer_waste_v2(&waste_id, &owner, &collector, &0, &0).unwrap();
+
+    // Now split as collector
+    let weights = vec![&env, 600u128, 400u128];
+    let child_ids = client.split_waste(&waste_id, &collector, &weights).unwrap();
+
+    // Each child should have the same transfer history as the parent
+    let parent_history = client.get_waste_transfer_history_v2(&waste_id);
+    for i in 0..child_ids.len() {
+        let child_history = client.get_waste_transfer_history_v2(&child_ids.get(i).unwrap());
+        assert_eq!(child_history.len(), parent_history.len());
+    }
+}
+
+#[test]
+fn test_split_max_10_parts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128];
+
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+    assert_eq!(child_ids.len(), 10);
+}
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_split_waste_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let weights = vec![&env, 500u128, 500u128];
+    let result = client.try_split_waste(&9999u128, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::WasteNotFound)));
+}
+
+#[test]
+fn test_split_not_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+
+    let other = Address::generate(&env);
+    client.register_participant(
+        &other,
+        &ParticipantRole::Recycler,
+        &soroban_sdk::symbol_short!("other"),
+        &0,
+        &0,
+    );
+
+    let weights = vec![&env, 500u128, 500u128];
+    let result = client.try_split_waste(&waste_id, &other, &weights);
+    assert_eq!(result, Err(Ok(Error::NotWasteOwner)));
+}
+
+#[test]
+fn test_split_deactivated_waste() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    client.deactivate_waste(&waste_id, &admin);
+
+    let weights = vec![&env, 500u128, 500u128];
+    let result = client.try_split_waste(&waste_id, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::WasteDeactivated)));
+}
+
+#[test]
+fn test_split_too_few_weights() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 1000u128]; // only 1 weight
+
+    let result = client.try_split_waste(&waste_id, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::TooFewSplits)));
+}
+
+#[test]
+fn test_split_too_many_weights() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1100);
+    // 11 weights
+    let weights = vec![&env, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128, 100u128];
+
+    let result = client.try_split_waste(&waste_id, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::TooManySplits)));
+}
+
+#[test]
+fn test_split_weight_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 400u128, 400u128]; // sums to 800, not 1000
+
+    let result = client.try_split_waste(&waste_id, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::WeightMismatch)));
+}
+
+#[test]
+fn test_split_weight_exceeds_original() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 600u128, 600u128]; // sums to 1200, not 1000
+
+    let result = client.try_split_waste(&waste_id, &owner, &weights);
+    assert_eq!(result, Err(Ok(Error::WeightMismatch)));
+}
+
+#[test]
+fn test_split_children_are_independent() {
+    // Verify that deactivating one child does not affect the other
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let waste_id = register_waste(&client, &owner, 1000);
+    let weights = vec![&env, 500u128, 500u128];
+    let child_ids = client.split_waste(&waste_id, &owner, &weights).unwrap();
+
+    let c1_id = child_ids.get(0).unwrap();
+    let c2_id = child_ids.get(1).unwrap();
+
+    client.deactivate_waste(&c1_id, &admin);
+
+    let c1 = client.get_waste_v2(&c1_id).unwrap();
+    let c2 = client.get_waste_v2(&c2_id).unwrap();
+    assert!(!c1.is_active);
+    assert!(c2.is_active);
+}


### PR DESCRIPTION
Closes #362 — Allow waste owners to split a single waste item into multiple smaller items (2–10 splits per operation).

## Changes

### stellar-contract/src/errors.rs
- Add TooFewSplits (34): fewer than 2 weights provided
- Add TooManySplits (32): more than 10 weights provided
- Add WeightMismatch (33): split weights do not sum to original weight

### stellar-contract/src/events.rs
- Add emit_waste_split(env, parent_id, owner, child_ids) using symbol_short!("waste_spl") topic

### stellar-contract/src/lib.rs
- Add split_waste(env, waste_id, owner, weights) -> Result<Vec<u128>, Error>
  - Validates ownership, active status, split count (2–10), and weight sum
  - Deactivates the parent waste item
  - Creates N child Waste records inheriting type, location, and owner
  - Copies parent transfer history to each child (parent-child reference)
  - Updates participant_wastes index: removes parent, adds all children
  - Emits WasteSplit event with parent ID, owner, and child IDs

### stellar-contract/tests/split_waste_test.rs
- 15 tests covering all acceptance criteria and edge cases: Happy paths: equal split, unequal split, type/location inheritance, owner waste list updated, parent removed from list, transfer history copied to children, max 10 splits allowed Error paths: waste not found, not owner, deactivated waste, too few splits (1), too many splits (11), weight mismatch (under), weight mismatch (over), child independence after sibling deactivation