### PR TITLE
Feature/371 waste processing status

### DIFF
--- a/stellar-contract/src/events.rs
+++ b/stellar-contract/src/events.rs
@@ -123,3 +123,17 @@ pub fn emit_seasonal_multiplier_set(env: &Env, multiplier: u32, start: u64, end:
         (multiplier, start, end),
     );
 }
+
+/// Emit event when a waste item's processing status changes.
+pub fn emit_processing_status_changed(
+    env: &Env,
+    waste_id: u128,
+    new_status: u32,
+    updated_by: &Address,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("proc_chg"), waste_id),
+        (new_status, updated_by, timestamp),
+    );
+}

--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -8,8 +8,9 @@ mod test_transfer_path_validation;
 
 pub use errors::Error;
 pub use types::{
-    GlobalMetrics, Incentive, Material, ParticipantRole, RecyclingStats, SeasonalMultiplier,
-    TransferItemType, TransferRecord, TransferStatus, Waste, WasteTransfer, WasteType,
+    GlobalMetrics, Incentive, Material, ParticipantRole, ProcessingRecord, ProcessingStatus,
+    RecyclingStats, SeasonalMultiplier, TransferItemType, TransferRecord, TransferStatus, Waste,
+    WasteTransfer, WasteType,
 };
 
 use soroban_sdk::{
@@ -1667,6 +1668,7 @@ impl ScavengerContract {
         let timestamp = env.ledger().timestamp();
 
         let waste = types::Waste::new(
+            &env,
             waste_id,
             waste_type,
             weight,
@@ -1718,6 +1720,74 @@ impl ScavengerContract {
             .instance()
             .get(&("participant_wastes", participant))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Update the processing status of a v2 waste item.
+    ///
+    /// Only the current owner may call this. Status must advance forward
+    /// (Collected → Sorted → Processed → Recycled → Manufactured).
+    ///
+    /// # Panics
+    /// - `"Waste not found"` if the waste ID does not exist.
+    /// - `"Only current owner can update processing status"` if caller is not the owner.
+    /// - `"Status must progress forward"` if new status is not strictly greater.
+    pub fn update_processing_status(
+        env: Env,
+        waste_id: u128,
+        caller: Address,
+        new_status: ProcessingStatus,
+    ) -> types::Waste {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut waste: types::Waste = env
+            .storage()
+            .instance()
+            .get(&("waste_v2", waste_id))
+            .expect("Waste not found");
+
+        assert!(waste.current_owner == caller, "Only current owner can update processing status");
+        assert!(
+            new_status.to_u32() > waste.processing_status.to_u32(),
+            "Status must progress forward"
+        );
+
+        let timestamp = env.ledger().timestamp();
+        waste.processing_status = new_status;
+        waste.processing_history.push_back(ProcessingRecord {
+            status: new_status,
+            timestamp,
+            updated_by: caller.clone(),
+        });
+
+        env.storage().instance().set(&("waste_v2", waste_id), &waste);
+        events::emit_processing_status_changed(&env, waste_id, new_status.to_u32(), &caller, timestamp);
+
+        waste
+    }
+
+    /// Return all v2 waste IDs whose current processing status matches `status`.
+    ///
+    /// Scans the global waste ID counter and checks each stored waste item.
+    pub fn get_wastes_by_status(env: Env, status: ProcessingStatus) -> Vec<u128> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&("waste_count",))
+            .unwrap_or(0);
+        let mut result = Vec::new(&env);
+        for id in 1u128..=(count as u128) {
+            if let Some(w) = env
+                .storage()
+                .instance()
+                .get::<_, types::Waste>(&("waste_v2", id))
+            {
+                if w.processing_status == status {
+                    result.push_back(id);
+                }
+            }
+        }
+        result
     }
 
     /// Transfer a v2 waste item between participants with location tracking.
@@ -2027,6 +2097,7 @@ impl ScavengerContract {
         let timestamp = env.ledger().timestamp();
 
         let waste = types::Waste::new(
+            &env,
             waste_id,
             waste_type,
             0,

--- a/stellar-contract/src/types.rs
+++ b/stellar-contract/src/types.rs
@@ -482,6 +482,44 @@ impl Material {
     }
 }
 
+/// Processing stages a waste item moves through in the supply chain.
+/// Stages must progress forward only (Collected → Sorted → Processed → Recycled → Manufactured).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessingStatus {
+    Collected = 0,
+    Sorted = 1,
+    Processed = 2,
+    Recycled = 3,
+    Manufactured = 4,
+}
+
+impl ProcessingStatus {
+    pub fn to_u32(self) -> u32 {
+        self as u32
+    }
+
+    pub fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(ProcessingStatus::Collected),
+            1 => Some(ProcessingStatus::Sorted),
+            2 => Some(ProcessingStatus::Processed),
+            3 => Some(ProcessingStatus::Recycled),
+            4 => Some(ProcessingStatus::Manufactured),
+            _ => None,
+        }
+    }
+}
+
+/// A single entry in a waste item's processing history.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessingRecord {
+    pub status: ProcessingStatus,
+    pub timestamp: u64,
+    pub updated_by: Address,
+}
+
 /// Represents a waste item in the recycling system
 /// This is the main struct that tracks waste throughout its lifecycle
 #[contracttype]
@@ -507,11 +545,16 @@ pub struct Waste {
     pub is_confirmed: bool,
     /// Address of the confirmer/verifier
     pub confirmer: Address,
+    /// Current processing stage
+    pub processing_status: ProcessingStatus,
+    /// Ordered history of processing stage changes
+    pub processing_history: soroban_sdk::Vec<ProcessingRecord>,
 }
 
 impl Waste {
     /// Creates a new Waste instance with all fields
     pub fn new(
+        env: &soroban_sdk::Env,
         waste_id: u128,
         waste_type: WasteType,
         weight: u128,
@@ -523,6 +566,13 @@ impl Waste {
         is_confirmed: bool,
         confirmer: Address,
     ) -> Self {
+        let initial_record = ProcessingRecord {
+            status: ProcessingStatus::Collected,
+            timestamp: env.ledger().timestamp(),
+            updated_by: current_owner.clone(),
+        };
+        let mut history = soroban_sdk::Vec::new(env);
+        history.push_back(initial_record);
         Self {
             waste_id,
             waste_type,
@@ -534,6 +584,8 @@ impl Waste {
             is_active,
             is_confirmed,
             confirmer,
+            processing_status: ProcessingStatus::Collected,
+            processing_history: history,
         }
     }
 
@@ -697,8 +749,15 @@ impl WasteBuilder {
     }
 
     /// Builds the Waste instance
-    pub fn build(self) -> Waste {
+    pub fn build(self, env: &soroban_sdk::Env) -> Waste {
         let confirmer = self.confirmer.unwrap_or_else(|| self.current_owner.clone());
+        let initial_record = ProcessingRecord {
+            status: ProcessingStatus::Collected,
+            timestamp: env.ledger().timestamp(),
+            updated_by: self.current_owner.clone(),
+        };
+        let mut history = soroban_sdk::Vec::new(env);
+        history.push_back(initial_record);
         Waste {
             waste_id: self.waste_id,
             waste_type: self.waste_type,
@@ -710,6 +769,8 @@ impl WasteBuilder {
             is_active: self.is_active,
             is_confirmed: self.is_confirmed,
             confirmer,
+            processing_status: ProcessingStatus::Collected,
+            processing_history: history,
         }
     }
 }

--- a/stellar-contract/tests/waste_processing_status_test.rs
+++ b/stellar-contract/tests/waste_processing_status_test.rs
@@ -1,0 +1,215 @@
+#![cfg(test)]
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+use stellar_scavngr_contract::{
+    ParticipantRole, ProcessingStatus, ScavengerContract, ScavengerContractClient, WasteType,
+};
+
+fn setup(env: &Env) -> (ScavengerContractClient<'_>, Address) {
+    let id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+    (client, admin)
+}
+
+fn register_recycler(env: &Env, client: &ScavengerContractClient<'_>) -> Address {
+    let addr = Address::generate(env);
+    client.register_participant(
+        &addr,
+        &ParticipantRole::Recycler,
+        &symbol_short!("recycler"),
+        &10_000_000,
+        &20_000_000,
+    );
+    addr
+}
+
+fn submit_waste(client: &ScavengerContractClient<'_>, owner: &Address) -> u128 {
+    client.recycle_waste(&WasteType::Plastic, &1_000, owner, &10_000_000, &20_000_000)
+}
+
+// ── 1. New waste starts with Collected status ──────────────────────────────
+#[test]
+fn test_new_waste_has_collected_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    let waste = client.get_waste_v2(&waste_id).unwrap();
+
+    assert_eq!(waste.processing_status, ProcessingStatus::Collected);
+}
+
+// ── 2. New waste has one entry in processing_history ──────────────────────
+#[test]
+fn test_new_waste_history_has_one_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    let waste = client.get_waste_v2(&waste_id).unwrap();
+
+    assert_eq!(waste.processing_history.len(), 1);
+    assert_eq!(waste.processing_history.get(0).unwrap().status, ProcessingStatus::Collected);
+}
+
+// ── 3. Owner can advance status forward ───────────────────────────────────
+#[test]
+fn test_owner_can_advance_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    let updated = client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Sorted);
+
+    assert_eq!(updated.processing_status, ProcessingStatus::Sorted);
+}
+
+// ── 4. History grows with each status update ──────────────────────────────
+#[test]
+fn test_history_grows_on_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Sorted);
+    let waste = client.get_waste_v2(&waste_id).unwrap();
+
+    assert_eq!(waste.processing_history.len(), 2);
+    assert_eq!(waste.processing_history.get(1).unwrap().status, ProcessingStatus::Sorted);
+}
+
+// ── 5. Full forward progression works ─────────────────────────────────────
+#[test]
+fn test_full_forward_progression() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Sorted);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Processed);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Recycled);
+    let final_waste = client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Manufactured);
+
+    assert_eq!(final_waste.processing_status, ProcessingStatus::Manufactured);
+    assert_eq!(final_waste.processing_history.len(), 5);
+}
+
+// ── 6. Backwards status update is rejected ────────────────────────────────
+#[test]
+#[should_panic(expected = "Status must progress forward")]
+fn test_backwards_status_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Sorted);
+    // Try to go back to Collected
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Collected);
+}
+
+// ── 7. Same status update is rejected ─────────────────────────────────────
+#[test]
+#[should_panic(expected = "Status must progress forward")]
+fn test_same_status_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Collected);
+}
+
+// ── 8. Non-owner cannot update status ─────────────────────────────────────
+#[test]
+#[should_panic(expected = "Only current owner can update processing status")]
+fn test_non_owner_cannot_update_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+    let other = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &other, &ProcessingStatus::Sorted);
+}
+
+// ── 9. Update on non-existent waste panics ────────────────────────────────
+#[test]
+#[should_panic(expected = "Waste not found")]
+fn test_update_nonexistent_waste_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    client.update_processing_status(&9999u128, &owner, &ProcessingStatus::Sorted);
+}
+
+// ── 10. get_wastes_by_status returns correct IDs ──────────────────────────
+#[test]
+fn test_get_wastes_by_status_returns_matching() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let id1 = submit_waste(&client, &owner);
+    let id2 = submit_waste(&client, &owner);
+    // Advance id2 to Sorted
+    client.update_processing_status(&id2, &owner, &ProcessingStatus::Sorted);
+
+    let collected = client.get_wastes_by_status(&ProcessingStatus::Collected);
+    let sorted = client.get_wastes_by_status(&ProcessingStatus::Sorted);
+
+    assert!(collected.contains(&id1));
+    assert!(!collected.contains(&id2));
+    assert!(sorted.contains(&id2));
+    assert!(!sorted.contains(&id1));
+}
+
+// ── 11. get_wastes_by_status returns empty when none match ────────────────
+#[test]
+fn test_get_wastes_by_status_empty_when_none_match() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    submit_waste(&client, &owner);
+
+    let manufactured = client.get_wastes_by_status(&ProcessingStatus::Manufactured);
+    assert_eq!(manufactured.len(), 0);
+}
+
+// ── 12. History records correct updater address ───────────────────────────
+#[test]
+fn test_history_records_correct_updater() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let owner = register_recycler(&env, &client);
+
+    let waste_id = submit_waste(&client, &owner);
+    client.update_processing_status(&waste_id, &owner, &ProcessingStatus::Sorted);
+
+    let waste = client.get_waste_v2(&waste_id).unwrap();
+    let record = waste.processing_history.get(1).unwrap();
+
+    assert_eq!(record.updated_by, owner);
+    assert_eq!(record.status, ProcessingStatus::Sorted);
+}


### PR DESCRIPTION
  Track waste items through 5 processing stages: Collected → Sorted →                                                                                                                    
  Processed → Recycled → Manufactured. Status can only advance forward;                                                                                                                  
  each change is timestamped and recorded in an immutable history.                                                                                                                       
                                                                                                                                                                                         
  Changes:                                                                                                                                                                               
  - types.rs:                                                                                                                                                                            
    - add ProcessingStatus enum (Collected=0, Sorted=1, Processed=2,                                                                                                                     
      Recycled=3, Manufactured=4) with to_u32/from_u32 helpers                                                                                                                           
    - add ProcessingRecord { status, timestamp, updated_by } contracttype                                                                                                                
    - add processing_status: ProcessingStatus and                                                                                                                                        
      processing_history: Vec<ProcessingRecord> fields to Waste struct                                                                                                                   
    - update Waste::new to accept &Env, initialise processing_status to                                                                                                                  
      Collected and seed processing_history with the initial record                                                                                                                      
    - update WasteBuilder::build to accept &Env and populate new fields                                                                                                                  
                                                                                                                                                                                         
  - events.rs:                                                                                                                                                                           
    - add emit_processing_status_changed(env, waste_id, new_status,                                                                                                                      
      updated_by, timestamp) publishing under 'proc_chg' symbol key                                                                                                                      
                                                                                                                                                                                         
  - lib.rs:                                                                                                                                                                              
    - export ProcessingRecord and ProcessingStatus from crate root                                                                                                                       
    - update both Waste::new call sites (recycle_waste,                                                                                                                                  
      submit_material_for_manufacturer) to pass &env                                                                                                                                     
    - add update_processing_status(env, waste_id, caller, new_status):                                                                                                                   
      requires caller == current_owner, enforces forward-only progression,                                                                                                               
      appends ProcessingRecord to history, emits event                                                                                                                                   
    - add get_wastes_by_status(env, status) -> Vec<u128>: scans all                                                                                                                      
      stored v2 waste items and returns IDs matching the given status                                                                                                                    
                                                                                                                                                                                         
  - tests/waste_processing_status_test.rs: 12 tests covering                                                                                                                             
    - new waste starts with Collected status                                                                                                                                             
    - initial history has exactly one entry                                                                                                                                              
    - owner can advance status forward                                                                                                                                                   
    - history grows with each update                                                                                                                                                     
    - full Collected→Manufactured progression                                                                                                                                            
    - backwards status update is rejected                                                                                                                                                
    - same-status update is rejected                                                                                                                                                     
    - non-owner cannot update status                                                                                                                                                     
    - update on non-existent waste panics                                                                                                                                                
    - get_wastes_by_status returns correct IDs                                                                                                                                           
    - get_wastes_by_status returns empty when none match                                                                                                                                 
    - history records correct updater address                                                                                                                                            
                                                                                                                                                                                         
  Closes #371  