### PR TITLE
Feature/365 incentive scheduling

### DIFF
--- a/stellar-contract/src/errors.rs
+++ b/stellar-contract/src/errors.rs
@@ -204,4 +204,7 @@ pub enum Error {
 
     /// (42) Waste is reserved by someone else; transfer is blocked.
     WasteReservedByOther = 42,
+
+    /// (43) starts_at is not before ends_at, or both are in the past.
+    InvalidSchedule = 43,
 }

--- a/stellar-contract/src/events.rs
+++ b/stellar-contract/src/events.rs
@@ -116,6 +116,20 @@ pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
     env.events().publish((symbol_short!("unpaused"),), admin);
 }
 
+/// Emit event when an incentive schedule is set
+pub fn emit_incentive_scheduled(
+    env: &Env,
+    incentive_id: u64,
+    rewarder: &Address,
+    starts_at: Option<u64>,
+    ends_at: Option<u64>,
+) {
+    env.events().publish(
+        (symbol_short!("inc_sched"), incentive_id),
+        (rewarder, starts_at, ends_at),
+    );
+}
+
 /// Emit event when a waste item is reserved
 pub fn emit_waste_reserved(env: &Env, waste_id: u128, reserved_by: &Address, reserved_until: u64) {
     env.events().publish(

--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -1120,7 +1120,7 @@ impl ScavengerContract {
 
         for i in 1..=count {
             if let Some(incentive) = Self::get_incentive(&env, i) {
-                if incentive.waste_type == waste_type && incentive.active {
+                if incentive.waste_type == waste_type && Self::incentive_in_window(&incentive, env.ledger().timestamp()) {
                     // Keep results sorted by reward_points descending.
                     let mut inserted = false;
                     for idx in 0..results.len() {
@@ -1152,10 +1152,11 @@ impl ScavengerContract {
     pub fn get_active_incentives(env: Env) -> soroban_sdk::Vec<Incentive> {
         let mut results = soroban_sdk::Vec::new(&env);
         let count = Self::get_incentive_count(&env);
+        let now = env.ledger().timestamp();
 
         for i in 1..=count {
             if let Some(incentive) = Self::get_incentive(&env, i) {
-                if incentive.active {
+                if Self::incentive_in_window(&incentive, now) {
                     results.push_back(incentive);
                 }
             }
@@ -3252,5 +3253,82 @@ impl ScavengerContract {
         events::emit_reservation_cancelled(&env, waste_id, &caller);
 
         Ok(waste)
+    }
+
+    /// Returns true if the incentive is active and within its scheduled time window.
+    fn incentive_in_window(incentive: &Incentive, now: u64) -> bool {
+        if !incentive.active {
+            return false;
+        }
+        if let Some(starts) = incentive.starts_at {
+            if now < starts {
+                return false;
+            }
+        }
+        if let Some(ends) = incentive.ends_at {
+            if now >= ends {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Set or update the activation schedule for an existing incentive.
+    ///
+    /// Only the original `rewarder` may schedule their incentive.
+    /// `starts_at` must be strictly less than `ends_at` when both are provided.
+    ///
+    /// # Parameters
+    /// - `incentive_id`: ID of the incentive to schedule.
+    /// - `rewarder`: Original creator. Must sign.
+    /// - `starts_at`: Optional UTC timestamp when the incentive becomes active.
+    /// - `ends_at`: Optional UTC timestamp when the incentive expires.
+    ///
+    /// # Errors
+    /// - Panics `"Incentive not found"` if the ID does not exist.
+    /// - [`Error::NotCreator`] if `rewarder` is not the original creator.
+    /// - [`Error::InvalidSchedule`] if `starts_at >= ends_at` (when both set),
+    ///   or if `ends_at` is already in the past.
+    pub fn schedule_incentive(
+        env: Env,
+        incentive_id: u64,
+        rewarder: Address,
+        starts_at: Option<u64>,
+        ends_at: Option<u64>,
+    ) -> Result<Incentive, Error> {
+        rewarder.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut incentive: Incentive =
+            Self::get_incentive(&env, incentive_id).expect("Incentive not found");
+
+        if incentive.rewarder != rewarder {
+            return Err(Error::NotCreator);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // ends_at must be in the future
+        if let Some(ends) = ends_at {
+            if ends <= now {
+                return Err(Error::InvalidSchedule);
+            }
+        }
+
+        // starts_at must be before ends_at when both provided
+        if let (Some(starts), Some(ends)) = (starts_at, ends_at) {
+            if starts >= ends {
+                return Err(Error::InvalidSchedule);
+            }
+        }
+
+        incentive.starts_at = starts_at;
+        incentive.ends_at = ends_at;
+
+        Self::set_incentive(&env, incentive_id, &incentive);
+
+        events::emit_incentive_scheduled(&env, incentive_id, &rewarder, starts_at, ends_at);
+
+        Ok(incentive)
     }
 }

--- a/stellar-contract/src/types.rs
+++ b/stellar-contract/src/types.rs
@@ -215,6 +215,10 @@ pub struct Incentive {
     pub active: bool,
     /// Timestamp when the incentive was created
     pub created_at: u64,
+    /// Optional UTC timestamp when the incentive becomes active
+    pub starts_at: Option<u64>,
+    /// Optional UTC timestamp when the incentive expires
+    pub ends_at: Option<u64>,
 }
 
 impl Incentive {
@@ -236,6 +240,8 @@ impl Incentive {
             remaining_budget: total_budget,
             active: true,
             created_at,
+            starts_at: None,
+            ends_at: None,
         }
     }
 

--- a/stellar-contract/tests/incentive_scheduling_test.rs
+++ b/stellar-contract/tests/incentive_scheduling_test.rs
@@ -1,0 +1,225 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use stellar_scavngr_contract::{Error, ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType};
+
+fn setup(env: &Env) -> (ScavengerContractClient, Address, Address) {
+    let contract_id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+
+    let manufacturer = Address::generate(env);
+    client.register_participant(
+        &manufacturer,
+        &ParticipantRole::Manufacturer,
+        &soroban_sdk::symbol_short!("mfr"),
+        &0,
+        &0,
+    );
+
+    (client, admin, manufacturer)
+}
+
+fn create_incentive(client: &ScavengerContractClient, manufacturer: &Address) -> u64 {
+    let incentive = client.create_incentive(manufacturer, &WasteType::Plastic, &10u64, &1000u64);
+    incentive.id
+}
+
+// ── Happy-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_schedule_sets_starts_and_ends() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    let incentive = client
+        .schedule_incentive(&id, &manufacturer, &Some(now + 100), &Some(now + 1000))
+        .unwrap();
+
+    assert_eq!(incentive.starts_at, Some(now + 100));
+    assert_eq!(incentive.ends_at, Some(now + 1000));
+}
+
+#[test]
+fn test_schedule_only_ends_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    let incentive = client
+        .schedule_incentive(&id, &manufacturer, &None, &Some(now + 500))
+        .unwrap();
+
+    assert_eq!(incentive.starts_at, None);
+    assert_eq!(incentive.ends_at, Some(now + 500));
+}
+
+#[test]
+fn test_incentive_excluded_before_starts_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    // Schedule to start in the future
+    client
+        .schedule_incentive(&id, &manufacturer, &Some(now + 500), &Some(now + 1000))
+        .unwrap();
+
+    // Query at current time — incentive should not appear
+    let active = client.get_active_incentives();
+    assert!(!active.iter().any(|i| i.id == id));
+}
+
+#[test]
+fn test_incentive_included_within_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    // Schedule window that includes now
+    client
+        .schedule_incentive(&id, &manufacturer, &Some(now - 100), &Some(now + 1000))
+        .unwrap();
+
+    let active = client.get_active_incentives();
+    assert!(active.iter().any(|i| i.id == id));
+}
+
+#[test]
+fn test_incentive_excluded_after_ends_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    // Schedule ends in the future so we can set it
+    client
+        .schedule_incentive(&id, &manufacturer, &None, &Some(now + 100))
+        .unwrap();
+
+    // Advance time past ends_at
+    env.ledger().with_mut(|l| l.timestamp = now + 200);
+
+    let active = client.get_active_incentives();
+    assert!(!active.iter().any(|i| i.id == id));
+}
+
+#[test]
+fn test_get_incentives_by_waste_type_respects_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    // Schedule to start in the future
+    client
+        .schedule_incentive(&id, &manufacturer, &Some(now + 500), &Some(now + 1000))
+        .unwrap();
+
+    let results = client.get_incentives_by_waste_type(&WasteType::Plastic);
+    assert!(!results.iter().any(|i| i.id == id));
+
+    // Advance into the window
+    env.ledger().with_mut(|l| l.timestamp = now + 600);
+    let results = client.get_incentives_by_waste_type(&WasteType::Plastic);
+    assert!(results.iter().any(|i| i.id == id));
+}
+
+#[test]
+fn test_no_schedule_incentive_always_visible() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let id = create_incentive(&client, &manufacturer);
+
+    // No schedule set — should always appear
+    let active = client.get_active_incentives();
+    assert!(active.iter().any(|i| i.id == id));
+}
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_schedule_not_creator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let other_mfr = Address::generate(&env);
+    client.register_participant(
+        &other_mfr,
+        &ParticipantRole::Manufacturer,
+        &soroban_sdk::symbol_short!("mfr2"),
+        &0,
+        &0,
+    );
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    let result = client.try_schedule_incentive(&id, &other_mfr, &None, &Some(now + 500));
+    assert_eq!(result, Err(Ok(Error::NotCreator)));
+}
+
+#[test]
+fn test_schedule_ends_in_past() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    // ends_at is at or before now
+    let result = client.try_schedule_incentive(&id, &manufacturer, &None, &Some(now));
+    assert_eq!(result, Err(Ok(Error::InvalidSchedule)));
+}
+
+#[test]
+fn test_schedule_starts_after_ends() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    let id = create_incentive(&client, &manufacturer);
+
+    let result = client.try_schedule_incentive(
+        &id,
+        &manufacturer,
+        &Some(now + 1000),
+        &Some(now + 500),
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidSchedule)));
+}
+
+#[test]
+#[should_panic(expected = "Incentive not found")]
+fn test_schedule_incentive_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, manufacturer) = setup(&env);
+
+    let now = env.ledger().timestamp();
+    client.schedule_incentive(&9999u64, &manufacturer, &None, &Some(now + 500)).unwrap();
+}


### PR DESCRIPTION
  Closes #365 — Allow manufacturers to schedule incentives to                                                                                                                                   
  activate/deactivate at specific UTC timestamps.                                                                                                                                               
                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  ### stellar-contract/src/types.rs                                                                                                                                                             
  - Add starts_at: Option<u64> to Incentive struct (UTC activation timestamp)                                                                                                                   
  - Add ends_at: Option<u64> to Incentive struct (UTC expiry timestamp)                                                                                                                         
  - Update Incentive::new to default both fields to None                                                                                                                                        
                                                                                                                                                                                                
  ### stellar-contract/src/errors.rs                                                                                                                                                            
  - Add InvalidSchedule (43): starts_at >= ends_at, or ends_at is in the past                                                                                                                   
                                                                                                                                                                                                
  ### stellar-contract/src/events.rs                                                                                                                                                            
  - Add emit_incentive_scheduled(env, incentive_id, rewarder, starts_at, ends_at)                                                                                                               
    using topic symbol_short!(\"inc_sched\")                                                                                                                                                    
                                                                                                                                                                                                
  ### stellar-contract/src/lib.rs                                                                                                                                                               
  - Add incentive_in_window(incentive, now) helper: returns true only when                                                                                                                      
    incentive.active AND now >= starts_at (if set) AND now < ends_at (if set)                                                                                                                   
  - Add schedule_incentive(env, incentive_id, rewarder, starts_at, ends_at):                                                                                                                    
    - Only the original rewarder may schedule their incentive                                                                                                                                   
    - Validates ends_at > now and starts_at < ends_at when both provided                                                                                                                        
    - Persists the schedule and emits IncentiveScheduled event                                                                                                                                  
  - Update get_active_incentives: use incentive_in_window instead of .active                                                                                                                    
  - Update get_incentives_by_waste_type: use incentive_in_window instead of .active                                                                                                             
                                                                                                                                                                                                
  ### stellar-contract/tests/incentive_scheduling_test.rs                                                                                                                                       
  - 11 tests covering all acceptance criteria and edge cases:                                                                                                                                   
    Happy paths: schedule sets fields, only ends_at, excluded before starts_at,                                                                                                                 
    included within window, excluded after ends_at, get_incentives_by_waste_type                                                                                                                
    respects window, unscheduled incentive always visible                                                                                                                                       
    Error paths: not creator, ends_at in past, starts_at after ends_at,                                                                                                                         
    incentive not found" && git push -u origin feature/365-incentive-scheduling 2>&1    