### PR TITLE
feat(incentives): implement tiered reward system (#366)

### DIFF
--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -8,8 +8,8 @@ mod test_transfer_path_validation;
 
 pub use errors::Error;
 pub use types::{
-    GlobalMetrics, Incentive, Material, ParticipantRole, RecyclingStats, TransferItemType,
-    TransferRecord, TransferStatus, Waste, WasteTransfer, WasteType,
+    GlobalMetrics, Incentive, IncentiveTier, Material, ParticipantRole, RecyclingStats,
+    TransferItemType, TransferRecord, TransferStatus, Waste, WasteTransfer, WasteType,
 };
 
 use soroban_sdk::{
@@ -1096,12 +1096,8 @@ impl ScavengerContract {
             return 0;
         }
 
-        // Calculate reward: (weight in kg) * reward_points
-        let weight_kg = waste_amount / 1000;
-        let reward = weight_kg * incentive.reward_points;
-        
-        // Exact reward calculation instead of capping
-        reward
+        // Use tiered or flat reward calculation
+        incentive.calculate_reward(waste_amount)
     }
 
     /// Get all active incentives for a specific waste type, sorted by reward descending.
@@ -2599,6 +2595,7 @@ impl ScavengerContract {
             reward_points,
             total_budget,
             env.ledger().timestamp(),
+            &env,
         );
 
         // Store incentive
@@ -2715,6 +2712,88 @@ impl ScavengerContract {
         incentive
     }
 
+    /// Set tiered reward structure for an incentive (max 5 tiers).
+    ///
+    /// Tiers must be sorted by `min_weight_kg` ascending, non-overlapping,
+    /// and contiguous (each tier's `min_weight_kg` must equal the previous
+    /// tier's `max_weight_kg`). Only the original `rewarder` may call this.
+    ///
+    /// # Parameters
+    /// - `incentive_id`: ID of the incentive to update.
+    /// - `rewarder`: Original creator. Must sign.
+    /// - `tiers`: Vec of up to 5 [`IncentiveTier`] entries.
+    ///
+    /// # Returns
+    /// The updated [`Incentive`].
+    ///
+    /// # Errors
+    /// - Panics `"Incentive not found"`.
+    /// - Panics `"Only incentive creator can set tiers"`.
+    /// - Panics `"Incentive is not active"`.
+    /// - Panics `"Maximum 5 tiers allowed"`.
+    /// - Panics `"Tiers cannot be empty"`.
+    /// - Panics `"Tier reward_points must be greater than zero"`.
+    /// - Panics `"Tiers must be sorted by min_weight_kg ascending"`.
+    /// - Panics `"Tier ranges must not overlap"`.
+    /// - Panics `"Last tier must be unbounded (max_weight_kg == 0)"`.
+    pub fn set_incentive_tiers(
+        env: Env,
+        incentive_id: u64,
+        rewarder: Address,
+        tiers: soroban_sdk::Vec<IncentiveTier>,
+    ) -> Incentive {
+        Self::require_not_paused(&env);
+        rewarder.require_auth();
+        Self::require_registered(&env, &rewarder);
+
+        let mut incentive =
+            Self::get_incentive_internal(&env, incentive_id).expect("Incentive not found");
+
+        if incentive.rewarder != rewarder {
+            panic!("Only incentive creator can set tiers");
+        }
+        if !incentive.active {
+            panic!("Incentive is not active");
+        }
+        if tiers.is_empty() {
+            panic!("Tiers cannot be empty");
+        }
+        if tiers.len() > 5 {
+            panic!("Maximum 5 tiers allowed");
+        }
+
+        // Validate each tier and ordering
+        let mut prev_max: u64 = 0;
+        for i in 0..tiers.len() {
+            let tier = tiers.get(i).unwrap();
+            if tier.reward_points == 0 {
+                panic!("Tier reward_points must be greater than zero");
+            }
+            if tier.min_weight_kg < prev_max {
+                panic!("Tier ranges must not overlap");
+            }
+            if tier.min_weight_kg != prev_max {
+                panic!("Tiers must be sorted by min_weight_kg ascending");
+            }
+            // Last tier must be unbounded
+            if i == tiers.len() - 1 && tier.max_weight_kg != 0 {
+                panic!("Last tier must be unbounded (max_weight_kg == 0)");
+            }
+            // Non-last tiers must have max > min
+            if i < tiers.len() - 1 {
+                if tier.max_weight_kg == 0 || tier.max_weight_kg <= tier.min_weight_kg {
+                    panic!("Tier ranges must not overlap");
+                }
+                prev_max = tier.max_weight_kg;
+            }
+        }
+
+        incentive.tiers = tiers;
+        Self::set_incentive(&env, incentive_id, &incentive);
+
+        incentive
+    }
+
     // ========== Global Metrics ==========
 
     /// Get global contract metrics (total waste count and total tokens earned)
@@ -2785,8 +2864,7 @@ impl ScavengerContract {
         assert!(incentive.waste_type == material.waste_type, "Waste type mismatch");
         assert!(incentive.active, "Incentive not active");
 
-        let weight_kg = material.weight / 1000;
-        let total_reward = (incentive.reward_points as i128) * (weight_kg as i128);
+        let total_reward = incentive.calculate_reward(material.weight) as i128;
         assert!(
             (total_reward as u64) <= incentive.remaining_budget,
             "Insufficient incentive budget"
@@ -2794,8 +2872,6 @@ impl ScavengerContract {
 
         let transfers = Self::get_transfer_history(env.clone(), waste_id);
         let cfg = Self::get_reward_config(&env);
-        let collector_pct: u32 = cfg.collector_percentage;
-        let owner_pct: u32 = cfg.owner_percentage;
         let collector_pct = cfg.collector_percentage;
         let owner_pct = cfg.owner_percentage;
 

--- a/stellar-contract/src/types.rs
+++ b/stellar-contract/src/types.rs
@@ -195,6 +195,20 @@ impl TransferRecord {
     }
 }
 
+/// A single tier in a tiered incentive program.
+/// Reward is `reward_points` per kg for waste weight in [min_weight_kg, max_weight_kg).
+/// `max_weight_kg == 0` means unbounded (no upper limit).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IncentiveTier {
+    /// Minimum weight in kg (inclusive) for this tier to apply
+    pub min_weight_kg: u64,
+    /// Maximum weight in kg (exclusive); 0 means unbounded
+    pub max_weight_kg: u64,
+    /// Reward points per kg for this tier
+    pub reward_points: u64,
+}
+
 /// Represents an incentive offered by a manufacturer to encourage recycling
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -205,7 +219,7 @@ pub struct Incentive {
     pub rewarder: Address,
     /// Type of waste this incentive targets
     pub waste_type: WasteType,
-    /// Reward points per kilogram
+    /// Reward points per kilogram (used when no tiers are set)
     pub reward_points: u64,
     /// Total points budget allocated for this incentive
     pub total_budget: u64,
@@ -215,6 +229,8 @@ pub struct Incentive {
     pub active: bool,
     /// Timestamp when the incentive was created
     pub created_at: u64,
+    /// Optional tiered reward structure (max 5 tiers, sorted by min_weight_kg asc)
+    pub tiers: soroban_sdk::Vec<IncentiveTier>,
 }
 
 impl Incentive {
@@ -226,6 +242,7 @@ impl Incentive {
         reward_points: u64,
         total_budget: u64,
         created_at: u64,
+        env: &soroban_sdk::Env,
     ) -> Self {
         Self {
             id,
@@ -236,6 +253,7 @@ impl Incentive {
             remaining_budget: total_budget,
             active: true,
             created_at,
+            tiers: soroban_sdk::Vec::new(env),
         }
     }
 
@@ -244,10 +262,24 @@ impl Incentive {
         self.active = false;
     }
 
-    /// Calculates reward for a given weight in grams
+    /// Calculates reward for a given weight in grams.
+    /// Uses tiered rates if tiers are set; falls back to flat `reward_points`.
     pub fn calculate_reward(&self, weight_grams: u64) -> u64 {
-        // Convert grams to kg and multiply by reward points
-        (weight_grams / 1000) * self.reward_points
+        let weight_kg = weight_grams / 1000;
+        if self.tiers.is_empty() {
+            return weight_kg * self.reward_points;
+        }
+        // Find the matching tier (tiers are sorted by min_weight_kg ascending)
+        for i in 0..self.tiers.len() {
+            let tier = self.tiers.get(i).unwrap();
+            let in_lower = weight_kg >= tier.min_weight_kg;
+            let in_upper = tier.max_weight_kg == 0 || weight_kg < tier.max_weight_kg;
+            if in_lower && in_upper {
+                return weight_kg * tier.reward_points;
+            }
+        }
+        // No tier matched — fall back to flat rate
+        weight_kg * self.reward_points
     }
 
     /// Attempts to claim a reward, returns the amount claimed
@@ -279,7 +311,6 @@ impl Incentive {
         }
         let reward = self.calculate_reward(weight_grams);
         reward <= self.remaining_budget
-
     }
 }
 

--- a/stellar-contract/tests/incentive_tiers_test.rs
+++ b/stellar-contract/tests/incentive_tiers_test.rs
@@ -1,0 +1,241 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use stellar_scavngr_contract::{IncentiveTier, ScavengerContract, ScavengerContractClient, WasteType};
+
+fn setup() -> (Env, ScavengerContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ScavengerContract);
+    let client = ScavengerContractClient::new(&env, &contract_id);
+
+    let manufacturer = Address::generate(&env);
+    client.register_participant(
+        &manufacturer,
+        &stellar_scavngr_contract::ParticipantRole::Manufacturer,
+        &soroban_sdk::symbol_short!("mfr"),
+        &0,
+        &0,
+    );
+
+    (env, client, manufacturer)
+}
+
+fn make_tiers(env: &Env, specs: &[(u64, u64, u64)]) -> Vec<IncentiveTier> {
+    let mut tiers = Vec::new(env);
+    for &(min, max, pts) in specs {
+        tiers.push_back(IncentiveTier {
+            min_weight_kg: min,
+            max_weight_kg: max,
+            reward_points: pts,
+        });
+    }
+    tiers
+}
+
+// ── 1. set_incentive_tiers stores tiers and they are retrievable ──────────────
+#[test]
+fn test_set_tiers_stored_correctly() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 500, 15), (500, 0, 20)]);
+    let updated = client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    assert_eq!(updated.tiers.len(), 3);
+    assert_eq!(updated.tiers.get(0).unwrap().reward_points, 10);
+    assert_eq!(updated.tiers.get(1).unwrap().reward_points, 15);
+    assert_eq!(updated.tiers.get(2).unwrap().reward_points, 20);
+}
+
+// ── 2. Reward uses first tier for weight in [0, 100) kg ──────────────────────
+#[test]
+fn test_reward_first_tier() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &5, &100_000);
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 500, 15), (500, 0, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    // 50 kg → tier 1 → 50 * 10 = 500
+    let reward = client.calculate_incentive_reward(&incentive.id, &50_000);
+    assert_eq!(reward, 500);
+}
+
+// ── 3. Reward uses second tier for weight in [100, 500) kg ───────────────────
+#[test]
+fn test_reward_second_tier() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &5, &100_000);
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 500, 15), (500, 0, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    // 200 kg → tier 2 → 200 * 15 = 3000
+    let reward = client.calculate_incentive_reward(&incentive.id, &200_000);
+    assert_eq!(reward, 3000);
+}
+
+// ── 4. Reward uses last (unbounded) tier for weight >= 500 kg ─────────────────
+#[test]
+fn test_reward_last_tier_unbounded() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &5, &100_000);
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 500, 15), (500, 0, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    // 1000 kg → tier 3 → 1000 * 20 = 20000
+    let reward = client.calculate_incentive_reward(&incentive.id, &1_000_000);
+    assert_eq!(reward, 20000);
+}
+
+// ── 5. Flat rate still works when no tiers are set ───────────────────────────
+#[test]
+fn test_flat_rate_without_tiers() {
+    let (_env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Metal, &10, &100_000);
+
+    // 50 kg * 10 pts = 500
+    let reward = client.calculate_incentive_reward(&incentive.id, &50_000);
+    assert_eq!(reward, 500);
+}
+
+// ── 6. Validation: max 5 tiers ────────────────────────────────────────────────
+#[test]
+#[should_panic(expected = "Maximum 5 tiers allowed")]
+fn test_max_5_tiers_enforced() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    // 6 tiers
+    let tiers = make_tiers(
+        &env,
+        &[
+            (0, 50, 5),
+            (50, 100, 10),
+            (100, 200, 15),
+            (200, 300, 18),
+            (300, 400, 20),
+            (400, 0, 25),
+        ],
+    );
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 7. Validation: empty tiers rejected ──────────────────────────────────────
+#[test]
+#[should_panic(expected = "Tiers cannot be empty")]
+fn test_empty_tiers_rejected() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    let tiers: Vec<IncentiveTier> = Vec::new(&env);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 8. Validation: overlapping ranges rejected ───────────────────────────────
+#[test]
+#[should_panic]
+fn test_overlapping_tiers_rejected() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    // Gap between tiers (min of second != max of first)
+    let tiers = make_tiers(&env, &[(0, 100, 10), (50, 0, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 9. Validation: last tier must be unbounded ───────────────────────────────
+#[test]
+#[should_panic(expected = "Last tier must be unbounded (max_weight_kg == 0)")]
+fn test_last_tier_must_be_unbounded() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 500, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 10. Validation: only creator can set tiers ───────────────────────────────
+#[test]
+#[should_panic(expected = "Only incentive creator can set tiers")]
+fn test_only_creator_can_set_tiers() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+
+    // Register a second manufacturer
+    let other = Address::generate(&env);
+    client.register_participant(
+        &other,
+        &stellar_scavngr_contract::ParticipantRole::Manufacturer,
+        &soroban_sdk::symbol_short!("other"),
+        &0,
+        &0,
+    );
+
+    let tiers = make_tiers(&env, &[(0, 0, 10)]);
+    client.set_incentive_tiers(&incentive.id, &other, &tiers);
+}
+
+// ── 11. Validation: cannot set tiers on inactive incentive ───────────────────
+#[test]
+#[should_panic(expected = "Incentive is not active")]
+fn test_cannot_set_tiers_on_inactive_incentive() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    client.deactivate_incentive(&incentive.id, &manufacturer);
+
+    let tiers = make_tiers(&env, &[(0, 0, 10)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 12. Validation: tier reward_points must be > 0 ───────────────────────────
+#[test]
+#[should_panic(expected = "Tier reward_points must be greater than zero")]
+fn test_zero_reward_points_in_tier_rejected() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Plastic, &10, &100_000);
+    let tiers = make_tiers(&env, &[(0, 100, 0), (100, 0, 10)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+}
+
+// ── 13. Single unbounded tier works ──────────────────────────────────────────
+#[test]
+fn test_single_unbounded_tier() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Glass, &5, &100_000);
+    let tiers = make_tiers(&env, &[(0, 0, 25)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    // 10 kg * 25 = 250
+    let reward = client.calculate_incentive_reward(&incentive.id, &10_000);
+    assert_eq!(reward, 250);
+}
+
+// ── 14. Tiers can be updated (overwritten) ───────────────────────────────────
+#[test]
+fn test_tiers_can_be_overwritten() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Paper, &5, &100_000);
+
+    let tiers_v1 = make_tiers(&env, &[(0, 0, 10)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers_v1);
+
+    let tiers_v2 = make_tiers(&env, &[(0, 100, 20), (100, 0, 30)]);
+    let updated = client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers_v2);
+
+    assert_eq!(updated.tiers.len(), 2);
+    assert_eq!(updated.tiers.get(0).unwrap().reward_points, 20);
+}
+
+// ── 15. Boundary: weight exactly at tier boundary uses correct tier ───────────
+#[test]
+fn test_tier_boundary_exact() {
+    let (env, client, manufacturer) = setup();
+    let incentive = client.create_incentive(&manufacturer, &WasteType::Metal, &5, &100_000);
+    // Tiers: [0,100) → 10pts, [100,∞) → 20pts
+    let tiers = make_tiers(&env, &[(0, 100, 10), (100, 0, 20)]);
+    client.set_incentive_tiers(&incentive.id, &manufacturer, &tiers);
+
+    // Exactly 100 kg → second tier → 100 * 20 = 2000
+    let reward = client.calculate_incentive_reward(&incentive.id, &100_000);
+    assert_eq!(reward, 2000);
+
+    // 99 kg → first tier → 99 * 10 = 990
+    let reward2 = client.calculate_incentive_reward(&incentive.id, &99_000);
+    assert_eq!(reward2, 990);
+}


### PR DESCRIPTION
Add volume-based tiered incentives where reward points scale with the weight of recycled material submitted.

Changes:
- types.rs: Add IncentiveTier struct (min_weight_kg, max_weight_kg, reward_points). Add tiers: Vec<IncentiveTier> field to Incentive. Update Incentive::new to accept &Env for Vec initialisation. Update calculate_reward to iterate tiers when present, falling back to flat reward_points when tiers is empty.
- lib.rs: Export IncentiveTier from crate root. Update Incentive::new call in create_incentive to pass &env. Update calculate_incentive_reward to delegate to incentive.calculate_reward(). Update distribute_rewards to use incentive.calculate_reward(material.weight). Remove duplicate collector_pct/owner_pct variable declarations. Add set_incentive_tiers contract function with full validation:
    - max 5 tiers per incentive
    - tiers must be non-empty
    - tiers must be contiguous and sorted by min_weight_kg ascending
    - no overlapping ranges
    - last tier must be unbounded (max_weight_kg == 0)
    - each tier reward_points must be > 0
    - only the original rewarder may call this
    - incentive must be active
- tests/incentive_tiers_test.rs: 15 integration tests covering:
    - tiers stored and retrievable
    - correct tier selected for each weight range (first, middle, last)
    - flat-rate fallback when no tiers set
    - max-5-tiers enforcement
    - empty tiers rejection
    - overlapping/non-contiguous ranges rejection
    - last tier unbounded enforcement
    - zero reward_points rejection
    - only-creator access control
    - inactive incentive guard
    - single unbounded tier
    - tier overwrite
    - exact boundary weight routing

Closes #366