### PR TITLE
Feature/364 waste reservation

### DIFF
--- a/stellar-contract/src/errors.rs
+++ b/stellar-contract/src/errors.rs
@@ -192,4 +192,16 @@ pub enum Error {
 
     /// (38) Not all wastes share the same location.
     LocationMismatch = 38,
+
+    /// (39) Waste is already reserved by another participant.
+    WasteAlreadyReserved = 39,
+
+    /// (40) Waste is not reserved (cannot cancel a non-existent reservation).
+    WasteNotReserved = 40,
+
+    /// (41) Caller is not the reserver and not the owner; cannot cancel.
+    NotReserver = 41,
+
+    /// (42) Waste is reserved by someone else; transfer is blocked.
+    WasteReservedByOther = 42,
 }

--- a/stellar-contract/src/events.rs
+++ b/stellar-contract/src/events.rs
@@ -116,6 +116,22 @@ pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
     env.events().publish((symbol_short!("unpaused"),), admin);
 }
 
+/// Emit event when a waste item is reserved
+pub fn emit_waste_reserved(env: &Env, waste_id: u128, reserved_by: &Address, reserved_until: u64) {
+    env.events().publish(
+        (symbol_short!("wst_res"), waste_id),
+        (reserved_by, reserved_until),
+    );
+}
+
+/// Emit event when a reservation is cancelled
+pub fn emit_reservation_cancelled(env: &Env, waste_id: u128, cancelled_by: &Address) {
+    env.events().publish(
+        (symbol_short!("res_cncl"), waste_id),
+        cancelled_by,
+    );
+}
+
 /// Emit event when multiple waste items are merged into one
 pub fn emit_wastes_merged(
     env: &Env,

--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -1751,6 +1751,14 @@ impl ScavengerContract {
             return Err(Error::InvalidTransferRoute);
         }
 
+        // Reservation check: block transfer if waste is reserved by someone other than `to`
+        let now = env.ledger().timestamp();
+        if let (Some(reserver), Some(until)) = (waste.reserved_by.clone(), waste.reserved_until) {
+            if until > now && reserver != to {
+                return Err(Error::WasteReservedByOther);
+            }
+        }
+
         waste.transfer_to(to.clone());
         env.storage()
             .instance()
@@ -3139,5 +3147,110 @@ impl ScavengerContract {
         events::emit_wastes_merged(&env, merged_id, &owner, &waste_ids);
 
         Ok(merged_id)
+    }
+
+    /// Reserve a v2 waste item for a limited time.
+    ///
+    /// Only registered participants may reserve. The waste must be active and
+    /// not already reserved (or the previous reservation must have expired).
+    /// Emits a `WasteReserved` event.
+    ///
+    /// # Parameters
+    /// - `waste_id`: ID of the v2 waste to reserve.
+    /// - `reserver`: Registered participant making the reservation. Must sign.
+    /// - `duration`: Reservation duration in seconds.
+    ///
+    /// # Errors
+    /// - [`Error::WasteNotFound`] if the waste does not exist.
+    /// - [`Error::WasteDeactivated`] if the waste is inactive.
+    /// - [`Error::WasteAlreadyReserved`] if an active reservation exists.
+    pub fn reserve_waste(
+        env: Env,
+        waste_id: u128,
+        reserver: Address,
+        duration: u64,
+    ) -> Result<types::Waste, Error> {
+        reserver.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_registered(&env, &reserver);
+
+        let mut waste: types::Waste = env
+            .storage()
+            .instance()
+            .get(&("waste_v2", waste_id))
+            .ok_or(Error::WasteNotFound)?;
+
+        if !waste.is_active {
+            return Err(Error::WasteDeactivated);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Block if an active (non-expired) reservation exists
+        if let (Some(_), Some(until)) = (waste.reserved_by.clone(), waste.reserved_until) {
+            if until > now {
+                return Err(Error::WasteAlreadyReserved);
+            }
+        }
+
+        let reserved_until = now.checked_add(duration).ok_or(Error::Overflow)?;
+        waste.reserved_by = Some(reserver.clone());
+        waste.reserved_until = Some(reserved_until);
+
+        env.storage()
+            .instance()
+            .set(&("waste_v2", waste_id), &waste);
+
+        events::emit_waste_reserved(&env, waste_id, &reserver, reserved_until);
+
+        Ok(waste)
+    }
+
+    /// Cancel a reservation on a v2 waste item.
+    ///
+    /// The reserver themselves or the waste owner may cancel. Emits a
+    /// `ReservationCancelled` event.
+    ///
+    /// # Parameters
+    /// - `waste_id`: ID of the v2 waste.
+    /// - `caller`: Reserver or current owner. Must sign.
+    ///
+    /// # Errors
+    /// - [`Error::WasteNotFound`] if the waste does not exist.
+    /// - [`Error::WasteNotReserved`] if no reservation exists.
+    /// - [`Error::NotReserver`] if caller is neither the reserver nor the owner.
+    pub fn cancel_reservation(
+        env: Env,
+        waste_id: u128,
+        caller: Address,
+    ) -> Result<types::Waste, Error> {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut waste: types::Waste = env
+            .storage()
+            .instance()
+            .get(&("waste_v2", waste_id))
+            .ok_or(Error::WasteNotFound)?;
+
+        if waste.reserved_by.is_none() {
+            return Err(Error::WasteNotReserved);
+        }
+
+        let reserver = waste.reserved_by.clone().unwrap();
+        if caller != reserver && caller != waste.current_owner {
+            return Err(Error::NotReserver);
+        }
+
+        waste.reserved_by = None;
+        waste.reserved_until = None;
+
+        env.storage()
+            .instance()
+            .set(&("waste_v2", waste_id), &waste);
+
+        events::emit_reservation_cancelled(&env, waste_id, &caller);
+
+        Ok(waste)
     }
 }

--- a/stellar-contract/src/types.rs
+++ b/stellar-contract/src/types.rs
@@ -507,6 +507,10 @@ pub struct Waste {
     pub is_confirmed: bool,
     /// Address of the confirmer/verifier
     pub confirmer: Address,
+    /// Address that has reserved this waste item (None if unreserved)
+    pub reserved_by: Option<Address>,
+    /// Ledger timestamp at which the reservation expires (None if unreserved)
+    pub reserved_until: Option<u64>,
 }
 
 impl Waste {
@@ -534,6 +538,8 @@ impl Waste {
             is_active,
             is_confirmed,
             confirmer,
+            reserved_by: None,
+            reserved_until: None,
         }
     }
 
@@ -710,6 +716,8 @@ impl WasteBuilder {
             is_active: self.is_active,
             is_confirmed: self.is_confirmed,
             confirmer,
+            reserved_by: None,
+            reserved_until: None,
         }
     }
 }

--- a/stellar-contract/tests/waste_reservation_test.rs
+++ b/stellar-contract/tests/waste_reservation_test.rs
@@ -1,0 +1,228 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use stellar_scavngr_contract::{Error, ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType};
+
+fn setup(env: &Env) -> (ScavengerContractClient, Address, Address) {
+    let contract_id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+
+    let recycler = Address::generate(env);
+    client.register_participant(
+        &recycler,
+        &ParticipantRole::Recycler,
+        &soroban_sdk::symbol_short!("recycler"),
+        &0,
+        &0,
+    );
+
+    (client, admin, recycler)
+}
+
+fn register_collector(client: &ScavengerContractClient, env: &Env) -> Address {
+    let collector = Address::generate(env);
+    client.register_participant(
+        &collector,
+        &ParticipantRole::Collector,
+        &soroban_sdk::symbol_short!("col"),
+        &0,
+        &0,
+    );
+    collector
+}
+
+// ── Happy-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_reserve_waste_sets_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    let waste = client.reserve_waste(&waste_id, &collector, &3600u64).unwrap();
+
+    assert_eq!(waste.reserved_by, Some(collector));
+    assert!(waste.reserved_until.is_some());
+}
+
+#[test]
+fn test_cancel_reservation_by_reserver() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector, &3600u64).unwrap();
+    let waste = client.cancel_reservation(&waste_id, &collector).unwrap();
+
+    assert_eq!(waste.reserved_by, None);
+    assert_eq!(waste.reserved_until, None);
+}
+
+#[test]
+fn test_cancel_reservation_by_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector, &3600u64).unwrap();
+    // Owner (recycler) cancels the reservation
+    let waste = client.cancel_reservation(&waste_id, &recycler).unwrap();
+
+    assert_eq!(waste.reserved_by, None);
+}
+
+#[test]
+fn test_transfer_to_reserver_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector, &3600u64).unwrap();
+
+    // Transfer to the reserver should succeed
+    let result = client.transfer_waste_v2(&waste_id, &recycler, &collector, &0, &0);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_transfer_blocked_when_reserved_by_other() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector1 = register_collector(&client, &env);
+    let collector2 = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    // collector1 reserves
+    client.reserve_waste(&waste_id, &collector1, &3600u64).unwrap();
+
+    // Transfer to collector2 (not the reserver) should fail
+    let result = client.try_transfer_waste_v2(&waste_id, &recycler, &collector2, &0, &0);
+    assert_eq!(result, Err(Ok(Error::WasteReservedByOther)));
+}
+
+#[test]
+fn test_expired_reservation_allows_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector1 = register_collector(&client, &env);
+    let collector2 = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    // Reserve with duration=1 second
+    client.reserve_waste(&waste_id, &collector1, &1u64).unwrap();
+
+    // Advance ledger time past the reservation expiry
+    env.ledger().with_mut(|l| l.timestamp = l.timestamp + 100);
+
+    // Transfer to a different collector should now succeed (reservation expired)
+    let result = client.transfer_waste_v2(&waste_id, &recycler, &collector2, &0, &0);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_expired_reservation_can_be_overwritten() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector1 = register_collector(&client, &env);
+    let collector2 = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector1, &1u64).unwrap();
+    env.ledger().with_mut(|l| l.timestamp = l.timestamp + 100);
+
+    // New reservation by collector2 should succeed after expiry
+    let waste = client.reserve_waste(&waste_id, &collector2, &3600u64).unwrap();
+    assert_eq!(waste.reserved_by, Some(collector2));
+}
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_reserve_waste_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let result = client.try_reserve_waste(&9999u128, &collector, &3600u64);
+    assert_eq!(result, Err(Ok(Error::WasteNotFound)));
+}
+
+#[test]
+fn test_reserve_deactivated_waste() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+    client.deactivate_waste(&waste_id, &admin);
+
+    let result = client.try_reserve_waste(&waste_id, &collector, &3600u64);
+    assert_eq!(result, Err(Ok(Error::WasteDeactivated)));
+}
+
+#[test]
+fn test_double_reservation_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector1 = register_collector(&client, &env);
+    let collector2 = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector1, &3600u64).unwrap();
+
+    let result = client.try_reserve_waste(&waste_id, &collector2, &3600u64);
+    assert_eq!(result, Err(Ok(Error::WasteAlreadyReserved)));
+}
+
+#[test]
+fn test_cancel_not_reserved() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    let result = client.try_cancel_reservation(&waste_id, &recycler);
+    assert_eq!(result, Err(Ok(Error::WasteNotReserved)));
+}
+
+#[test]
+fn test_cancel_by_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, recycler) = setup(&env);
+
+    let collector = register_collector(&client, &env);
+    let stranger = register_collector(&client, &env);
+    let waste_id = client.recycle_waste(&WasteType::Plastic, &1000u128, &recycler, &0, &0);
+
+    client.reserve_waste(&waste_id, &collector, &3600u64).unwrap();
+
+    let result = client.try_cancel_reservation(&waste_id, &stranger);
+    assert_eq!(result, Err(Ok(Error::NotReserver)));
+}


### PR DESCRIPTION
  Closes #364  Allow collectors/manufacturers to reserve waste items for                                                                                                                       
  a limited time before transfer.                                                                                                                                                               
                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  ### stellar-contract/src/types.rs                                                                                                                                                             
  - Add reserved_by: Option<Address> to Waste struct                                                                                                                                            
  - Add reserved_until: Option<u64> to Waste struct                                                                                                                                             
  - Update Waste::new and WasteBuilder::build to default both fields to None                                                                                                                    
                                                                                                                                                                                                
  ### stellar-contract/src/errors.rs                                                                                                                                                            
  - Add WasteAlreadyReserved (39): active reservation already exists                                                                                                                            
  - Add WasteNotReserved (40): no reservation to cancel                                                                                                                                         
  - Add NotReserver (41): caller is neither reserver nor owner                                                                                                                                  
  - Add WasteReservedByOther (42): transfer blocked by active reservation                                                                                                                       
                                                                                                                                                                                                
  ### stellar-contract/src/events.rs                                                                                                                                                            
  - Add emit_waste_reserved(env, waste_id, reserved_by, reserved_until)                                                                                                                         
    using topic symbol_short!(\"wst_res\")                                                                                                                                                      
  - Add emit_reservation_cancelled(env, waste_id, cancelled_by)                                                                                                                                 
    using topic symbol_short!(\"res_cncl\")                                                                                                                                                     
                                                                                                                                                                                                
  ### stellar-contract/src/lib.rs                                                                                                                                                               
  - Add reserve_waste(env, waste_id, reserver, duration):                                                                                                                                       
    - Only registered participants may reserve                                                                                                                                                  
    - Waste must be active and not already reserved (or reservation expired)                                                                                                                    
    - Sets reserved_by and reserved_until on the Waste record                                                                                                                                   
    - Emits WasteReserved event                                                                                                                                                                 
  - Add cancel_reservation(env, waste_id, caller):                                                                                                                                              
    - Reserver or waste owner may cancel                                                                                                                                                        
    - Clears reserved_by and reserved_until                                                                                                                                                     
    - Emits ReservationCancelled event                                                                                                                                                          
  - Patch transfer_waste_v2: block transfer if waste is reserved by                                                                                                                             
    someone other than the intended recipient (expired reservations                                                                                                                             
    are ignored automatically via timestamp comparison)                                                                                                                                         
                                                                                                                                                                                                
  ### stellar-contract/tests/waste_reservation_test.rs                                                                                                                                          
  - 12 tests covering all acceptance criteria and edge cases:                                                                                                                                   
    Happy paths: reserve sets fields, cancel by reserver, cancel by owner,                                                                                                                      
    transfer to reserver succeeds, expired reservation allows transfer,                                                                                                                         
    expired reservation can be overwritten                                                                                                                                                      
    Error paths: waste not found, deactivated waste, double reservation,                                                                                                                        
    cancel non-reserved waste, cancel by unauthorized caller" && git push -u origin feature/364-waste-reservation 2>&1  