### PR TITLE
feat(ui): add search, notifications, profile, and incentives enhancements

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -11,12 +11,15 @@ import {
   History,
   Wallet,
   LogOut,
-  Recycle
+  Recycle,
+  User
 } from 'lucide-react'
 import { useWallet } from '@/context/WalletContext'
 import { useAuth } from '@/context/AuthContext'
 import { Button } from '@/components/ui/Button'
 import { ThemeToggle } from '@/components/ui/ThemeToggle'
+import { SearchBar } from '@/components/ui/SearchBar'
+import { NotificationBell } from '@/components/ui/NotificationBell'
 import { cn } from '@/lib/utils'
 
 const NAV_LINKS = [
@@ -47,6 +50,12 @@ const NAV_LINKS = [
     href: '/history',
     roles: ['Recycler', 'Collector', 'Manufacturer'],
     icon: History
+  },
+  {
+    label: 'Profile',
+    href: '/profile',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: User
   }
 ]
 
@@ -105,7 +114,12 @@ export function AppShell({ children }: PropsWithChildren) {
         <header className="flex h-14 items-center justify-between border-b px-4">
           <span className="text-sm font-medium md:hidden">Scavngr</span>
 
+          <div className="mx-4 hidden flex-1 md:flex">
+            <SearchBar />
+          </div>
+
           <div className="ml-auto flex items-center gap-3">
+            <NotificationBell />
             <ThemeToggle className="shrink-0" />
 
             {isConnected && address ? (
@@ -133,7 +147,7 @@ export function AppShell({ children }: PropsWithChildren) {
       {/* Mobile bottom navigation */}
       <nav className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden">
         <div className="flex min-h-16 items-center justify-around gap-1 px-2 py-1">
-          {links.slice(0, 5).map((link) => {
+          {links.filter((l) => l.href !== '/profile').slice(0, 4).map((link) => {
             const Icon = link.icon
             return (
               <NavLink
@@ -151,6 +165,18 @@ export function AppShell({ children }: PropsWithChildren) {
               </NavLink>
             )
           })}
+          <NavLink
+            to="/profile"
+            className={({ isActive }) =>
+              cn(
+                'flex min-h-12 min-w-[3.5rem] flex-1 flex-col items-center justify-center rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
+              )
+            }
+          >
+            <User className="mb-0.5 h-5 w-5" />
+            <span className="truncate">Profile</span>
+          </NavLink>
         </div>
       </nav>
     </div>

--- a/frontend/src/components/ui/IncentiveDetailModal.tsx
+++ b/frontend/src/components/ui/IncentiveDetailModal.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { CheckCircle, Loader2 } from 'lucide-react'
+import { Incentive } from '@/api/types'
+import { Role } from '@/api/types'
+import { useAuth } from '@/context/AuthContext'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { formatAddress, wasteTypeLabel, formatDate } from '@/lib/helpers'
+
+interface IncentiveDetailModalProps {
+  incentive: Incentive | null
+  open: boolean
+  onClose: () => void
+  onClaim: (incentiveId: number) => Promise<void>
+  isClaiming?: boolean
+}
+
+export function IncentiveDetailModal({
+  incentive,
+  open,
+  onClose,
+  onClaim,
+  isClaiming = false,
+}: IncentiveDetailModalProps) {
+  const { user } = useAuth()
+  const [confirmStep, setConfirmStep] = useState(false)
+
+  const canClaim =
+    user?.role === Role.Recycler || user?.role === Role.Collector
+
+  function handleClose() {
+    setConfirmStep(false)
+    onClose()
+  }
+
+  async function handleConfirmClaim() {
+    if (!incentive) return
+    await onClaim(incentive.id)
+    setConfirmStep(false)
+    onClose()
+  }
+
+  if (!incentive) return null
+
+  const budgetPercent =
+    incentive.total_budget > 0
+      ? Math.round((incentive.remaining_budget / incentive.total_budget) * 100)
+      : 0
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            Incentive #{incentive.id}
+            <Badge variant={incentive.active ? 'default' : 'secondary'}>
+              {incentive.active ? 'Active' : 'Inactive'}
+            </Badge>
+          </DialogTitle>
+          <DialogDescription>
+            Full details for this incentive offer
+          </DialogDescription>
+        </DialogHeader>
+
+        {!confirmStep ? (
+          <>
+            <div className="space-y-3 text-sm">
+              <Row label="Waste Type" value={wasteTypeLabel(incentive.waste_type)} />
+              <Row label="Rewarder" value={
+                <span className="font-mono text-xs break-all">{incentive.rewarder}</span>
+              } />
+              <Row label="Reward Points" value={`${Number(incentive.reward_points).toLocaleString()} pts`} />
+              <Row label="Total Budget" value={`${Number(incentive.total_budget).toLocaleString()}`} />
+              <Row label="Remaining Budget" value={`${Number(incentive.remaining_budget).toLocaleString()}`} />
+              <Row label="Created" value={formatDate(incentive.created_at)} />
+
+              {/* Budget bar */}
+              <div className="space-y-1 pt-1">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary transition-all"
+                    style={{ width: `${budgetPercent}%` }}
+                    role="progressbar"
+                    aria-valuenow={budgetPercent}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="Budget remaining"
+                  />
+                </div>
+                <p className="text-right text-xs text-muted-foreground">{budgetPercent}% remaining</p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={handleClose}>
+                Close
+              </Button>
+              {canClaim && incentive.active && (
+                <Button onClick={() => setConfirmStep(true)}>
+                  Claim
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <div className="flex flex-col items-center gap-3 py-4 text-center">
+              <CheckCircle className="h-10 w-10 text-primary" />
+              <p className="font-medium">Confirm Claim</p>
+              <p className="text-sm text-muted-foreground">
+                Are you sure you want to claim incentive #{incentive.id} for{' '}
+                <strong>{wasteTypeLabel(incentive.waste_type)}</strong>?
+                You will earn{' '}
+                <strong>{Number(incentive.reward_points).toLocaleString()} pts</strong>.
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setConfirmStep(false)} disabled={isClaiming}>
+                Back
+              </Button>
+              <Button onClick={handleConfirmClaim} disabled={isClaiming}>
+                {isClaiming ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Claiming…
+                  </>
+                ) : (
+                  'Confirm Claim'
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/NotificationBell.tsx
+++ b/frontend/src/components/ui/NotificationBell.tsx
@@ -1,0 +1,54 @@
+import { useState, useRef } from 'react'
+import { Bell } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { NotificationPanel } from '@/components/ui/NotificationPanel'
+import { useNotifications } from '@/hooks/useNotifications'
+import { useWallet } from '@/context/WalletContext'
+import { cn } from '@/lib/utils'
+
+interface NotificationBellProps {
+  className?: string
+}
+
+export function NotificationBell({ className }: NotificationBellProps) {
+  const { address } = useWallet()
+  const { notifications, unreadCount, markRead, markAllRead, deleteNotification } =
+    useNotifications(address)
+  const [open, setOpen] = useState(false)
+  const bellRef = useRef<HTMLDivElement>(null)
+
+  const badgeLabel = unreadCount > 99 ? '99+' : String(unreadCount)
+  const showBadge = unreadCount > 0
+
+  return (
+    <div ref={bellRef} className={cn('relative', className)}>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        aria-label={`Notifications${showBadge ? `, ${badgeLabel} unread` : ''}`}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <Bell className="h-4 w-4" />
+        {showBadge && (
+          <span
+            className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-0.5 text-[10px] font-bold leading-none text-destructive-foreground"
+            aria-hidden="true"
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </Button>
+
+      {open && (
+        <NotificationPanel
+          notifications={notifications}
+          onClose={() => setOpen(false)}
+          onMarkRead={markRead}
+          onMarkAllRead={markAllRead}
+          onDelete={deleteNotification}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/NotificationPanel.tsx
+++ b/frontend/src/components/ui/NotificationPanel.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { Bell, CheckCircle, Coins, Info, X, Settings } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { cn } from '@/lib/utils'
+import type { Notification, NotificationType } from '@/lib/notifications'
+
+// ---------------------------------------------------------------------------
+// Helpers (pure — also used by property tests)
+// ---------------------------------------------------------------------------
+
+/** Returns the display label for the unread badge. */
+export function getBadgeLabel(unreadCount: number): string {
+  return unreadCount > 99 ? '99+' : String(unreadCount)
+}
+
+/** Returns the capped badge count value (max 99). */
+export function getBadgeCount(unreadCount: number): number {
+  return Math.min(unreadCount, 99)
+}
+
+/** Sorts notifications descending by createdAt and caps at 20. */
+export function getPanelNotifications(notifications: Notification[]): Notification[] {
+  return [...notifications].sort((a, b) => b.createdAt - a.createdAt).slice(0, 20)
+}
+
+/** Returns a relative timestamp string for a given Unix ms timestamp. */
+export function getRelativeTimestamp(createdAt: number): string {
+  const diffMs = Date.now() - createdAt
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} min ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr} hr ago`
+  const diffDays = Math.floor(diffHr / 24)
+  return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`
+}
+
+/** Returns the icon component name for a notification type. */
+export function getTypeIconName(type: NotificationType): string {
+  switch (type) {
+    case 'transfer':
+      return 'Bell'
+    case 'confirmation':
+      return 'CheckCircle'
+    case 'reward':
+      return 'Coins'
+    case 'system':
+    default:
+      return 'Info'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Type icon component
+// ---------------------------------------------------------------------------
+
+function TypeIcon({ type, className }: { type: NotificationType; className?: string }) {
+  const cls = cn('h-4 w-4 shrink-0', className)
+  switch (type) {
+    case 'transfer':
+      return <Bell className={cls} />
+    case 'confirmation':
+      return <CheckCircle className={cls} />
+    case 'reward':
+      return <Coins className={cls} />
+    case 'system':
+    default:
+      return <Info className={cls} />
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NotificationPanel
+// ---------------------------------------------------------------------------
+
+interface NotificationPanelProps {
+  notifications: Notification[]
+  onClose: () => void
+  onMarkRead: (id: string) => Promise<void>
+  onMarkAllRead: () => Promise<void>
+  onDelete: (id: string) => Promise<void>
+}
+
+export function NotificationPanel({
+  notifications,
+  onClose,
+  onMarkRead,
+  onMarkAllRead,
+  onDelete,
+}: NotificationPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const items = getPanelNotifications(notifications)
+
+  // Click-outside closes the panel
+  useEffect(() => {
+    function handleMouseDown(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [onClose])
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label="Notifications"
+      className="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border bg-popover text-popover-foreground shadow-lg sm:w-96"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <span className="text-sm font-semibold">Notifications</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-2 py-1 text-xs"
+          onClick={() => void onMarkAllRead()}
+        >
+          Mark all as read
+        </Button>
+      </div>
+
+      {/* List */}
+      <ul className="max-h-96 overflow-y-auto divide-y">
+        {items.length === 0 ? (
+          <li className="px-4 py-6 text-center text-sm text-muted-foreground">
+            No notifications
+          </li>
+        ) : (
+          items.map((n) => (
+            <li
+              key={n.id}
+              className={cn(
+                'flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors hover:bg-accent',
+                !n.read && 'bg-accent/30'
+              )}
+              onClick={() => void onMarkRead(n.id)}
+            >
+              <TypeIcon
+                type={n.type}
+                className={cn(
+                  'mt-0.5',
+                  n.type === 'transfer' && 'text-blue-500',
+                  n.type === 'confirmation' && 'text-green-500',
+                  n.type === 'reward' && 'text-yellow-500',
+                  n.type === 'system' && 'text-muted-foreground'
+                )}
+              />
+              <div className="min-w-0 flex-1">
+                <p className={cn('truncate text-sm font-medium', !n.read && 'font-semibold')}>
+                  {n.title}
+                  {n.count > 1 && (
+                    <span className="ml-1 text-xs text-muted-foreground">×{n.count}</span>
+                  )}
+                </p>
+                <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{n.body}</p>
+                <p className="mt-1 text-[10px] text-muted-foreground">
+                  {getRelativeTimestamp(n.createdAt)}
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Delete notification"
+                className="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  void onDelete(n.id)
+                }}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))
+        )}
+      </ul>
+
+      {/* Footer */}
+      <div className="border-t px-4 py-2">
+        <Link
+          to="/settings"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+          onClick={onClose}
+        >
+          <Settings className="h-3.5 w-3.5" />
+          Notification preferences →
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/SearchBar.test.ts
+++ b/frontend/src/components/ui/SearchBar.test.ts
@@ -1,0 +1,80 @@
+// Feature: frontend-enhancements, Property 8: Search preview capped at 5 results
+// Validates: Requirements 6.7
+
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import type { SearchResult } from '@/lib/searchStorage'
+
+/**
+ * The SearchBar caps the inline results dropdown at exactly MAX_PREVIEW (5) entries.
+ * This pure function mirrors the slicing logic in SearchBar.tsx.
+ */
+const MAX_PREVIEW = 5
+
+function getPreviewResults(results: SearchResult[]): SearchResult[] {
+  return results.slice(0, MAX_PREVIEW)
+}
+
+// Arbitrary for a single SearchResult
+const searchResultArb = fc.record({
+  type: fc.constantFrom('waste' as const, 'participant' as const),
+  id: fc.string({ minLength: 1, maxLength: 20 }),
+  label: fc.string({ minLength: 1, maxLength: 50 }),
+  sublabel: fc.string({ minLength: 0, maxLength: 80 }),
+  data: fc.constant({}),
+})
+
+describe('SearchBar — Property 8: search preview capped at 5 results', () => {
+  it('renders at most 5 results regardless of how many matches exist', () => {
+    fc.assert(
+      fc.property(
+        // Generate arrays with more than 5 results to exercise the cap
+        fc.array(searchResultArb, { minLength: 6, maxLength: 50 }),
+        (results) => {
+          const preview = getPreviewResults(results)
+          return preview.length <= MAX_PREVIEW
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('renders exactly 5 results when more than 5 matches exist', () => {
+    fc.assert(
+      fc.property(
+        fc.array(searchResultArb, { minLength: 6, maxLength: 50 }),
+        (results) => {
+          const preview = getPreviewResults(results)
+          return preview.length === MAX_PREVIEW
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('renders all results when fewer than 5 matches exist', () => {
+    fc.assert(
+      fc.property(
+        fc.array(searchResultArb, { minLength: 0, maxLength: MAX_PREVIEW - 1 }),
+        (results) => {
+          const preview = getPreviewResults(results)
+          return preview.length === results.length
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('preview is always a prefix of the original results array', () => {
+    fc.assert(
+      fc.property(
+        fc.array(searchResultArb, { minLength: 0, maxLength: 30 }),
+        (results) => {
+          const preview = getPreviewResults(results)
+          return preview.every((item, idx) => item === results[idx])
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})

--- a/frontend/src/components/ui/SearchBar.tsx
+++ b/frontend/src/components/ui/SearchBar.tsx
@@ -1,0 +1,169 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Search, Clock, Package, User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { getSearchHistory, addSearchHistory } from '@/lib/searchStorage'
+import { useSearch, useDebounce } from '@/hooks/useSearch'
+import type { SearchResult } from '@/lib/searchStorage'
+
+const MAX_PREVIEW = 5
+const MAX_HISTORY = 5
+
+export function SearchBar() {
+  const navigate = useNavigate()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const [query, setQuery] = useState('')
+  const [isFocused, setIsFocused] = useState(false)
+  const [history, setHistory] = useState<string[]>([])
+
+  const debouncedQuery = useDebounce(query, 300)
+  const results = useSearch(debouncedQuery)
+
+  // Load history when dropdown opens
+  useEffect(() => {
+    if (isFocused) {
+      setHistory(getSearchHistory().slice(0, MAX_HISTORY))
+    }
+  }, [isFocused])
+
+  // Keyboard shortcuts: Cmd+K / Ctrl+K to focus, Escape to clear+blur
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        inputRef.current?.focus()
+      }
+      if (e.key === 'Escape' && document.activeElement === inputRef.current) {
+        setQuery('')
+        inputRef.current?.blur()
+        setIsFocused(false)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsFocused(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleSelect = useCallback(
+    (selectedQuery: string) => {
+      addSearchHistory(selectedQuery)
+      setQuery(selectedQuery)
+      setIsFocused(false)
+      navigate(`/search?q=${encodeURIComponent(selectedQuery)}`)
+    },
+    [navigate]
+  )
+
+  const handleKeyDownInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && query.trim()) {
+      handleSelect(query.trim())
+    }
+  }
+
+  const previewResults = results.slice(0, MAX_PREVIEW)
+  const showDropdown = isFocused && (query === '' ? history.length > 0 : previewResults.length > 0)
+
+  return (
+    <div ref={containerRef} className="relative w-full max-w-sm">
+      {/* Input */}
+      <div className="relative flex items-center">
+        <Search className="pointer-events-none absolute left-3 h-4 w-4 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onKeyDown={handleKeyDownInput}
+          placeholder="Search… (⌘K)"
+          aria-label="Search"
+          className={cn(
+            'h-9 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm',
+            'placeholder:text-muted-foreground',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+          )}
+        />
+      </div>
+
+      {/* Dropdown */}
+      {showDropdown && (
+        <div
+          role="listbox"
+          aria-label="Search suggestions"
+          className="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-md border bg-popover shadow-md"
+        >
+          {query === '' ? (
+            // History entries
+            <>
+              <p className="px-3 py-1.5 text-xs font-medium text-muted-foreground">Recent</p>
+              {history.map((entry) => (
+                <button
+                  key={entry}
+                  role="option"
+                  aria-selected={false}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    handleSelect(entry)
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
+                >
+                  <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{entry}</span>
+                </button>
+              ))}
+            </>
+          ) : (
+            // Inline results
+            previewResults.map((result) => (
+              <SearchResultItem
+                key={`${result.type}-${result.id}`}
+                result={result}
+                onSelect={() => handleSelect(query.trim())}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SearchResultItem({
+  result,
+  onSelect,
+}: {
+  result: SearchResult
+  onSelect: () => void
+}) {
+  const Icon = result.type === 'waste' ? Package : User
+
+  return (
+    <button
+      role="option"
+      aria-selected={false}
+      onMouseDown={(e) => {
+        e.preventDefault()
+        onSelect()
+      }}
+      className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1 text-left">
+        <p className="truncate font-medium">{result.label}</p>
+        <p className="truncate text-xs text-muted-foreground">{result.sublabel}</p>
+      </div>
+    </button>
+  )
+}

--- a/frontend/src/components/ui/SearchPanel.test.ts
+++ b/frontend/src/components/ui/SearchPanel.test.ts
@@ -1,0 +1,125 @@
+// Feature: frontend-enhancements, Property 11: Active filter count matches applied filters
+// Validates: Requirements 7.4
+
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import { WasteType } from '@/api/types'
+import { countActiveFilters, DEFAULT_FILTERS } from '@/components/ui/SearchPanel'
+import type { SearchFilters } from '@/lib/searchStorage'
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+const wasteTypeArb = fc.constantFrom(
+  WasteType.Paper,
+  WasteType.PetPlastic,
+  WasteType.Plastic,
+  WasteType.Metal,
+  WasteType.Glass
+)
+
+const statusArb = fc.constantFrom(
+  'all' as const,
+  'active' as const,
+  'confirmed' as const,
+  'inactive' as const
+)
+
+const isoDateArb = fc
+  .integer({ min: 2020, max: 2030 })
+  .chain((year) =>
+    fc.integer({ min: 1, max: 12 }).chain((month) =>
+      fc.integer({ min: 1, max: 28 }).map((day) => {
+        const mm = String(month).padStart(2, '0')
+        const dd = String(day).padStart(2, '0')
+        return `${year}-${mm}-${dd}`
+      })
+    )
+  )
+
+const searchFiltersArb: fc.Arbitrary<SearchFilters> = fc.record({
+  wasteTypes: fc.array(wasteTypeArb, { minLength: 0, maxLength: 5 }),
+  status: statusArb,
+  dateFrom: fc.option(isoDateArb, { nil: null }),
+  dateTo: fc.option(isoDateArb, { nil: null }),
+  location: fc.string({ minLength: 0, maxLength: 50 }),
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SearchPanel — Property 11: active filter count matches applied filters', () => {
+  it('default filters produce a count of 0', () => {
+    expect(countActiveFilters(DEFAULT_FILTERS)).toBe(0)
+  })
+
+  it('count equals the number of fields that differ from defaults', () => {
+    fc.assert(
+      fc.property(searchFiltersArb, (filters) => {
+        const expected =
+          (filters.wasteTypes.length > 0 ? 1 : 0) +
+          (filters.status !== 'all' ? 1 : 0) +
+          (filters.dateFrom !== null ? 1 : 0) +
+          (filters.dateTo !== null ? 1 : 0) +
+          (filters.location.trim() !== '' ? 1 : 0)
+
+        return countActiveFilters(filters) === expected
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('count is always between 0 and 5 (one per filter field)', () => {
+    fc.assert(
+      fc.property(searchFiltersArb, (filters) => {
+        const count = countActiveFilters(filters)
+        return count >= 0 && count <= 5
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('count is non-negative for any filter state', () => {
+    fc.assert(
+      fc.property(searchFiltersArb, (filters) => {
+        return countActiveFilters(filters) >= 0
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('each individual filter field contributes exactly 1 to the count when active', () => {
+    // wasteTypes
+    expect(countActiveFilters({ ...DEFAULT_FILTERS, wasteTypes: [WasteType.Paper] })).toBe(1)
+    // status
+    expect(countActiveFilters({ ...DEFAULT_FILTERS, status: 'active' })).toBe(1)
+    // dateFrom
+    expect(countActiveFilters({ ...DEFAULT_FILTERS, dateFrom: '2024-01-01' })).toBe(1)
+    // dateTo
+    expect(countActiveFilters({ ...DEFAULT_FILTERS, dateTo: '2024-12-31' })).toBe(1)
+    // location
+    expect(countActiveFilters({ ...DEFAULT_FILTERS, location: 'Lagos' })).toBe(1)
+  })
+
+  it('all five fields active produces count of 5', () => {
+    const allActive: SearchFilters = {
+      wasteTypes: [WasteType.Metal],
+      status: 'confirmed',
+      dateFrom: '2024-01-01',
+      dateTo: '2024-12-31',
+      location: 'Nairobi',
+    }
+    expect(countActiveFilters(allActive)).toBe(5)
+  })
+
+  it('location with only whitespace is treated as default (not active)', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^\s+$/),
+        (whitespaceOnly) => {
+          const filters: SearchFilters = { ...DEFAULT_FILTERS, location: whitespaceOnly }
+          return countActiveFilters(filters) === 0
+        }
+      ),
+      { numRuns: 50 }
+    )
+  })
+})

--- a/frontend/src/components/ui/SearchPanel.tsx
+++ b/frontend/src/components/ui/SearchPanel.tsx
@@ -1,0 +1,333 @@
+import React, { useState, useCallback } from 'react'
+import { ChevronDown, ChevronUp, X, Save, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Input } from '@/components/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  getFilterPresets,
+  saveFilterPreset,
+  deleteFilterPreset,
+} from '@/lib/searchStorage'
+import type { SearchFilters, FilterPreset } from '@/lib/searchStorage'
+import { WasteType } from '@/api/types'
+
+// ─── Default filter state ────────────────────────────────────────────────────
+
+export const DEFAULT_FILTERS: SearchFilters = {
+  wasteTypes: [],
+  status: 'all',
+  dateFrom: null,
+  dateTo: null,
+  location: '',
+}
+
+// ─── Pure helper: count active filters ───────────────────────────────────────
+
+/**
+ * Returns the number of filter fields that differ from their default values.
+ * This is a pure function — no side effects, no React hooks.
+ */
+export function countActiveFilters(filters: SearchFilters): number {
+  let count = 0
+  if (filters.wasteTypes.length > 0) count++
+  if (filters.status !== DEFAULT_FILTERS.status) count++
+  if (filters.dateFrom !== null) count++
+  if (filters.dateTo !== null) count++
+  if (filters.location.trim() !== '') count++
+  return count
+}
+
+// ─── Waste type options ───────────────────────────────────────────────────────
+
+const WASTE_TYPE_OPTIONS: { value: WasteType; label: string }[] = [
+  { value: WasteType.Paper, label: 'Paper' },
+  { value: WasteType.PetPlastic, label: 'PET Plastic' },
+  { value: WasteType.Plastic, label: 'Plastic' },
+  { value: WasteType.Metal, label: 'Metal' },
+  { value: WasteType.Glass, label: 'Glass' },
+]
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface SearchPanelProps {
+  filters: SearchFilters
+  onChange: (filters: SearchFilters) => void
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SearchPanel({ filters, onChange }: SearchPanelProps) {
+  const [open, setOpen] = useState(false)
+  const [presets, setPresets] = useState<FilterPreset[]>(() => getFilterPresets())
+  const [presetName, setPresetName] = useState('')
+  const [showPresetInput, setShowPresetInput] = useState(false)
+
+  const activeCount = countActiveFilters(filters)
+
+  // ── Toggle waste type ──────────────────────────────────────────────────────
+  const toggleWasteType = useCallback(
+    (wt: WasteType) => {
+      const next = filters.wasteTypes.includes(wt)
+        ? filters.wasteTypes.filter((t) => t !== wt)
+        : [...filters.wasteTypes, wt]
+      onChange({ ...filters, wasteTypes: next })
+    },
+    [filters, onChange]
+  )
+
+  // ── Clear all ──────────────────────────────────────────────────────────────
+  const clearAll = useCallback(() => {
+    onChange({ ...DEFAULT_FILTERS })
+  }, [onChange])
+
+  // ── Save preset ───────────────────────────────────────────────────────────
+  const handleSavePreset = useCallback(() => {
+    const name = presetName.trim()
+    if (!name) return
+    const preset: FilterPreset = {
+      id: `preset_${Date.now()}`,
+      name,
+      filters: { ...filters },
+    }
+    saveFilterPreset(preset)
+    const updated = getFilterPresets()
+    setPresets(updated)
+    setPresetName('')
+    setShowPresetInput(false)
+  }, [presetName, filters])
+
+  // ── Delete preset ─────────────────────────────────────────────────────────
+  const handleDeletePreset = useCallback((id: string) => {
+    deleteFilterPreset(id)
+    setPresets(getFilterPresets())
+  }, [])
+
+  // ── Apply preset ──────────────────────────────────────────────────────────
+  const handleApplyPreset = useCallback(
+    (preset: FilterPreset) => {
+      onChange({ ...preset.filters })
+    },
+    [onChange]
+  )
+
+  return (
+    <div className="w-full">
+      {/* Toggle button */}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls="search-panel"
+        className="flex items-center gap-2"
+      >
+        {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        Advanced Filters
+        {activeCount > 0 && (
+          <Badge variant="default" className="ml-1 h-5 min-w-5 px-1.5 text-xs">
+            {activeCount}
+          </Badge>
+        )}
+      </Button>
+
+      {/* Collapsible panel */}
+      {open && (
+        <div
+          id="search-panel"
+          className="mt-2 rounded-lg border bg-card p-4 shadow-sm"
+          data-testid="search-panel"
+        >
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {/* WasteType multi-select */}
+            <fieldset className="space-y-2">
+              <legend className="text-sm font-medium">Waste Type</legend>
+              <div className="space-y-1">
+                {WASTE_TYPE_OPTIONS.map(({ value, label }) => (
+                  <label key={value} className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={filters.wasteTypes.includes(value)}
+                      onChange={() => toggleWasteType(value)}
+                      className="h-4 w-4 rounded border-input accent-primary"
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Status select */}
+            <div className="space-y-2">
+              <label htmlFor="filter-status" className="text-sm font-medium">
+                Status
+              </label>
+              <Select
+                value={filters.status}
+                onValueChange={(v) =>
+                  onChange({
+                    ...filters,
+                    status: v as SearchFilters['status'],
+                  })
+                }
+              >
+                <SelectTrigger id="filter-status" className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All</SelectItem>
+                  <SelectItem value="active">Active</SelectItem>
+                  <SelectItem value="confirmed">Confirmed</SelectItem>
+                  <SelectItem value="inactive">Inactive</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Date range */}
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Date Range</span>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="filter-date-from" className="sr-only">
+                  From date
+                </label>
+                <Input
+                  id="filter-date-from"
+                  type="date"
+                  placeholder="From"
+                  value={filters.dateFrom ?? ''}
+                  onChange={(e) =>
+                    onChange({ ...filters, dateFrom: e.target.value || null })
+                  }
+                  className="h-9"
+                />
+                <label htmlFor="filter-date-to" className="sr-only">
+                  To date
+                </label>
+                <Input
+                  id="filter-date-to"
+                  type="date"
+                  placeholder="To"
+                  value={filters.dateTo ?? ''}
+                  onChange={(e) =>
+                    onChange({ ...filters, dateTo: e.target.value || null })
+                  }
+                  className="h-9"
+                />
+              </div>
+            </div>
+
+            {/* Location */}
+            <div className="space-y-2">
+              <label htmlFor="filter-location" className="text-sm font-medium">
+                Location
+              </label>
+              <Input
+                id="filter-location"
+                type="text"
+                placeholder="Enter location…"
+                value={filters.location}
+                onChange={(e) => onChange({ ...filters, location: e.target.value })}
+                className="h-9"
+              />
+            </div>
+          </div>
+
+          {/* Actions row */}
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearAll}
+              className="flex items-center gap-1 text-muted-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+              Clear all
+            </Button>
+
+            {!showPresetInput ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowPresetInput(true)}
+                className="flex items-center gap-1"
+              >
+                <Save className="h-3.5 w-3.5" />
+                Save as preset
+              </Button>
+            ) : (
+              <div className="flex items-center gap-1">
+                <Input
+                  type="text"
+                  placeholder="Preset name…"
+                  value={presetName}
+                  onChange={(e) => setPresetName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSavePreset()
+                    if (e.key === 'Escape') {
+                      setShowPresetInput(false)
+                      setPresetName('')
+                    }
+                  }}
+                  className="h-8 w-40 text-sm"
+                  autoFocus
+                />
+                <Button size="sm" onClick={handleSavePreset} disabled={!presetName.trim()}>
+                  Save
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowPresetInput(false)
+                    setPresetName('')
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* Saved presets */}
+          {presets.length > 0 && (
+            <div className="mt-4 space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">Saved presets</p>
+              <ul className="space-y-1">
+                {presets.map((preset) => (
+                  <li
+                    key={preset.id}
+                    className={cn(
+                      'flex items-center justify-between rounded-md px-2 py-1',
+                      'border border-transparent hover:border-border hover:bg-accent'
+                    )}
+                  >
+                    <button
+                      className="flex-1 text-left text-sm"
+                      onClick={() => handleApplyPreset(preset)}
+                    >
+                      {preset.name}
+                    </button>
+                    <button
+                      aria-label={`Delete preset ${preset.name}`}
+                      onClick={() => handleDeletePreset(preset.id)}
+                      className="ml-2 text-muted-foreground hover:text-destructive"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useIncentivesClaim.ts
+++ b/frontend/src/hooks/useIncentivesClaim.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Incentive } from '@/api/types'
+import { useToast } from '@/hooks/useToast'
+
+/**
+ * Mutation hook for claiming an incentive.
+ *
+ * Optimistically decrements `remaining_budget` in the TanStack Query cache
+ * for the `['incentives', 'all']` query key. On error, rolls back to the
+ * previous cache snapshot and shows an error toast.
+ */
+export function useIncentivesClaim() {
+  const queryClient = useQueryClient()
+  const toast = useToast()
+
+  const mutation = useMutation<void, Error, number, { previousIncentives: Incentive[] | undefined }>({
+    mutationFn: async (_incentiveId: number) => {
+      // The actual on-chain claim is handled by distributeRewards in the contract.
+      // Here we simulate the claim action — in a real integration this would call
+      // ScavengerClient.distributeRewards or a dedicated claim endpoint.
+      // For now we resolve immediately; the optimistic update handles the UI.
+      return Promise.resolve()
+    },
+
+    onMutate: async (incentiveId: number) => {
+      // Cancel any in-flight refetches so they don't overwrite our optimistic update
+      await queryClient.cancelQueries({ queryKey: ['incentives', 'all'] })
+
+      // Snapshot the previous value for rollback
+      const previousIncentives = queryClient.getQueryData<Incentive[]>(['incentives', 'all'])
+
+      // Optimistically decrement remaining_budget
+      queryClient.setQueryData<Incentive[]>(['incentives', 'all'], (old) => {
+        if (!old) return old
+        return old.map((inc) =>
+          inc.id === incentiveId
+            ? { ...inc, remaining_budget: Math.max(0, inc.remaining_budget - 1) }
+            : inc
+        )
+      })
+
+      return { previousIncentives }
+    },
+
+    onError: (_err, _incentiveId, context) => {
+      // Roll back to the snapshot
+      if (context?.previousIncentives !== undefined) {
+        queryClient.setQueryData(['incentives', 'all'], context.previousIncentives)
+      }
+      toast.error('Failed to claim incentive. Please try again.')
+    },
+
+    onSettled: () => {
+      // Always refetch after error or success to sync with server
+      queryClient.invalidateQueries({ queryKey: ['incentives'] })
+    },
+  })
+
+  return {
+    claimIncentive: (incentiveId: number) => mutation.mutateAsync(incentiveId),
+    isClaiming: mutation.isPending,
+  }
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,108 @@
+import { useState, useEffect, useRef } from 'react'
+import { onSnapshot, collection, orderBy, limit, query } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { NotificationStore, type Notification } from '@/lib/notifications'
+
+const MAX_NOTIFICATIONS = 20
+const UNREAD_CAP = 99
+
+export function useNotifications(walletAddress: string | null | undefined) {
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const storeRef = useRef<NotificationStore | null>(null)
+
+  // Create/update store when walletAddress changes
+  useEffect(() => {
+    if (!walletAddress) {
+      setNotifications([])
+      storeRef.current = null
+      return
+    }
+
+    storeRef.current = new NotificationStore(walletAddress)
+
+    let unsubscribe: (() => void) | null = null
+    let pollInterval: ReturnType<typeof setInterval> | null = null
+
+    try {
+      const col = collection(db, 'notifications', walletAddress, 'items')
+      const q = query(col, orderBy('createdAt', 'desc'), limit(MAX_NOTIFICATIONS))
+
+      unsubscribe = onSnapshot(
+        q,
+        (snapshot) => {
+          const items: Notification[] = snapshot.docs.map((d) => d.data() as Notification)
+          setNotifications(items)
+        },
+        (_err) => {
+          // Firebase unavailable — fall back to localStorage polling
+          if (unsubscribe) {
+            unsubscribe()
+            unsubscribe = null
+          }
+          startLocalStoragePolling()
+        }
+      )
+    } catch {
+      startLocalStoragePolling()
+    }
+
+    function startLocalStoragePolling() {
+      const lsKey = `scavngr_notifications_${walletAddress}`
+      const readFromLS = () => {
+        try {
+          const raw = localStorage.getItem(lsKey)
+          const items: Notification[] = raw ? (JSON.parse(raw) as Notification[]) : []
+          const sorted = [...items]
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .slice(0, MAX_NOTIFICATIONS)
+          setNotifications(sorted)
+        } catch {
+          setNotifications([])
+        }
+      }
+      readFromLS()
+      pollInterval = setInterval(readFromLS, 3000)
+    }
+
+    return () => {
+      if (unsubscribe) unsubscribe()
+      if (pollInterval) clearInterval(pollInterval)
+    }
+  }, [walletAddress])
+
+  const unreadCount = Math.min(
+    notifications.filter((n) => !n.read).length,
+    UNREAD_CAP
+  )
+
+  const markRead = async (id: string): Promise<void> => {
+    if (!storeRef.current) return
+    await storeRef.current.markRead(id)
+  }
+
+  const markAllRead = async (): Promise<void> => {
+    if (!storeRef.current) return
+    await storeRef.current.markAllRead()
+  }
+
+  const deleteNotification = async (id: string): Promise<void> => {
+    if (!storeRef.current) return
+    await storeRef.current.delete(id)
+  }
+
+  const addNotification = async (
+    n: Omit<Notification, 'id' | 'read' | 'count'>
+  ): Promise<void> => {
+    if (!storeRef.current) return
+    await storeRef.current.add(n)
+  }
+
+  return {
+    notifications,
+    unreadCount,
+    markRead,
+    markAllRead,
+    deleteNotification,
+    addNotification,
+  }
+}

--- a/frontend/src/hooks/useProfileStats.ts
+++ b/frontend/src/hooks/useProfileStats.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query'
+import { ScavengerClient } from '@/api/client'
+import { ParticipantStats, Waste } from '@/api/types'
+import { useWallet } from '@/context/WalletContext'
+import { useContract } from '@/context/ContractContext'
+import { networkConfig } from '@/lib/stellar'
+
+export function useProfileStats() {
+  const { address } = useWallet()
+  const { config } = useContract()
+
+  const { data: stats, isLoading: isLoadingStats, isError: isStatsError } = useQuery<ParticipantStats | null>({
+    queryKey: ['participant-stats', address],
+    queryFn: async () => {
+      if (!address) return null
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+      return client.getStats(address)
+    },
+    enabled: !!address,
+    retry: false,
+  })
+
+  const { data: wastes, isLoading: isLoadingWastes, isError: isWastesError } = useQuery<Waste[]>({
+    queryKey: ['participant-wastes', address],
+    queryFn: async () => {
+      if (!address) return []
+      const client = new ScavengerClient({
+        rpcUrl: config.rpcUrl,
+        networkPassphrase: networkConfig.networkPassphrase,
+        contractId: config.contractId,
+      })
+      const wasteIds = await client.getParticipantWastes(address)
+      const results = await Promise.all(wasteIds.map((id) => client.getWaste(id)))
+      return results.filter((w): w is Waste => w !== null)
+    },
+    enabled: !!address,
+    retry: false,
+  })
+
+  return {
+    stats: stats ?? null,
+    wastes: wastes ?? [],
+    isLoadingStats,
+    isLoadingWastes,
+    isStatsError,
+    isWastesError,
+  }
+}

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -1,0 +1,98 @@
+import { useMemo, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import type { Participant, Waste } from '@/api/types'
+import type { SearchFilters, SearchResult } from '@/lib/searchStorage'
+
+// Simple debounce hook — delays the value by `delay` ms
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debounced
+}
+
+/**
+ * Client-side search over TanStack Query cached data.
+ * Reads participants and wastes from the query cache — no new network requests.
+ */
+export function useSearch(query: string, filters?: Partial<SearchFilters>): SearchResult[] {
+  const queryClient = useQueryClient()
+
+  return useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) return []
+
+    const results: SearchResult[] = []
+
+    // --- Search participants ---
+    const participantQueries = queryClient
+      .getQueriesData<Participant | null>({ queryKey: ['participant'] })
+
+    for (const [, participant] of participantQueries) {
+      if (!participant) continue
+
+      const nameMatch = participant.name.toLowerCase().includes(trimmed)
+      const addressMatch = participant.address.toLowerCase().includes(trimmed)
+
+      if (nameMatch || addressMatch) {
+        results.push({
+          type: 'participant',
+          id: participant.address,
+          label: participant.name,
+          sublabel: participant.address,
+          data: participant,
+        })
+      }
+    }
+
+    // --- Search wastes ---
+    // Wastes are cached under ['wastes', address, filters] and ['participant-wastes', address, filters]
+    const wasteQueryKeys = [
+      ...queryClient.getQueriesData<Waste[]>({ queryKey: ['wastes'] }),
+      ...queryClient.getQueriesData<Waste[]>({ queryKey: ['participant-wastes'] }),
+    ]
+
+    const seenWasteIds = new Set<string>()
+
+    for (const [, wastes] of wasteQueryKeys) {
+      if (!Array.isArray(wastes)) continue
+
+      for (const waste of wastes) {
+        const wasteIdStr = waste.waste_id.toString()
+        if (seenWasteIds.has(wasteIdStr)) continue
+
+        const idMatch = wasteIdStr.includes(trimmed)
+        const ownerMatch = waste.current_owner.toLowerCase().includes(trimmed)
+
+        // Apply status filter if provided
+        if (filters?.status && filters.status !== 'all') {
+          if (filters.status === 'active' && !waste.is_active) continue
+          if (filters.status === 'confirmed' && !waste.is_confirmed) continue
+          if (filters.status === 'inactive' && waste.is_active) continue
+        }
+
+        // Apply wasteType filter if provided
+        if (filters?.wasteTypes && filters.wasteTypes.length > 0) {
+          if (!filters.wasteTypes.includes(waste.waste_type)) continue
+        }
+
+        if (idMatch || ownerMatch) {
+          seenWasteIds.add(wasteIdStr)
+          results.push({
+            type: 'waste',
+            id: wasteIdStr,
+            label: `Waste #${wasteIdStr}`,
+            sublabel: waste.current_owner,
+            data: waste,
+          })
+        }
+      }
+    }
+
+    return results
+  }, [query, filters, queryClient])
+}

--- a/frontend/src/lib/incentivesUtils.ts
+++ b/frontend/src/lib/incentivesUtils.ts
@@ -1,0 +1,97 @@
+import type { Incentive, WasteType } from '@/api/types'
+
+export type SortField = 'reward_points' | 'remaining_budget' | 'waste_type'
+export type SortDir = 'asc' | 'desc'
+export type ViewMode = 'grid' | 'list'
+
+export interface IncentiveFilters {
+  wasteTypes: WasteType[]
+  rewarder: string
+}
+
+export const VIEW_STORAGE_KEY = 'scavngr_incentives_view'
+
+/**
+ * Sort a list of incentives by the given field and direction.
+ * Returns a new array — does not mutate the input.
+ */
+export function sortIncentives(
+  incentives: Incentive[],
+  field: SortField,
+  dir: SortDir
+): Incentive[] {
+  const sorted = [...incentives].sort((a, b) => {
+    let cmp = 0
+    if (field === 'reward_points') {
+      cmp = Number(a.reward_points) - Number(b.reward_points)
+    } else if (field === 'remaining_budget') {
+      cmp = Number(a.remaining_budget) - Number(b.remaining_budget)
+    } else {
+      // waste_type — numeric enum
+      cmp = a.waste_type - b.waste_type
+    }
+    return dir === 'asc' ? cmp : -cmp
+  })
+  return sorted
+}
+
+/**
+ * Filter a list of incentives by the given filters.
+ * Returns a new array — does not mutate the input.
+ */
+export function filterIncentives(
+  incentives: Incentive[],
+  filters: IncentiveFilters
+): Incentive[] {
+  return incentives.filter((inc) => {
+    if (filters.wasteTypes.length > 0 && !filters.wasteTypes.includes(inc.waste_type)) {
+      return false
+    }
+    if (
+      filters.rewarder.trim() !== '' &&
+      !inc.rewarder.toLowerCase().includes(filters.rewarder.trim().toLowerCase())
+    ) {
+      return false
+    }
+    return true
+  })
+}
+
+/** Read view mode from localStorage, defaulting to 'grid'. */
+export function readViewMode(): ViewMode {
+  try {
+    const stored = localStorage.getItem(VIEW_STORAGE_KEY)
+    if (stored === 'grid' || stored === 'list') return stored
+  } catch {
+    // ignore
+  }
+  return 'grid'
+}
+
+/** Persist view mode to localStorage. */
+export function writeViewMode(mode: ViewMode): void {
+  try {
+    localStorage.setItem(VIEW_STORAGE_KEY, mode)
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Comparison helpers ───────────────────────────────────────────────────────
+
+export const MAX_COMPARE = 3
+
+/**
+ * Toggle an incentive ID in the comparison set.
+ * Enforces a cap of MAX_COMPARE — attempting to add a 4th leaves the set unchanged.
+ * Returns a new Set — does not mutate the input.
+ */
+export function toggleCompareId(current: Set<number>, id: number): Set<number> {
+  if (current.has(id)) {
+    const next = new Set(current)
+    next.delete(id)
+    return next
+  }
+  if (current.size >= MAX_COMPARE) return current
+  return new Set([...current, id])
+}

--- a/frontend/src/lib/notifications.test.ts
+++ b/frontend/src/lib/notifications.test.ts
@@ -1,0 +1,411 @@
+// Feature: frontend-enhancements, Property 20: Mark-as-read updates read state
+// Feature: frontend-enhancements, Property 21: Notification batching within window
+// Validates: Requirements 14.1, 15.5
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fc from 'fast-check'
+import { NotificationStore, type Notification, type NotificationType } from './notifications'
+
+// ---------------------------------------------------------------------------
+// Mock Firebase so the store always falls through to the localStorage path
+// ---------------------------------------------------------------------------
+vi.mock('./firebase', () => ({
+  db: {},
+}))
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({})),
+  doc: vi.fn(() => ({})),
+  setDoc: vi.fn(() => Promise.reject(new Error('firebase unavailable'))),
+  updateDoc: vi.fn(() => Promise.reject(new Error('firebase unavailable'))),
+  deleteDoc: vi.fn(() => Promise.reject(new Error('firebase unavailable'))),
+  getDocs: vi.fn(() => Promise.reject(new Error('firebase unavailable'))),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  orderBy: vi.fn(() => ({})),
+  increment: vi.fn((n: number) => n),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WALLET = 'GTEST_WALLET_ADDRESS'
+const LS_KEY = `scavngr_notifications_${WALLET}`
+
+function lsLoad(): Notification[] {
+  const raw = localStorage.getItem(LS_KEY)
+  return raw ? (JSON.parse(raw) as Notification[]) : []
+}
+
+function lsSave(items: Notification[]): void {
+  localStorage.setItem(LS_KEY, JSON.stringify(items))
+}
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: `transfer_${Date.now()}`,
+    type: 'transfer',
+    title: 'Test',
+    body: 'Test body',
+    read: false,
+    createdAt: Date.now(),
+    count: 1,
+    ...overrides,
+  }
+}
+
+// Arbitrary for NotificationType
+const notifTypeArb = fc.constantFrom<NotificationType>(
+  'transfer',
+  'confirmation',
+  'reward',
+  'system'
+)
+
+// Arbitrary for a Notification
+const notifArb = fc.record<Notification>({
+  id: fc.string({ minLength: 1, maxLength: 30 }),
+  type: notifTypeArb,
+  title: fc.string({ minLength: 1, maxLength: 60 }),
+  body: fc.string({ minLength: 0, maxLength: 200 }),
+  read: fc.boolean(),
+  createdAt: fc.integer({ min: 0, max: Date.now() }),
+  count: fc.integer({ min: 1, max: 100 }),
+})
+
+// ---------------------------------------------------------------------------
+// Property 20: Mark-as-read updates read state
+// Validates: Requirements 14.1
+// ---------------------------------------------------------------------------
+
+describe('Property 20: Mark-as-read updates read state', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('markRead sets only the targeted notification to read=true, leaving others unchanged', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        // Generate a list of at least 1 notification; pick one index to mark as read
+        fc.array(notifArb, { minLength: 1, maxLength: 20 }).chain((notifs) => {
+          // Ensure unique IDs
+          const unique = notifs.map((n, i) => ({ ...n, id: `notif_${i}`, read: false }))
+          return fc.tuple(
+            fc.constant(unique),
+            fc.integer({ min: 0, max: unique.length - 1 })
+          )
+        }),
+        async ([notifs, targetIdx]) => {
+          // Seed localStorage
+          lsSave(notifs)
+
+          const store = new NotificationStore(WALLET)
+          const targetId = notifs[targetIdx].id
+
+          await store.markRead(targetId)
+
+          const after = lsLoad()
+
+          // The targeted notification must now be read
+          const target = after.find((n) => n.id === targetId)
+          if (!target) return false
+          if (!target.read) return false
+
+          // All other notifications must be unchanged
+          for (const original of notifs) {
+            if (original.id === targetId) continue
+            const updated = after.find((n) => n.id === original.id)
+            if (!updated) return false
+            if (updated.read !== original.read) return false
+          }
+
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('markRead on an already-read notification leaves it read', async () => {
+    const n = makeNotification({ read: true })
+    lsSave([n])
+
+    const store = new NotificationStore(WALLET)
+    await store.markRead(n.id)
+
+    const after = lsLoad()
+    expect(after[0].read).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Property 21: Notification batching within window
+// Validates: Requirements 15.5
+// ---------------------------------------------------------------------------
+
+describe('Property 21: Notification batching within window', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('two same-type notifications within 10 s produce exactly one entry with count=2', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        notifTypeArb,
+        fc.string({ minLength: 1, maxLength: 40 }),
+        async (type, title) => {
+          localStorage.clear()
+
+          const now = Date.now()
+          // First notification already in store (unread, within window)
+          const first: Notification = {
+            id: `${type}_${now - 1000}`,
+            type,
+            title,
+            body: 'first',
+            read: false,
+            createdAt: now - 1000, // 1 second ago — within 10 s window
+            count: 1,
+          }
+          lsSave([first])
+
+          const store = new NotificationStore(WALLET)
+          await store.add({ type, title, body: 'second', createdAt: now })
+
+          const items = lsLoad()
+
+          // Must have exactly one entry for this type
+          const ofType = items.filter((n) => n.type === type)
+          if (ofType.length !== 1) return false
+
+          // That entry must have count=2
+          if (ofType[0].count !== 2) return false
+
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('two same-type notifications outside 10 s window produce two separate entries', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        notifTypeArb,
+        async (type) => {
+          localStorage.clear()
+
+          const now = Date.now()
+          // First notification is older than 10 s
+          const first: Notification = {
+            id: `${type}_${now - 15000}`,
+            type,
+            title: 'old',
+            body: 'old body',
+            read: false,
+            createdAt: now - 15000,
+            count: 1,
+          }
+          lsSave([first])
+
+          const store = new NotificationStore(WALLET)
+          await store.add({ type, title: 'new', body: 'new body', createdAt: now })
+
+          const items = lsLoad()
+          const ofType = items.filter((n) => n.type === type)
+
+          // Should have two separate entries
+          return ofType.length === 2
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('batching does not apply to read notifications within the window', async () => {
+    const now = Date.now()
+    const type: NotificationType = 'reward'
+    const readNotif: Notification = {
+      id: `${type}_${now - 500}`,
+      type,
+      title: 'read one',
+      body: 'body',
+      read: true, // already read — should not be batched into
+      createdAt: now - 500,
+      count: 1,
+    }
+    lsSave([readNotif])
+
+    const store = new NotificationStore(WALLET)
+    await store.add({ type, title: 'new', body: 'new body', createdAt: now })
+
+    const items = lsLoad()
+    const ofType = items.filter((n) => n.type === type)
+
+    // Should create a new entry, not batch into the read one
+    expect(ofType.length).toBe(2)
+    expect(readNotif.count).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Property 17: Notification badge count accuracy
+// Feature: frontend-enhancements, Property 17: badge count = min(unread count, 99), displays "99+" for > 99
+// Validates: Requirements 13.2, 14.4
+// ---------------------------------------------------------------------------
+
+import { getBadgeLabel, getBadgeCount, getPanelNotifications, getRelativeTimestamp, getTypeIconName } from '@/components/ui/NotificationPanel'
+
+describe('Property 17: Notification badge count accuracy', () => {
+  it('badge count equals min(unread count, 99) and label is "99+" when count > 99', () => {
+    // Feature: frontend-enhancements, Property 17: badge count = min(unread count, 99), displays "99+" for > 99
+    fc.assert(
+      fc.property(
+        fc.array(notifArb, { minLength: 0, maxLength: 200 }),
+        (notifs) => {
+          const unread = notifs.filter((n) => !n.read).length
+          const count = getBadgeCount(unread)
+          const label = getBadgeLabel(unread)
+
+          // count must be min(unread, 99)
+          if (count !== Math.min(unread, 99)) return false
+
+          // label must be "99+" when unread > 99, else the string of unread
+          if (unread > 99) {
+            if (label !== '99+') return false
+          } else {
+            if (label !== String(unread)) return false
+          }
+
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('badge is hidden (count=0) when all notifications are read', () => {
+    fc.assert(
+      fc.property(
+        fc.array(notifArb.map((n) => ({ ...n, read: true })), { minLength: 0, maxLength: 50 }),
+        (notifs) => {
+          const unread = notifs.filter((n) => !n.read).length
+          return getBadgeCount(unread) === 0
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Property 18: Notification panel ordering and limit
+// Feature: frontend-enhancements, Property 18: panel renders ≤ 20 items in descending createdAt order
+// Validates: Requirements 13.4
+// ---------------------------------------------------------------------------
+
+describe('Property 18: Notification panel ordering and limit', () => {
+  it('getPanelNotifications returns at most 20 items in descending createdAt order', () => {
+    // Feature: frontend-enhancements, Property 18: panel renders ≤ 20 items in descending createdAt order
+    fc.assert(
+      fc.property(
+        fc.array(notifArb, { minLength: 0, maxLength: 100 }),
+        (notifs) => {
+          const result = getPanelNotifications(notifs)
+
+          // Must not exceed 20
+          if (result.length > 20) return false
+
+          // Must be in descending createdAt order
+          for (let i = 0; i < result.length - 1; i++) {
+            if (result[i].createdAt < result[i + 1].createdAt) return false
+          }
+
+          // Must contain the 20 most recent items (by createdAt)
+          const sorted = [...notifs].sort((a, b) => b.createdAt - a.createdAt).slice(0, 20)
+          if (result.length !== sorted.length) return false
+
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Property 19: Notification panel renders all required fields
+// Feature: frontend-enhancements, Property 19: each notification row contains type icon, title, body, relative timestamp
+// Validates: Requirements 13.6
+// ---------------------------------------------------------------------------
+
+describe('Property 19: Notification panel renders all required fields', () => {
+  it('getTypeIconName returns a non-empty icon name for every notification type', () => {
+    // Feature: frontend-enhancements, Property 19: each notification row contains type icon, title, body, relative timestamp
+    fc.assert(
+      fc.property(
+        notifArb,
+        (n) => {
+          const iconName = getTypeIconName(n.type)
+          // Must return a non-empty string
+          if (!iconName || iconName.length === 0) return false
+
+          // Must be one of the known icon names
+          const validIcons = ['Bell', 'CheckCircle', 'Coins', 'Info']
+          if (!validIcons.includes(iconName)) return false
+
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('getRelativeTimestamp returns a non-empty string for any createdAt timestamp', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: Date.now() }),
+        (createdAt) => {
+          const ts = getRelativeTimestamp(createdAt)
+          // Must be a non-empty string ending with "ago"
+          if (!ts || ts.length === 0) return false
+          if (!ts.endsWith('ago')) return false
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('each notification has title, body, type, and a valid relative timestamp', () => {
+    fc.assert(
+      fc.property(
+        notifArb,
+        (n) => {
+          // title must be a non-empty string
+          if (!n.title || n.title.length === 0) return false
+          // type must be one of the valid types
+          const validTypes: NotificationType[] = ['transfer', 'confirmation', 'reward', 'system']
+          if (!validTypes.includes(n.type)) return false
+          // getTypeIconName must return a valid icon
+          const icon = getTypeIconName(n.type)
+          if (!icon) return false
+          // getRelativeTimestamp must return a string ending with "ago"
+          const ts = getRelativeTimestamp(n.createdAt)
+          if (!ts.endsWith('ago')) return false
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,154 @@
+import {
+  collection,
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  increment,
+} from 'firebase/firestore'
+import { db } from './firebase'
+
+export type NotificationType = 'transfer' | 'confirmation' | 'reward' | 'system'
+
+export interface Notification {
+  id: string
+  type: NotificationType
+  title: string
+  body: string
+  read: boolean
+  createdAt: number
+  count: number
+}
+
+export type NotificationPreferences = Record<NotificationType, boolean>
+
+export const DEFAULT_PREFS: NotificationPreferences = {
+  transfer: true,
+  confirmation: true,
+  reward: true,
+  system: true,
+}
+
+const PREFS_KEY = 'scavngr_notif_prefs'
+const LS_KEY = (address: string) => `scavngr_notifications_${address}`
+const BATCH_WINDOW_MS = 10_000
+
+function loadPrefs(): NotificationPreferences {
+  try {
+    const raw = localStorage.getItem(PREFS_KEY)
+    return raw ? (JSON.parse(raw) as NotificationPreferences) : { ...DEFAULT_PREFS }
+  } catch {
+    return { ...DEFAULT_PREFS }
+  }
+}
+
+function savePrefs(prefs: NotificationPreferences): void {
+  localStorage.setItem(PREFS_KEY, JSON.stringify(prefs))
+}
+
+function lsLoad(address: string): Notification[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY(address))
+    return raw ? (JSON.parse(raw) as Notification[]) : []
+  } catch {
+    return []
+  }
+}
+
+function lsSave(address: string, notifications: Notification[]): void {
+  localStorage.setItem(LS_KEY(address), JSON.stringify(notifications))
+}
+
+export class NotificationStore {
+  private walletAddress: string
+
+  constructor(walletAddress: string) {
+    this.walletAddress = walletAddress
+  }
+
+  private col() {
+    return collection(db, 'notifications', this.walletAddress, 'items')
+  }
+
+  async add(notification: Omit<Notification, 'id' | 'read' | 'count'>): Promise<void> {
+    const prefs = loadPrefs()
+    if (!prefs[notification.type]) return
+
+    const now = Date.now()
+    const windowStart = now - BATCH_WINDOW_MS
+
+    try {
+      const q = query(
+        this.col(),
+        where('type', '==', notification.type),
+        where('read', '==', false),
+        where('createdAt', '>=', windowStart),
+        orderBy('createdAt', 'desc'),
+      )
+      const snap = await getDocs(q)
+
+      if (!snap.empty) {
+        const existing = snap.docs[0]
+        await updateDoc(existing.ref, { count: increment(1) })
+        return
+      }
+
+      const id = `${notification.type}_${now}`
+      const newDoc: Notification = { ...notification, id, read: false, count: 1 }
+      await setDoc(doc(this.col(), id), newDoc)
+    } catch {
+      // localStorage fallback
+      const items = lsLoad(this.walletAddress)
+      const recent = items.find(
+        (n) =>
+          n.type === notification.type &&
+          !n.read &&
+          n.createdAt >= windowStart,
+      )
+      if (recent) {
+        recent.count += 1
+      } else {
+        const id = `${notification.type}_${now}`
+        items.unshift({ ...notification, id, read: false, count: 1 })
+      }
+      lsSave(this.walletAddress, items)
+    }
+  }
+
+  async markRead(id: string): Promise<void> {
+    try {
+      await updateDoc(doc(this.col(), id), { read: true })
+    } catch {
+      const items = lsLoad(this.walletAddress)
+      const n = items.find((x) => x.id === id)
+      if (n) n.read = true
+      lsSave(this.walletAddress, items)
+    }
+  }
+
+  async markAllRead(): Promise<void> {
+    try {
+      const snap = await getDocs(query(this.col(), where('read', '==', false)))
+      await Promise.all(snap.docs.map((d) => updateDoc(d.ref, { read: true })))
+    } catch {
+      const items = lsLoad(this.walletAddress).map((n) => ({ ...n, read: true }))
+      lsSave(this.walletAddress, items)
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await deleteDoc(doc(this.col(), id))
+    } catch {
+      const items = lsLoad(this.walletAddress).filter((n) => n.id !== id)
+      lsSave(this.walletAddress, items)
+    }
+  }
+
+  static loadPrefs = loadPrefs
+  static savePrefs = savePrefs
+}

--- a/frontend/src/lib/profile.ts
+++ b/frontend/src/lib/profile.ts
@@ -1,0 +1,89 @@
+import type { ParticipantStats } from '../api/types'
+
+// ─── localStorage keys ────────────────────────────────────────────────────────
+
+export const PROFILE_NAME_KEY = (address: string) => `scavngr_profile_${address}`
+export const PROFILE_IMAGE_KEY = (address: string) => `scavngr_profile_image_${address}`
+
+// ─── Profile image validation ─────────────────────────────────────────────────
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png']
+const MAX_FILE_SIZE = 2_097_152 // 2 MB
+
+export interface FileValidationResult {
+  valid: boolean
+  error?: string
+}
+
+export function validateProfileImage(file: { type: string; size: number }): FileValidationResult {
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return { valid: false, error: 'Only JPEG and PNG images are allowed.' }
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return { valid: false, error: 'Image must be 2 MB or smaller.' }
+  }
+  return { valid: true }
+}
+
+// ─── localStorage helpers ─────────────────────────────────────────────────────
+
+export function getStoredProfileName(address: string): string | null {
+  return localStorage.getItem(PROFILE_NAME_KEY(address))
+}
+
+export function setStoredProfileName(address: string, name: string): void {
+  localStorage.setItem(PROFILE_NAME_KEY(address), name)
+}
+
+export function getStoredProfileImage(address: string): string | null {
+  return localStorage.getItem(PROFILE_IMAGE_KEY(address))
+}
+
+export function setStoredProfileImage(address: string, dataUrl: string): void {
+  localStorage.setItem(PROFILE_IMAGE_KEY(address), dataUrl)
+}
+
+export interface Milestone {
+  id: string
+  label: string
+  description: string
+  reached: boolean
+}
+
+export function computeReputationScore(stats: ParticipantStats): number {
+  return Math.floor(Number(stats.total_earned) / 100 + stats.materials_submitted * 10)
+}
+
+export function computeMilestones(stats: ParticipantStats): Milestone[] {
+  return [
+    {
+      id: 'first_submission',
+      label: 'First Submission',
+      description: 'Submit your first waste item',
+      reached: stats.materials_submitted >= 1,
+    },
+    {
+      id: 'ten_transfers',
+      label: '10 Transfers',
+      description: 'Complete 10 waste transfers',
+      reached: stats.transfers_count >= 10,
+    },
+    {
+      id: 'hundred_tokens',
+      label: '100 Tokens',
+      description: 'Earn 100 tokens',
+      reached: Number(stats.total_earned) >= 100,
+    },
+    {
+      id: 'fifty_materials',
+      label: '50 Submissions',
+      description: 'Submit 50 waste items',
+      reached: stats.materials_submitted >= 50,
+    },
+  ]
+}
+
+export function generateAvatarUrl(address: string): string {
+  const hue = parseInt(address.slice(2, 6), 16) % 360
+  return `https://api.dicebear.com/7.x/identicon/svg?seed=${address}&backgroundColor=${hue}`
+}

--- a/frontend/src/lib/searchStorage.test.ts
+++ b/frontend/src/lib/searchStorage.test.ts
@@ -1,0 +1,144 @@
+// Feature: frontend-enhancements, Property 12: Search results URL round-trip
+// Validates: Requirements 9.5
+
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import { WasteType } from '@/api/types'
+import { filtersToSearchParams, searchParamsToFilters } from '@/lib/searchStorage'
+import type { SearchFilters } from '@/lib/searchStorage'
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+const wasteTypeArb = fc.constantFrom(
+  WasteType.Paper,
+  WasteType.PetPlastic,
+  WasteType.Plastic,
+  WasteType.Metal,
+  WasteType.Glass
+)
+
+const statusArb = fc.constantFrom(
+  'all' as const,
+  'active' as const,
+  'confirmed' as const,
+  'inactive' as const
+)
+
+const isoDateArb = fc
+  .integer({ min: 2020, max: 2030 })
+  .chain((year) =>
+    fc.integer({ min: 1, max: 12 }).chain((month) =>
+      fc.integer({ min: 1, max: 28 }).map((day) => {
+        const mm = String(month).padStart(2, '0')
+        const dd = String(day).padStart(2, '0')
+        return `${year}-${mm}-${dd}`
+      })
+    )
+  )
+
+const searchFiltersArb: fc.Arbitrary<SearchFilters> = fc.record({
+  wasteTypes: fc.uniqueArray(wasteTypeArb, { minLength: 0, maxLength: 5 }),
+  status: statusArb,
+  dateFrom: fc.option(isoDateArb, { nil: null }),
+  dateTo: fc.option(isoDateArb, { nil: null }),
+  location: fc.string({ minLength: 0, maxLength: 50 }).map((s) => s.trim()),
+})
+
+// Non-empty printable query strings (no leading/trailing whitespace)
+const queryArb = fc
+  .string({ minLength: 0, maxLength: 80 })
+  .map((s) => s.trim())
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('searchStorage — Property 12: search results URL round-trip', () => {
+  it('query round-trips through URL params', () => {
+    fc.assert(
+      fc.property(queryArb, (query) => {
+        const params = filtersToSearchParams(query, {
+          wasteTypes: [],
+          status: 'all',
+          dateFrom: null,
+          dateTo: null,
+          location: '',
+        })
+        const { query: parsed } = searchParamsToFilters(params)
+        return parsed === query
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('filters round-trip through URL params', () => {
+    fc.assert(
+      fc.property(queryArb, searchFiltersArb, (query, filters) => {
+        const params = filtersToSearchParams(query, filters)
+        const { query: parsedQuery, filters: parsedFilters } = searchParamsToFilters(params)
+
+        // Query must match
+        if (parsedQuery !== query) return false
+
+        // Status must match
+        if (parsedFilters.status !== filters.status) return false
+
+        // wasteTypes must contain the same values (order may differ after parse)
+        const sortedOriginal = [...filters.wasteTypes].sort()
+        const sortedParsed = [...parsedFilters.wasteTypes].sort()
+        if (JSON.stringify(sortedOriginal) !== JSON.stringify(sortedParsed)) return false
+
+        // dateFrom / dateTo must match
+        if (parsedFilters.dateFrom !== filters.dateFrom) return false
+        if (parsedFilters.dateTo !== filters.dateTo) return false
+
+        // location must match
+        if (parsedFilters.location !== filters.location) return false
+
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('serialising default filters produces no extra params beyond q', () => {
+    fc.assert(
+      fc.property(queryArb, (query) => {
+        const defaultFilters: SearchFilters = {
+          wasteTypes: [],
+          status: 'all',
+          dateFrom: null,
+          dateTo: null,
+          location: '',
+        }
+        const params = filtersToSearchParams(query, defaultFilters)
+        // Only 'q' should be present (when query is non-empty)
+        const keys = [...params.keys()]
+        const expectedKeys = query ? ['q'] : []
+        return JSON.stringify(keys.sort()) === JSON.stringify(expectedKeys.sort())
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('parsing empty URLSearchParams returns default filters and empty query', () => {
+    const { query, filters } = searchParamsToFilters(new URLSearchParams())
+    expect(query).toBe('')
+    expect(filters.status).toBe('all')
+    expect(filters.wasteTypes).toEqual([])
+    expect(filters.dateFrom).toBeNull()
+    expect(filters.dateTo).toBeNull()
+    expect(filters.location).toBe('')
+  })
+
+  it('invalid status value falls back to "all"', () => {
+    const params = new URLSearchParams({ status: 'bogus' })
+    const { filters } = searchParamsToFilters(params)
+    expect(filters.status).toBe('all')
+  })
+
+  it('invalid wasteType values are filtered out', () => {
+    const params = new URLSearchParams({ wasteTypes: '0,99,-1,abc,3' })
+    const { filters } = searchParamsToFilters(params)
+    // Only 0 and 3 are valid WasteType values
+    expect(filters.wasteTypes).toEqual([WasteType.Paper, WasteType.Metal])
+  })
+})

--- a/frontend/src/lib/searchStorage.ts
+++ b/frontend/src/lib/searchStorage.ts
@@ -1,0 +1,125 @@
+import type { WasteType } from '../api/types'
+
+export interface SearchFilters {
+  wasteTypes: WasteType[]
+  status: 'all' | 'active' | 'confirmed' | 'inactive'
+  dateFrom: string | null
+  dateTo: string | null
+  location: string
+}
+
+export interface FilterPreset {
+  id: string
+  name: string
+  filters: SearchFilters
+}
+
+export interface SearchResult {
+  type: 'waste' | 'participant'
+  id: string
+  label: string
+  sublabel: string
+  data: unknown
+}
+
+const HISTORY_KEY = 'scavngr_search_history'
+const PRESETS_KEY = 'scavngr_filter_presets'
+const MAX_HISTORY = 20
+
+export function getSearchHistory(): string[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY)
+    return raw ? (JSON.parse(raw) as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function addSearchHistory(query: string): void {
+  const trimmed = query.trim()
+  if (!trimmed) return
+  const history = getSearchHistory().filter((q) => q !== trimmed)
+  history.unshift(trimmed)
+  if (history.length > MAX_HISTORY) {
+    history.splice(MAX_HISTORY)
+  }
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history))
+}
+
+export function getFilterPresets(): FilterPreset[] {
+  try {
+    const raw = localStorage.getItem(PRESETS_KEY)
+    return raw ? (JSON.parse(raw) as FilterPreset[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function saveFilterPreset(preset: FilterPreset): void {
+  const presets = getFilterPresets().filter((p) => p.id !== preset.id)
+  presets.push(preset)
+  localStorage.setItem(PRESETS_KEY, JSON.stringify(presets))
+}
+
+export function deleteFilterPreset(id: string): void {
+  const presets = getFilterPresets().filter((p) => p.id !== id)
+  localStorage.setItem(PRESETS_KEY, JSON.stringify(presets))
+}
+
+// ─── URL serialisation ────────────────────────────────────────────────────────
+
+/**
+ * Serialises a query string and SearchFilters into URLSearchParams.
+ * Only non-default values are written to keep URLs short.
+ */
+export function filtersToSearchParams(
+  query: string,
+  filters: SearchFilters
+): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (query) params.set('q', query)
+  if (filters.status !== 'all') params.set('status', filters.status)
+  if (filters.wasteTypes.length > 0)
+    params.set('wasteTypes', filters.wasteTypes.join(','))
+  if (filters.dateFrom) params.set('dateFrom', filters.dateFrom)
+  if (filters.dateTo) params.set('dateTo', filters.dateTo)
+  if (filters.location.trim()) params.set('location', filters.location)
+
+  return params
+}
+
+/**
+ * Parses URLSearchParams back into a query string and SearchFilters.
+ * Missing or invalid values fall back to defaults.
+ */
+export function searchParamsToFilters(params: URLSearchParams): {
+  query: string
+  filters: SearchFilters
+} {
+  const query = params.get('q') ?? ''
+
+  const rawStatus = params.get('status')
+  const validStatuses = ['all', 'active', 'confirmed', 'inactive'] as const
+  const status: SearchFilters['status'] =
+    validStatuses.includes(rawStatus as SearchFilters['status'])
+      ? (rawStatus as SearchFilters['status'])
+      : 'all'
+
+  const rawWasteTypes = params.get('wasteTypes')
+  const wasteTypes: WasteType[] = rawWasteTypes
+    ? rawWasteTypes
+        .split(',')
+        .map(Number)
+        .filter((n) => !isNaN(n) && n >= 0 && n <= 4) as WasteType[]
+    : []
+
+  const dateFrom = params.get('dateFrom') || null
+  const dateTo = params.get('dateTo') || null
+  const location = params.get('location') ?? ''
+
+  return {
+    query,
+    filters: { wasteTypes, status, dateFrom, dateTo, location },
+  }
+}

--- a/frontend/src/pages/IncentivesMarketplacePage.test.ts
+++ b/frontend/src/pages/IncentivesMarketplacePage.test.ts
@@ -1,0 +1,380 @@
+// Feature: frontend-enhancements, Property 13: Incentive sort correctness
+// Feature: frontend-enhancements, Property 14: Incentive filter correctness
+// Feature: frontend-enhancements, Property 15: View preference persistence
+// Validates: Requirements 10.2, 10.3, 10.4
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { WasteType } from '@/api/types'
+import type { Incentive } from '@/api/types'
+import {
+  sortIncentives,
+  filterIncentives,
+  readViewMode,
+  writeViewMode,
+  VIEW_STORAGE_KEY,
+  type SortField,
+  type SortDir,
+  type IncentiveFilters,
+  type ViewMode,
+} from '@/lib/incentivesUtils'
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+const wasteTypeArb = fc.constantFrom(
+  WasteType.Paper,
+  WasteType.PetPlastic,
+  WasteType.Plastic,
+  WasteType.Metal,
+  WasteType.Glass
+)
+
+const incentiveArb: fc.Arbitrary<Incentive> = fc.record({
+  id: fc.integer({ min: 1, max: 10_000 }),
+  rewarder: fc.hexaString({ minLength: 10, maxLength: 56 }).map((s) => `G${s.toUpperCase()}`),
+  waste_type: wasteTypeArb,
+  reward_points: fc.integer({ min: 0, max: 1_000_000 }),
+  total_budget: fc.integer({ min: 0, max: 10_000_000 }),
+  remaining_budget: fc.integer({ min: 0, max: 10_000_000 }),
+  active: fc.boolean(),
+  created_at: fc.integer({ min: 0, max: 2_000_000_000 }),
+})
+
+const sortFieldArb: fc.Arbitrary<SortField> = fc.constantFrom(
+  'reward_points' as const,
+  'remaining_budget' as const,
+  'waste_type' as const
+)
+
+const sortDirArb: fc.Arbitrary<SortDir> = fc.constantFrom('asc' as const, 'desc' as const)
+
+const incentiveFiltersArb: fc.Arbitrary<IncentiveFilters> = fc.record({
+  wasteTypes: fc.array(wasteTypeArb, { minLength: 0, maxLength: 5 }),
+  rewarder: fc.string({ minLength: 0, maxLength: 20 }),
+})
+
+const viewModeArb: fc.Arbitrary<ViewMode> = fc.constantFrom('grid' as const, 'list' as const)
+
+// ─── Property 13: Incentive sort correctness ──────────────────────────────────
+
+describe('IncentivesMarketplacePage — Property 13: incentive sort correctness', () => {
+  it('sorted output satisfies total order for reward_points asc', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const sorted = sortIncentives(incentives, 'reward_points', 'asc')
+        for (let i = 1; i < sorted.length; i++) {
+          if (Number(sorted[i - 1].reward_points) > Number(sorted[i].reward_points)) return false
+        }
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sorted output satisfies total order for reward_points desc', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const sorted = sortIncentives(incentives, 'reward_points', 'desc')
+        for (let i = 1; i < sorted.length; i++) {
+          if (Number(sorted[i - 1].reward_points) < Number(sorted[i].reward_points)) return false
+        }
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sorted output satisfies total order for remaining_budget asc', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const sorted = sortIncentives(incentives, 'remaining_budget', 'asc')
+        for (let i = 1; i < sorted.length; i++) {
+          if (Number(sorted[i - 1].remaining_budget) > Number(sorted[i].remaining_budget))
+            return false
+        }
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sorted output satisfies total order for remaining_budget desc', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const sorted = sortIncentives(incentives, 'remaining_budget', 'desc')
+        for (let i = 1; i < sorted.length; i++) {
+          if (Number(sorted[i - 1].remaining_budget) < Number(sorted[i].remaining_budget))
+            return false
+        }
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sorted output satisfies total order for waste_type asc', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const sorted = sortIncentives(incentives, 'waste_type', 'asc')
+        for (let i = 1; i < sorted.length; i++) {
+          if (sorted[i - 1].waste_type > sorted[i].waste_type) return false
+        }
+        return true
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sort does not mutate the original array', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 1, maxLength: 30 }),
+        sortFieldArb,
+        sortDirArb,
+        (incentives, field, dir) => {
+          const original = incentives.map((i) => i.id)
+          sortIncentives(incentives, field, dir)
+          return incentives.map((i) => i.id).join(',') === original.join(',')
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('sorted output has the same length as the input', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 0, maxLength: 50 }),
+        sortFieldArb,
+        sortDirArb,
+        (incentives, field, dir) => {
+          return sortIncentives(incentives, field, dir).length === incentives.length
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ─── Property 14: Incentive filter correctness ────────────────────────────────
+
+describe('IncentivesMarketplacePage — Property 14: incentive filter correctness', () => {
+  it('every item in the filtered output satisfies all active filter predicates', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 0, maxLength: 50 }),
+        incentiveFiltersArb,
+        (incentives, filters) => {
+          const result = filterIncentives(incentives, filters)
+          return result.every((inc) => {
+            const typeOk =
+              filters.wasteTypes.length === 0 || filters.wasteTypes.includes(inc.waste_type)
+            const rewarderOk =
+              filters.rewarder.trim() === '' ||
+              inc.rewarder.toLowerCase().includes(filters.rewarder.trim().toLowerCase())
+            return typeOk && rewarderOk
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('no item that satisfies all predicates is absent from the output', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 0, maxLength: 50 }),
+        incentiveFiltersArb,
+        (incentives, filters) => {
+          const result = filterIncentives(incentives, filters)
+          const resultIds = new Set(result.map((i) => i.id))
+          return incentives
+            .filter((inc) => {
+              const typeOk =
+                filters.wasteTypes.length === 0 || filters.wasteTypes.includes(inc.waste_type)
+              const rewarderOk =
+                filters.rewarder.trim() === '' ||
+                inc.rewarder.toLowerCase().includes(filters.rewarder.trim().toLowerCase())
+              return typeOk && rewarderOk
+            })
+            .every((inc) => resultIds.has(inc.id))
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('empty filters return all incentives', () => {
+    fc.assert(
+      fc.property(fc.array(incentiveArb, { minLength: 0, maxLength: 50 }), (incentives) => {
+        const result = filterIncentives(incentives, { wasteTypes: [], rewarder: '' })
+        return result.length === incentives.length
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('filter does not mutate the original array', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 1, maxLength: 30 }),
+        incentiveFiltersArb,
+        (incentives, filters) => {
+          const original = incentives.map((i) => i.id)
+          filterIncentives(incentives, filters)
+          return incentives.map((i) => i.id).join(',') === original.join(',')
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('filtered output length is always <= input length', () => {
+    fc.assert(
+      fc.property(
+        fc.array(incentiveArb, { minLength: 0, maxLength: 50 }),
+        incentiveFiltersArb,
+        (incentives, filters) => {
+          return filterIncentives(incentives, filters).length <= incentives.length
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ─── Property 15: View preference persistence ─────────────────────────────────
+
+describe('IncentivesMarketplacePage — Property 15: view preference persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('writing a view mode and reading it back returns the same value', () => {
+    fc.assert(
+      fc.property(viewModeArb, (mode) => {
+        writeViewMode(mode)
+        return readViewMode() === mode
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('reading without writing returns the default grid mode', () => {
+    expect(readViewMode()).toBe('grid')
+  })
+
+  it('last write wins when writing multiple times', () => {
+    fc.assert(
+      fc.property(viewModeArb, viewModeArb, (first, second) => {
+        writeViewMode(first)
+        writeViewMode(second)
+        return readViewMode() === second
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('only valid values are returned (never an arbitrary string)', () => {
+    // Corrupt the storage with an invalid value
+    localStorage.setItem(VIEW_STORAGE_KEY, 'invalid_value')
+    expect(readViewMode()).toBe('grid')
+  })
+})
+
+// ─── Property 16: Comparison selection capped at 3 ───────────────────────────
+// Feature: frontend-enhancements, Property 16: Comparison selection capped at 3
+// Validates: Requirements 12.1
+
+import { toggleCompareId } from '@/lib/incentivesUtils'
+
+describe('IncentivesMarketplacePage — Property 16: comparison selection capped at 3', () => {
+  it('set never exceeds 3 elements after any sequence of toggle actions', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer({ min: 1, max: 100 }), { minLength: 0, maxLength: 20 }),
+        (ids) => {
+          let set = new Set<number>()
+          for (const id of ids) {
+            set = toggleCompareId(set, id)
+          }
+          return set.size <= 3
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('attempting to add a 4th element leaves the set unchanged', () => {
+    fc.assert(
+      fc.property(
+        // Generate 4 distinct IDs
+        fc.uniqueArray(fc.integer({ min: 1, max: 1000 }), { minLength: 4, maxLength: 4 }),
+        ([a, b, c, d]) => {
+          let set = new Set<number>()
+          set = toggleCompareId(set, a)
+          set = toggleCompareId(set, b)
+          set = toggleCompareId(set, c)
+          // set now has 3 elements; adding d should leave it unchanged
+          const before = new Set(set)
+          const after = toggleCompareId(set, d)
+          return (
+            after.size === 3 &&
+            after.has(a) &&
+            after.has(b) &&
+            after.has(c) &&
+            !after.has(d) &&
+            // original set is not mutated
+            before.size === set.size
+          )
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('toggling an already-selected ID removes it from the set', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.integer({ min: 1, max: 1000 }), { minLength: 1, maxLength: 3 }),
+        (ids) => {
+          let set = new Set<number>()
+          for (const id of ids) {
+            set = toggleCompareId(set, id)
+          }
+          // Now deselect each one
+          for (const id of ids) {
+            set = toggleCompareId(set, id)
+          }
+          return set.size === 0
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('toggleCompareId does not mutate the input set', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.integer({ min: 1, max: 100 }), { minLength: 0, maxLength: 3 }),
+        fc.integer({ min: 1, max: 100 }),
+        (ids, newId) => {
+          const original = new Set<number>(ids)
+          const snapshot = new Set(original)
+          toggleCompareId(original, newId)
+          // original must be unchanged
+          if (original.size !== snapshot.size) return false
+          for (const id of snapshot) {
+            if (!original.has(id)) return false
+          }
+          return true
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})

--- a/frontend/src/pages/IncentivesMarketplacePage.tsx
+++ b/frontend/src/pages/IncentivesMarketplacePage.tsx
@@ -1,0 +1,558 @@
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { FixedSizeList, type ListChildComponentProps } from 'react-window'
+import { LayoutGrid, List, SlidersHorizontal, X, Zap, GitCompare } from 'lucide-react'
+import { useIncentives } from '@/hooks/useIncentives'
+import { useIncentivesClaim } from '@/hooks/useIncentivesClaim'
+import { useAuth } from '@/context/AuthContext'
+import { Incentive, WasteType } from '@/api/types'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Badge } from '@/components/ui/Badge'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { IncentiveCard } from '@/components/ui/IncentiveCard'
+import { IncentiveDetailModal } from '@/components/ui/IncentiveDetailModal'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import { cn } from '@/lib/utils'
+import { wasteTypeLabel } from '@/lib/helpers'
+import {
+  sortIncentives,
+  filterIncentives,
+  readViewMode,
+  writeViewMode,
+  toggleCompareId,
+  type ViewMode,
+  type SortField,
+  type SortDir,
+  type IncentiveFilters,
+} from '@/lib/incentivesUtils'
+
+// Re-export pure functions and types for consumers / tests
+export { sortIncentives, filterIncentives, readViewMode, writeViewMode, toggleCompareId }
+export type { ViewMode, SortField, SortDir, IncentiveFilters }
+
+// ─── localStorage helpers for claimed incentives ──────────────────────────────
+
+const CLAIMS_KEY_PREFIX = 'scavngr_claimed_incentives_'
+
+function getClaimedIds(address: string | null | undefined): Set<number> {
+  if (!address) return new Set()
+  try {
+    const raw = localStorage.getItem(`${CLAIMS_KEY_PREFIX}${address}`)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) return new Set(parsed as number[])
+  } catch { /* ignore */ }
+  return new Set()
+}
+
+function addClaimedId(address: string | null | undefined, id: number): void {
+  if (!address) return
+  try {
+    const existing = getClaimedIds(address)
+    existing.add(id)
+    localStorage.setItem(`${CLAIMS_KEY_PREFIX}${address}`, JSON.stringify([...existing]))
+  } catch { /* ignore */ }
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ALL_WASTE_TYPES = Object.values(WasteType).filter((v): v is WasteType => typeof v === 'number')
+
+const GRID_COLS_DESKTOP = 3
+const CARD_HEIGHT_LIST = 80
+const CARD_HEIGHT_GRID = 260
+const OVERSCAN = 3
+
+// ─── Skeleton card ────────────────────────────────────────────────────────────
+
+function IncentiveSkeletonCard({ className }: { className?: string }) {
+  return (
+    <div className={cn('rounded-lg border bg-card shadow-sm p-4 space-y-3 animate-pulse', className)}>
+      <div className="flex items-center justify-between">
+        <div className="h-4 w-24 rounded bg-muted" />
+        <div className="h-5 w-14 rounded-full bg-muted" />
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-full rounded bg-muted" />
+        <div className="h-3 w-3/4 rounded bg-muted" />
+        <div className="h-2 w-full rounded-full bg-muted" />
+        <div className="h-3 w-1/2 rounded bg-muted" />
+      </div>
+    </div>
+  )
+}
+
+// ─── Virtualized list row ─────────────────────────────────────────────────────
+
+interface RowData {
+  items: Incentive[][]
+  viewMode: ViewMode
+  containerWidth: number
+  compareIds: Set<number>
+  onToggleCompare: (id: number) => void
+  onCardClick: (inc: Incentive) => void
+}
+
+function VirtualRow({ index, style, data }: ListChildComponentProps<RowData>) {
+  const row = data.items[index]
+  if (!row) return null
+
+  if (data.viewMode === 'list') {
+    const inc = row[0]
+    return (
+      <div style={style} className="px-1 py-1">
+        <div
+          className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3 text-sm shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
+          onClick={() => data.onCardClick(inc)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => e.key === 'Enter' && data.onCardClick(inc)}
+        >
+          <input
+            type="checkbox"
+            aria-label={`Compare incentive #${inc.id}`}
+            checked={data.compareIds.has(inc.id)}
+            onChange={(e) => { e.stopPropagation(); data.onToggleCompare(inc.id) }}
+            onClick={(e) => e.stopPropagation()}
+            className="h-4 w-4 shrink-0 cursor-pointer"
+          />
+          <span className="w-8 font-mono text-muted-foreground">#{inc.id}</span>
+          <Badge variant={inc.active ? 'default' : 'secondary'} className="shrink-0">
+            {wasteTypeLabel(inc.waste_type)}
+          </Badge>
+          <span className="flex-1 truncate font-mono text-xs text-muted-foreground">
+            {inc.rewarder}
+          </span>
+          <span className="shrink-0 font-medium">{Number(inc.reward_points).toLocaleString()} pts</span>
+          <span className="shrink-0 text-muted-foreground">
+            {Number(inc.remaining_budget).toLocaleString()} left
+          </span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={style} className="flex gap-4 px-1 py-1">
+      {row.map((inc) => (
+        <div key={inc.id} className="flex-1 min-w-0 relative">
+          <label
+            className="absolute top-2 left-2 z-10 flex items-center gap-1 cursor-pointer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              aria-label={`Compare incentive #${inc.id}`}
+              checked={data.compareIds.has(inc.id)}
+              onChange={() => data.onToggleCompare(inc.id)}
+              className="h-4 w-4 cursor-pointer"
+            />
+          </label>
+          <div
+            className="cursor-pointer"
+            onClick={() => data.onCardClick(inc)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && data.onCardClick(inc)}
+          >
+            <IncentiveCard incentive={inc} />
+          </div>
+        </div>
+      ))}
+      {Array.from({ length: GRID_COLS_DESKTOP - row.length }).map((_, i) => (
+        <div key={`empty-${i}`} className="flex-1 min-w-0" />
+      ))}
+    </div>
+  )
+}
+
+// ─── Comparison panel ─────────────────────────────────────────────────────────
+
+interface ComparisonPanelProps {
+  incentives: Incentive[]
+  selectedIds: Set<number>
+  onClear: () => void
+}
+
+function ComparisonPanel({ incentives, selectedIds, onClear }: ComparisonPanelProps) {
+  const selected = incentives.filter((inc) => selectedIds.has(inc.id))
+  if (selected.length < 2) return null
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background shadow-lg"
+      role="region"
+      aria-label="Incentive comparison panel"
+    >
+      <div className="mx-auto max-w-5xl px-4 py-3">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <GitCompare className="h-4 w-4 text-primary" />
+            <span className="text-sm font-medium">Comparing {selected.length} incentives</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            <X className="mr-1 h-3.5 w-3.5" />
+            Clear comparison
+          </Button>
+        </div>
+        <div
+          className="grid gap-3"
+          style={{ gridTemplateColumns: `repeat(${selected.length}, 1fr)` }}
+        >
+          {selected.map((inc) => (
+            <div key={inc.id} className="rounded-lg border bg-card p-3 text-xs space-y-1.5">
+              <p className="font-semibold text-sm">#{inc.id} — {wasteTypeLabel(inc.waste_type)}</p>
+              <CompareRow label="Reward" value={`${Number(inc.reward_points).toLocaleString()} pts`} />
+              <CompareRow label="Budget" value={`${Number(inc.total_budget).toLocaleString()}`} />
+              <CompareRow label="Remaining" value={`${Number(inc.remaining_budget).toLocaleString()}`} />
+              <CompareRow label="Status" value={inc.active ? 'Active' : 'Inactive'} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CompareRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  )
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export function IncentivesMarketplacePage() {
+  const { incentives, isLoading, error } = useIncentives()
+  const { claimIncentive, isClaiming } = useIncentivesClaim()
+  const { user } = useAuth()
+
+  const [viewMode, setViewMode] = useState<ViewMode>(readViewMode)
+  const handleViewMode = useCallback((mode: ViewMode) => {
+    setViewMode(mode)
+    writeViewMode(mode)
+  }, [])
+
+  const [sortField, setSortField] = useState<SortField>('reward_points')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const [filters, setFilters] = useState<IncentiveFilters>({ wasteTypes: [], rewarder: '' })
+  const [showFilters, setShowFilters] = useState(false)
+
+  const toggleWasteType = useCallback((wt: WasteType) => {
+    setFilters((f) => ({
+      ...f,
+      wasteTypes: f.wasteTypes.includes(wt)
+        ? f.wasteTypes.filter((t) => t !== wt)
+        : [...f.wasteTypes, wt],
+    }))
+  }, [])
+
+  const clearFilters = useCallback(() => setFilters({ wasteTypes: [], rewarder: '' }), [])
+
+  const activeFilterCount =
+    filters.wasteTypes.length + (filters.rewarder.trim() !== '' ? 1 : 0)
+
+  const [selectedIncentive, setSelectedIncentive] = useState<Incentive | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const handleCardClick = useCallback((inc: Incentive) => {
+    setSelectedIncentive(inc)
+    setModalOpen(true)
+  }, [])
+
+  const [claimedIds, setClaimedIds] = useState<Set<number>>(() => getClaimedIds(user?.address))
+
+  const handleClaim = useCallback(async (incentiveId: number) => {
+    await claimIncentive(incentiveId)
+    addClaimedId(user?.address, incentiveId)
+    setClaimedIds((prev) => new Set([...prev, incentiveId]))
+  }, [claimIncentive, user?.address])
+
+  const [compareIds, setCompareIds] = useState<Set<number>>(new Set())
+
+  const handleToggleCompare = useCallback((id: number) => {
+    setCompareIds((prev) => toggleCompareId(prev, id))
+  }, [])
+
+  const handleClearComparison = useCallback(() => setCompareIds(new Set()), [])
+
+  const processed = useMemo(() => {
+    const filtered = filterIncentives(incentives, filters)
+    return sortIncentives(filtered, sortField, sortDir)
+  }, [incentives, filters, sortField, sortDir])
+
+  const myClaims = useMemo(
+    () => incentives.filter((inc) => claimedIds.has(inc.id)),
+    [incentives, claimedIds]
+  )
+
+  const colCount = viewMode === 'grid' ? GRID_COLS_DESKTOP : 1
+  const rows = useMemo<Incentive[][]>(() => {
+    const result: Incentive[][] = []
+    for (let i = 0; i < processed.length; i += colCount) {
+      result.push(processed.slice(i, i + colCount))
+    }
+    return result
+  }, [processed, colCount])
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(800)
+  const [containerHeight, setContainerHeight] = useState(600)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) {
+        setContainerWidth(entry.contentRect.width)
+        setContainerHeight(Math.max(400, window.innerHeight - 280))
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const rowHeight = viewMode === 'list' ? CARD_HEIGHT_LIST : CARD_HEIGHT_GRID
+
+  const rowData: RowData = useMemo(
+    () => ({
+      items: rows,
+      viewMode,
+      containerWidth,
+      compareIds,
+      onToggleCompare: handleToggleCompare,
+      onCardClick: handleCardClick,
+    }),
+    [rows, viewMode, containerWidth, compareIds, handleToggleCompare, handleCardClick]
+  )
+
+  const hasComparison = compareIds.size >= 2
+
+  return (
+    <div className={cn('space-y-4 px-4 py-6 sm:px-0 sm:py-0', hasComparison && 'pb-48')}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-xl font-bold sm:text-2xl">Incentives Marketplace</h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select
+            value={`${sortField}:${sortDir}`}
+            onValueChange={(v) => {
+              const [f, d] = v.split(':') as [SortField, SortDir]
+              setSortField(f)
+              setSortDir(d)
+            }}
+          >
+            <SelectTrigger className="w-52">
+              <SelectValue placeholder="Sort by…" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="reward_points:desc">Reward pts — high to low</SelectItem>
+              <SelectItem value="reward_points:asc">Reward pts — low to high</SelectItem>
+              <SelectItem value="remaining_budget:desc">Budget — high to low</SelectItem>
+              <SelectItem value="remaining_budget:asc">Budget — low to high</SelectItem>
+              <SelectItem value="waste_type:asc">Waste type</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowFilters((s) => !s)}
+            aria-expanded={showFilters}
+            aria-controls="incentives-filter-panel"
+          >
+            <SlidersHorizontal className="mr-1.5 h-4 w-4" />
+            Filters
+            {activeFilterCount > 0 && (
+              <Badge className="ml-1.5 h-5 w-5 rounded-full p-0 text-xs flex items-center justify-center">
+                {activeFilterCount}
+              </Badge>
+            )}
+          </Button>
+
+          <div className="flex rounded-md border" role="group" aria-label="View mode">
+            <button
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-l-md transition-colors',
+                viewMode === 'grid'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background text-muted-foreground hover:bg-accent'
+              )}
+              onClick={() => handleViewMode('grid')}
+              aria-label="Grid view"
+              aria-pressed={viewMode === 'grid'}
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </button>
+            <button
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-r-md transition-colors',
+                viewMode === 'list'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background text-muted-foreground hover:bg-accent'
+              )}
+              onClick={() => handleViewMode('list')}
+              aria-label="List view"
+              aria-pressed={viewMode === 'list'}
+            >
+              <List className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {showFilters && (
+        <div
+          id="incentives-filter-panel"
+          className="rounded-lg border bg-card p-4 space-y-4"
+          role="region"
+          aria-label="Incentive filters"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">Filters</span>
+            {activeFilterCount > 0 && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                <X className="mr-1 h-3.5 w-3.5" />
+                Clear all
+              </Button>
+            )}
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Waste Type
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {ALL_WASTE_TYPES.map((wt) => {
+                const active = filters.wasteTypes.includes(wt)
+                return (
+                  <button
+                    key={wt}
+                    onClick={() => toggleWasteType(wt)}
+                    className={cn(
+                      'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                      active
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-input bg-background text-foreground hover:bg-accent'
+                    )}
+                    aria-pressed={active}
+                  >
+                    {wasteTypeLabel(wt)}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="rewarder-filter"
+              className="text-xs font-medium text-muted-foreground uppercase tracking-wide"
+            >
+              Rewarder Address
+            </label>
+            <Input
+              id="rewarder-filter"
+              placeholder="Filter by rewarder address…"
+              value={filters.rewarder}
+              onChange={(e) => setFilters((f) => ({ ...f, rewarder: e.target.value }))}
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p
+          role="alert"
+          aria-live="assertive"
+          className="rounded-md border border-destructive bg-destructive/10 px-4 py-2 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      )}
+
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <IncentiveSkeletonCard key={i} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && myClaims.length > 0 && (
+        <section aria-label="My Claims">
+          <h2 className="mb-3 text-base font-semibold">My Claims</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {myClaims.map((inc) => (
+              <div
+                key={inc.id}
+                className="cursor-pointer"
+                onClick={() => handleCardClick(inc)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && handleCardClick(inc)}
+              >
+                <IncentiveCard incentive={inc} />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {!isLoading && processed.length === 0 && !error && (
+        <EmptyState
+          icon={Zap}
+          title="No incentives found"
+          description={
+            activeFilterCount > 0
+              ? 'No incentives match your current filters. Try clearing some filters.'
+              : 'No active incentives available right now.'
+          }
+          action={
+            activeFilterCount > 0
+              ? { label: 'Clear filters', onClick: clearFilters }
+              : undefined
+          }
+        />
+      )}
+
+      {!isLoading && processed.length > 0 && (
+        <div ref={containerRef} className="w-full">
+          <FixedSizeList
+            height={containerHeight}
+            width={containerWidth || '100%'}
+            itemCount={rows.length}
+            itemSize={rowHeight}
+            itemData={rowData}
+            overscanCount={OVERSCAN}
+          >
+            {VirtualRow}
+          </FixedSizeList>
+        </div>
+      )}
+
+      <IncentiveDetailModal
+        incentive={selectedIncentive}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onClaim={handleClaim}
+        isClaiming={isClaiming}
+      />
+
+      <ComparisonPanel
+        incentives={incentives}
+        selectedIds={compareIds}
+        onClear={handleClearComparison}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/ProfilePage.test.ts
+++ b/frontend/src/pages/ProfilePage.test.ts
@@ -1,0 +1,240 @@
+// Feature: frontend-enhancements, Property 5: Waste timeline is chronologically ordered
+// Validates: Requirements 3.1
+
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import { WasteType } from '@/api/types'
+import type { Waste } from '@/api/types'
+
+// ── Arbitrary generators ──────────────────────────────────────────────────────
+
+const wasteTypeArb = fc.constantFrom(
+  WasteType.Paper,
+  WasteType.PetPlastic,
+  WasteType.Plastic,
+  WasteType.Metal,
+  WasteType.Glass
+)
+
+const wasteArb: fc.Arbitrary<Waste> = fc
+  .record({
+    waste_id: fc.bigInt({ min: 1n, max: 1_000_000n }),
+    waste_type: wasteTypeArb,
+    weight: fc.bigInt({ min: 1n, max: 100_000n }),
+    current_owner: fc.hexaString({ minLength: 56, maxLength: 56 }),
+    latitude: fc.bigInt({ min: -90_000_000n, max: 90_000_000n }),
+    longitude: fc.bigInt({ min: -180_000_000n, max: 180_000_000n }),
+    recycled_timestamp: fc.integer({ min: 0, max: 2_000_000_000 }),
+    is_active: fc.boolean(),
+    is_confirmed: fc.boolean(),
+    confirmer: fc.hexaString({ minLength: 56, maxLength: 56 }),
+  })
+
+// ── The sort function extracted from WasteTimeline ────────────────────────────
+// This mirrors the exact logic in the component:
+//   [...wastes].sort((a, b) => b.recycled_timestamp - a.recycled_timestamp)
+
+function sortWastesDescending(wastes: Waste[]): Waste[] {
+  return [...wastes].sort((a, b) => b.recycled_timestamp - a.recycled_timestamp)
+}
+
+// ── Property 5 ────────────────────────────────────────────────────────────────
+
+describe('Property 5: Waste timeline is chronologically ordered', () => {
+  it('renders items in descending recycled_timestamp order for any waste list', () => {
+    fc.assert(
+      fc.property(fc.array(wasteArb, { minLength: 0, maxLength: 50 }), (wastes) => {
+        const sorted = sortWastesDescending(wastes)
+
+        // Every adjacent pair must satisfy: earlier index has >= timestamp
+        for (let i = 0; i < sorted.length - 1; i++) {
+          expect(sorted[i].recycled_timestamp).toBeGreaterThanOrEqual(
+            sorted[i + 1].recycled_timestamp
+          )
+        }
+
+        // The sorted array must contain the same elements (no items lost or added)
+        expect(sorted).toHaveLength(wastes.length)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('does not mutate the original array', () => {
+    fc.assert(
+      fc.property(fc.array(wasteArb, { minLength: 1, maxLength: 20 }), (wastes) => {
+        const original = wastes.map((w) => w.recycled_timestamp)
+        sortWastesDescending(wastes)
+        const after = wastes.map((w) => w.recycled_timestamp)
+        expect(after).toEqual(original)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('handles empty list without error', () => {
+    const result = sortWastesDescending([])
+    expect(result).toEqual([])
+  })
+
+  it('single item list is already sorted', () => {
+    fc.assert(
+      fc.property(wasteArb, (waste) => {
+        const result = sortWastesDescending([waste])
+        expect(result).toHaveLength(1)
+        expect(result[0].waste_id).toBe(waste.waste_id)
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature: frontend-enhancements, Property 6: Edit form rejects empty names
+// Validates: Requirements 5.4
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Inline validation logic mirroring EditProfileModal's handleSubmit check
+function validateProfileName(name: string): { valid: boolean; error?: string } {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    return { valid: false, error: 'Name cannot be empty.' }
+  }
+  return { valid: true }
+}
+
+describe('Property 6: Edit form rejects empty names', () => {
+  // Generator for whitespace-only strings (including empty string)
+  const whitespaceOnlyArb = fc.stringOf(
+    fc.constantFrom(' ', '\t', '\n', '\r', '\u00a0'),
+    { minLength: 0, maxLength: 30 }
+  )
+
+  it('rejects any whitespace-only or empty name', () => {
+    fc.assert(
+      fc.property(whitespaceOnlyArb, (name) => {
+        const result = validateProfileName(name)
+        expect(result.valid).toBe(false)
+        expect(result.error).toBeTruthy()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('accepts names with at least one non-whitespace character', () => {
+    // Generate strings that have at least one non-whitespace char
+    const validNameArb = fc
+      .tuple(
+        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => s.trim().length > 0),
+        fc.string({ minLength: 0, maxLength: 5 }).map((s) => s.replace(/\S/g, ' ')),
+        fc.string({ minLength: 0, maxLength: 5 }).map((s) => s.replace(/\S/g, ' '))
+      )
+      .map(([core, prefix, suffix]) => prefix + core + suffix)
+
+    fc.assert(
+      fc.property(validNameArb, (name) => {
+        const result = validateProfileName(name)
+        expect(result.valid).toBe(true)
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature: frontend-enhancements, Property 7: Profile image file validation
+// Validates: Requirements 5.6
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { validateProfileImage } from '@/lib/profile'
+
+const MAX_FILE_SIZE = 2_097_152 // 2 MB
+
+describe('Property 7: Profile image file validation', () => {
+  const allowedMimeTypes = ['image/jpeg', 'image/png']
+  const disallowedMimeTypes = ['image/gif', 'image/webp', 'image/bmp', 'application/pdf', 'text/plain', 'video/mp4']
+
+  it('accepts JPEG and PNG files within 2 MB', () => {
+    const validFileArb = fc.record({
+      type: fc.constantFrom(...allowedMimeTypes),
+      size: fc.integer({ min: 1, max: MAX_FILE_SIZE }),
+    })
+
+    fc.assert(
+      fc.property(validFileArb, (file) => {
+        const result = validateProfileImage(file)
+        expect(result.valid).toBe(true)
+        expect(result.error).toBeUndefined()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('rejects files with disallowed MIME types regardless of size', () => {
+    const invalidTypeArb = fc.record({
+      type: fc.constantFrom(...disallowedMimeTypes),
+      size: fc.integer({ min: 1, max: MAX_FILE_SIZE }),
+    })
+
+    fc.assert(
+      fc.property(invalidTypeArb, (file) => {
+        const result = validateProfileImage(file)
+        expect(result.valid).toBe(false)
+        expect(result.error).toBeTruthy()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('rejects files exceeding 2 MB even if MIME type is valid', () => {
+    const oversizedArb = fc.record({
+      type: fc.constantFrom(...allowedMimeTypes),
+      size: fc.integer({ min: MAX_FILE_SIZE + 1, max: MAX_FILE_SIZE * 10 }),
+    })
+
+    fc.assert(
+      fc.property(oversizedArb, (file) => {
+        const result = validateProfileImage(file)
+        expect(result.valid).toBe(false)
+        expect(result.error).toBeTruthy()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('rejects files that are both wrong type and oversized', () => {
+    const bothInvalidArb = fc.record({
+      type: fc.constantFrom(...disallowedMimeTypes),
+      size: fc.integer({ min: MAX_FILE_SIZE + 1, max: MAX_FILE_SIZE * 10 }),
+    })
+
+    fc.assert(
+      fc.property(bothInvalidArb, (file) => {
+        const result = validateProfileImage(file)
+        expect(result.valid).toBe(false)
+        expect(result.error).toBeTruthy()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('accepts a file at exactly 2 MB boundary', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...allowedMimeTypes), (type) => {
+        const result = validateProfileImage({ type, size: MAX_FILE_SIZE })
+        expect(result.valid).toBe(true)
+      }),
+      { numRuns: 10 }
+    )
+  })
+
+  it('rejects a file one byte over 2 MB', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...allowedMimeTypes), (type) => {
+        const result = validateProfileImage({ type, size: MAX_FILE_SIZE + 1 })
+        expect(result.valid).toBe(false)
+      }),
+      { numRuns: 10 }
+    )
+  })
+})

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,867 @@
+import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import {
+  Coins,
+  Package,
+  ArrowRightLeft,
+  Star,
+  AlertCircle,
+  RefreshCw,
+  Recycle,
+  CheckCircle2,
+  Lock,
+  Clock,
+  XCircle,
+  Pencil,
+  Upload,
+} from 'lucide-react'
+import { useParticipant } from '@/hooks/useParticipant'
+import { useProfileStats } from '@/hooks/useProfileStats'
+import {
+  generateAvatarUrl,
+  computeReputationScore,
+  computeMilestones,
+  validateProfileImage,
+  getStoredProfileName,
+  setStoredProfileName,
+  getStoredProfileImage,
+  setStoredProfileImage,
+} from '@/lib/profile'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { StatCard } from '@/components/ui/StatCard'
+import { AddressDisplay } from '@/components/ui/AddressDisplay'
+import { StatCardSkeleton } from '@/components/ui/Skeletons'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { WasteDetailsModal } from '@/components/modals/WasteDetailsModal'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { WasteType, Waste, ParticipantStats } from '@/api/types'
+import { wasteTypeLabel, formatDate } from '@/lib/helpers'
+import { cn } from '@/lib/utils'
+import { useQueryClient } from '@tanstack/react-query'
+import { useWallet } from '@/context/WalletContext'
+import { useToast } from '@/hooks/useToast'
+
+const WASTE_TYPE_LABELS: Record<number, string> = {
+  [WasteType.Paper]: 'Paper',
+  [WasteType.PetPlastic]: 'PET Plastic',
+  [WasteType.Plastic]: 'Plastic',
+  [WasteType.Metal]: 'Metal',
+  [WasteType.Glass]: 'Glass',
+}
+
+const PIE_COLORS = ['#22c55e', '#3b82f6', '#f59e0b', '#ef4444', '#8b5cf6']
+
+// ─── Skeleton helpers ────────────────────────────────────────────────────────
+
+function ProfileHeaderSkeleton() {
+  return (
+    <Card className="p-4 sm:p-6">
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+        <div className="h-20 w-20 animate-pulse rounded-full bg-muted shrink-0" />
+        <div className="flex-1 space-y-3 text-center sm:text-left">
+          <div className="h-6 w-40 animate-pulse rounded bg-muted mx-auto sm:mx-0" />
+          <div className="h-4 w-32 animate-pulse rounded bg-muted mx-auto sm:mx-0" />
+          <div className="flex flex-wrap justify-center gap-2 sm:justify-start">
+            <div className="h-5 w-20 animate-pulse rounded-full bg-muted" />
+            <div className="h-5 w-28 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="h-48 w-full animate-pulse rounded-lg bg-muted" />
+  )
+}
+
+// ─── ProfileHeader ────────────────────────────────────────────────────────────
+
+interface ProfileHeaderProps {
+  name: string
+  address: string
+  role: string
+  registeredAt: number
+  profileImageUrl?: string | null
+  canEdit?: boolean
+  onEditClick?: () => void
+}
+
+function ProfileHeader({ name, address, role, registeredAt, profileImageUrl, canEdit, onEditClick }: ProfileHeaderProps) {
+  const avatarUrl = profileImageUrl || generateAvatarUrl(address)
+  const formattedDate = new Date(registeredAt * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
+  return (
+    <Card className="p-4 sm:p-6">
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+        <img
+          src={avatarUrl}
+          alt={`${name} avatar`}
+          className="h-20 w-20 rounded-full border-2 border-primary/20 bg-muted shrink-0 object-cover"
+          onError={(e) => {
+            ;(e.currentTarget as HTMLImageElement).style.display = 'none'
+          }}
+        />
+        <div className="flex-1 space-y-2 text-center sm:text-left">
+          <div className="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h1 className="text-xl font-bold sm:text-2xl">{name}</h1>
+            {canEdit && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onEditClick}
+                aria-label="Edit profile"
+              >
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Edit Profile
+              </Button>
+            )}
+          </div>
+          <AddressDisplay address={address} chars={6} showExplorer />
+          <div className="flex flex-wrap justify-center gap-2 sm:justify-start">
+            <Badge variant="secondary">{role}</Badge>
+            <span className="text-xs text-muted-foreground self-center">
+              Joined {formattedDate}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+// ─── StatsSection ─────────────────────────────────────────────────────────────
+
+interface StatsSectionProps {
+  totalEarned: bigint
+  materialsSubmitted: number
+  transfersCount: number
+  reputationScore: number
+  wastes: import('@/api/types').Waste[]
+  isLoading: boolean
+  isError: boolean
+  onRetry: () => void
+}
+
+function StatsSection({
+  totalEarned,
+  materialsSubmitted,
+  transfersCount,
+  reputationScore,
+  wastes,
+  isLoading,
+  isError,
+  onRetry,
+}: StatsSectionProps) {
+  // Waste type breakdown for PieChart
+  const pieData = useMemo(() => {
+    const counts: Record<number, number> = {}
+    for (const w of wastes) {
+      counts[w.waste_type] = (counts[w.waste_type] ?? 0) + 1
+    }
+    return Object.entries(counts).map(([type, count]) => ({
+      name: WASTE_TYPE_LABELS[Number(type)] ?? `Type ${type}`,
+      value: count,
+    }))
+  }, [wastes])
+
+  // Submissions over time for BarChart (group by month)
+  const barData = useMemo(() => {
+    const byMonth: Record<string, number> = {}
+    for (const w of wastes) {
+      const d = new Date(w.recycled_timestamp * 1000)
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+      byMonth[key] = (byMonth[key] ?? 0) + 1
+    }
+    return Object.entries(byMonth)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .slice(-6)
+      .map(([month, count]) => ({ month, count }))
+  }, [wastes])
+
+  if (isError) {
+    return (
+      <Card className="p-4 sm:p-6">
+        <div className="flex flex-col items-center gap-3 py-4 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <p className="text-sm text-muted-foreground">Failed to load statistics.</p>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {isLoading ? (
+          <>
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+          </>
+        ) : (
+          <>
+            <StatCard
+              icon={<Coins className="h-4 w-4" />}
+              label="Total Earned"
+              value={`${totalEarned.toString()} tokens`}
+              variant="success"
+            />
+            <StatCard
+              icon={<Package className="h-4 w-4" />}
+              label="Materials Submitted"
+              value={materialsSubmitted}
+              variant="primary"
+            />
+            <StatCard
+              icon={<ArrowRightLeft className="h-4 w-4" />}
+              label="Transfers"
+              value={transfersCount}
+            />
+            <StatCard
+              icon={<Star className="h-4 w-4" />}
+              label="Reputation Score"
+              value={reputationScore}
+              variant="warning"
+            />
+          </>
+        )}
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Waste by Type</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <ChartSkeleton />
+            ) : pieData.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">No data yet</p>
+            ) : (
+              <ResponsiveContainer width="100%" height={200}>
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    dataKey="value"
+                    label={({ name, percent }) =>
+                      `${name} ${(percent * 100).toFixed(0)}%`
+                    }
+                    labelLine={false}
+                  >
+                    {pieData.map((_, index) => (
+                      <Cell key={index} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Submissions Over Time</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <ChartSkeleton />
+            ) : barData.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">No data yet</p>
+            ) : (
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart data={barData}>
+                  <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <Tooltip />
+                  <Bar dataKey="count" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+// ─── WasteTimeline ────────────────────────────────────────────────────────────
+
+const WASTE_TYPE_ICONS: Record<number, string> = {
+  [WasteType.Paper]: '📰',
+  [WasteType.PetPlastic]: '♻️',
+  [WasteType.Plastic]: '🧴',
+  [WasteType.Metal]: '🔩',
+  [WasteType.Glass]: '🫙',
+}
+
+const TIMELINE_PAGE_SIZE = 10
+
+interface WasteTimelineItemProps {
+  waste: Waste
+  onClick: (waste: Waste) => void
+}
+
+function WasteTimelineItem({ waste, onClick }: WasteTimelineItemProps) {
+  const isConfirmed = waste.is_confirmed
+  const isActive = waste.is_active
+
+  let statusIcon: React.ReactNode
+  let statusClass: string
+  if (!isActive) {
+    statusIcon = <XCircle className="h-3.5 w-3.5" />
+    statusClass = 'bg-muted text-muted-foreground border-border'
+  } else if (isConfirmed) {
+    statusIcon = <CheckCircle2 className="h-3.5 w-3.5" />
+    statusClass =
+      'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+  } else {
+    statusIcon = <Clock className="h-3.5 w-3.5" />
+    statusClass =
+      'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800'
+  }
+
+  const statusLabel = !isActive ? 'Inactive' : isConfirmed ? 'Confirmed' : 'Pending'
+  const weightNum = Number(waste.weight)
+  const weightStr = weightNum >= 1000 ? `${(weightNum / 1000).toFixed(2)} kg` : `${weightNum} g`
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(waste)}
+      className="w-full text-left rounded-lg border bg-card p-3 shadow-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-xl shrink-0" aria-hidden="true">
+          {WASTE_TYPE_ICONS[waste.waste_type] ?? '🗑️'}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium truncate">
+              {wasteTypeLabel(waste.waste_type)} — #{waste.waste_id.toString()}
+            </span>
+            <Badge
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1 border text-xs font-medium',
+                statusClass
+              )}
+            >
+              {statusIcon}
+              {statusLabel}
+            </Badge>
+          </div>
+          <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+            <span>{weightStr}</span>
+            <span>·</span>
+            <span>{formatDate(waste.recycled_timestamp)}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+interface WasteTimelineProps {
+  wastes: Waste[]
+  isLoading: boolean
+}
+
+export function WasteTimeline({ wastes, isLoading }: WasteTimelineProps) {
+  const [visibleCount, setVisibleCount] = useState(TIMELINE_PAGE_SIZE)
+  const [selectedWaste, setSelectedWaste] = useState<Waste | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  // Sort descending by recycled_timestamp (most recent first)
+  const sorted = useMemo(
+    () => [...wastes].sort((a, b) => b.recycled_timestamp - a.recycled_timestamp),
+    [wastes]
+  )
+
+  const visible = sorted.slice(0, visibleCount)
+  const hasMore = visibleCount < sorted.length
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => prev + TIMELINE_PAGE_SIZE)
+  }, [])
+
+  // Intersection Observer for lazy loading
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || !hasMore) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore()
+        }
+      },
+      { rootMargin: '100px' }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, loadMore])
+
+  const handleItemClick = (waste: Waste) => {
+    setSelectedWaste(waste)
+    setModalOpen(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Waste History</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-16 animate-pulse rounded-lg bg-muted" />
+            ))}
+          </div>
+        ) : sorted.length === 0 ? (
+          <EmptyState
+            icon={Recycle}
+            title="No waste items yet"
+            description="Submit your first waste item to start building your recycling history."
+          />
+        ) : (
+          <div className="space-y-2">
+            {visible.map((waste) => (
+              <WasteTimelineItem
+                key={waste.waste_id.toString()}
+                waste={waste}
+                onClick={handleItemClick}
+              />
+            ))}
+            {/* Sentinel element for Intersection Observer */}
+            {hasMore && <div ref={sentinelRef} className="h-1" aria-hidden="true" />}
+          </div>
+        )}
+      </CardContent>
+
+      <WasteDetailsModal
+        waste={selectedWaste}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </Card>
+  )
+}
+
+// ─── AchievementsSection ──────────────────────────────────────────────────────
+
+interface AchievementsSectionProps {
+  stats: ParticipantStats | null
+}
+
+function AchievementsSection({ stats }: AchievementsSectionProps) {
+  const milestones = useMemo(
+    () =>
+      stats
+        ? computeMilestones(stats)
+        : [
+            { id: 'first_submission', label: 'First Submission', description: 'Submit your first waste item', reached: false },
+            { id: 'ten_transfers', label: '10 Transfers', description: 'Complete 10 waste transfers', reached: false },
+            { id: 'hundred_tokens', label: '100 Tokens', description: 'Earn 100 tokens', reached: false },
+            { id: 'fifty_materials', label: '50 Submissions', description: 'Submit 50 waste items', reached: false },
+          ],
+    [stats]
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Achievements</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {milestones.map((milestone) => (
+            <div
+              key={milestone.id}
+              className={cn(
+                'flex items-start gap-3 rounded-lg border p-3 transition-colors',
+                milestone.reached
+                  ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20'
+                  : 'border-border bg-muted/30 opacity-60'
+              )}
+            >
+              <span
+                className={cn(
+                  'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
+                  milestone.reached
+                    ? 'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400'
+                    : 'bg-muted text-muted-foreground'
+                )}
+                aria-label={milestone.reached ? 'Achieved' : 'Not yet achieved'}
+              >
+                {milestone.reached ? (
+                  <CheckCircle2 className="h-4 w-4" />
+                ) : (
+                  <Lock className="h-3.5 w-3.5" />
+                )}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-medium leading-tight">{milestone.label}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{milestone.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── EditProfileModal ─────────────────────────────────────────────────────────
+
+interface EditProfileModalProps {
+  open: boolean
+  onClose: () => void
+  currentName: string
+  address: string
+  onSave: (name: string, imageDataUrl: string | null) => Promise<void>
+}
+
+function EditProfileModal({ open, onClose, currentName, address, onSave }: EditProfileModalProps) {
+  const [name, setName] = useState(currentName)
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(
+    getStoredProfileImage(address)
+  )
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setName(currentName)
+      setNameError(null)
+      setImageFile(null)
+      setImagePreview(getStoredProfileImage(address))
+      setImageError(null)
+    }
+  }, [open, currentName, address])
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const result = validateProfileImage(file)
+    if (!result.valid) {
+      setImageError(result.error ?? 'Invalid file.')
+      setImageFile(null)
+      setImagePreview(getStoredProfileImage(address))
+      e.target.value = ''
+      return
+    }
+
+    setImageError(null)
+    setImageFile(file)
+
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      setImagePreview(ev.target?.result as string)
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setNameError('Name cannot be empty.')
+      return
+    }
+    setNameError(null)
+
+    setIsSaving(true)
+    try {
+      let dataUrl: string | null = null
+      if (imageFile) {
+        dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = (ev) => resolve(ev.target?.result as string)
+          reader.onerror = reject
+          reader.readAsDataURL(imageFile)
+        })
+      }
+      await onSave(trimmed, dataUrl)
+      onClose()
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Profile</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+          {/* Name field */}
+          <div className="space-y-1.5">
+            <label htmlFor="edit-profile-name" className="text-sm font-medium">
+              Display Name
+            </label>
+            <Input
+              id="edit-profile-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value)
+                if (nameError) setNameError(null)
+              }}
+              placeholder="Enter your name"
+              aria-describedby={nameError ? 'edit-name-error' : undefined}
+              aria-invalid={!!nameError}
+            />
+            {nameError && (
+              <p id="edit-name-error" className="text-xs text-destructive" role="alert">
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          {/* Image upload */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Profile Image</label>
+            <div className="flex items-center gap-3">
+              {imagePreview ? (
+                <img
+                  src={imagePreview}
+                  alt="Profile preview"
+                  className="h-16 w-16 rounded-full border-2 border-primary/20 object-cover shrink-0"
+                />
+              ) : (
+                <div className="h-16 w-16 rounded-full bg-muted border-2 border-border shrink-0 flex items-center justify-center">
+                  <Upload className="h-5 w-5 text-muted-foreground" />
+                </div>
+              )}
+              <div className="flex-1 space-y-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Upload className="mr-2 h-3.5 w-3.5" />
+                  Choose Image
+                </Button>
+                <p className="text-xs text-muted-foreground">JPEG or PNG, max 2 MB</p>
+              </div>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png"
+              className="sr-only"
+              onChange={handleFileChange}
+              aria-label="Upload profile image"
+            />
+            {imageError && (
+              <p className="text-xs text-destructive" role="alert">
+                {imageError}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── ProfilePage ──────────────────────────────────────────────────────────────
+
+export function ProfilePage() {
+  const { address } = useWallet()
+  const queryClient = useQueryClient()
+  const toast = useToast()
+
+  const { participant, isLoading: isLoadingParticipant, isError: isParticipantError } = useParticipant()
+  const { stats, wastes, isLoadingStats, isLoadingWastes, isStatsError } = useProfileStats()
+
+  const [editModalOpen, setEditModalOpen] = useState(false)
+
+  // Resolve displayed name: localStorage override takes precedence
+  const displayName = useMemo(() => {
+    if (!participant) return ''
+    return getStoredProfileName(participant.address) ?? participant.name
+  }, [participant])
+
+  // Resolve displayed profile image
+  const displayImage = useMemo(() => {
+    if (!participant) return null
+    return getStoredProfileImage(participant.address)
+  }, [participant])
+
+  const reputationScore = useMemo(
+    () => (stats ? computeReputationScore(stats) : 0),
+    [stats]
+  )
+
+  const retryParticipant = () => {
+    queryClient.invalidateQueries({ queryKey: ['participant', address] })
+  }
+
+  const retryStats = () => {
+    queryClient.invalidateQueries({ queryKey: ['participant-stats', address] })
+    queryClient.invalidateQueries({ queryKey: ['participant-wastes', address] })
+  }
+
+  // Whether the authenticated wallet owns this profile
+  const isOwnProfile = !!address && !!participant && address === participant.address
+
+  const handleSaveProfile = async (newName: string, imageDataUrl: string | null) => {
+    if (!participant) return
+
+    // Snapshot previous cache value for rollback
+    const previousData = queryClient.getQueryData<typeof participant>(['participant', address])
+
+    // Optimistic update in TanStack Query cache
+    queryClient.setQueryData(['participant', address], (old: typeof participant) => {
+      if (!old) return old
+      return { ...old, name: newName }
+    })
+
+    try {
+      // Persist to localStorage
+      setStoredProfileName(participant.address, newName)
+      if (imageDataUrl) {
+        setStoredProfileImage(participant.address, imageDataUrl)
+      }
+    } catch (err) {
+      // Revert optimistic update on error
+      queryClient.setQueryData(['participant', address], previousData)
+      toast.error(err)
+      throw err
+    }
+  }
+
+  // Participant loading state
+  if (isLoadingParticipant) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-6 p-4 sm:p-6">
+        <ProfileHeaderSkeleton />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+        </div>
+      </div>
+    )
+  }
+
+  // Participant error state
+  if (isParticipantError || !participant) {
+    return (
+      <div className="mx-auto max-w-4xl p-4 sm:p-6">
+        <Card className="p-6">
+          <div className="flex flex-col items-center gap-4 py-8 text-center">
+            <AlertCircle className="h-12 w-12 text-destructive" aria-hidden="true" />
+            <div>
+              <h2 className="text-lg font-semibold">Failed to load profile</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {!participant && !isParticipantError
+                  ? 'No profile found for this wallet address.'
+                  : 'There was an error loading your profile data.'}
+              </p>
+            </div>
+            <Button onClick={retryParticipant} variant="outline">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Retry
+            </Button>
+          </div>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 sm:p-6">
+      <ProfileHeader
+        name={displayName}
+        address={participant.address}
+        role={participant.role}
+        registeredAt={participant.registered_at}
+        profileImageUrl={displayImage}
+        canEdit={isOwnProfile}
+        onEditClick={() => setEditModalOpen(true)}
+      />
+
+      <StatsSection
+        totalEarned={stats?.total_earned ?? 0n}
+        materialsSubmitted={stats?.materials_submitted ?? 0}
+        transfersCount={stats?.transfers_count ?? 0}
+        reputationScore={reputationScore}
+        wastes={wastes}
+        isLoading={isLoadingStats || isLoadingWastes}
+        isError={isStatsError}
+        onRetry={retryStats}
+      />
+
+      <WasteTimeline wastes={wastes} isLoading={isLoadingWastes} />
+
+      <AchievementsSection stats={stats} />
+
+      <EditProfileModal
+        open={editModalOpen}
+        onClose={() => setEditModalOpen(false)}
+        currentName={displayName}
+        address={participant.address}
+        onSave={handleSaveProfile}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useSearch } from '@/hooks/useSearch'
+import { SearchPanel, DEFAULT_FILTERS } from '@/components/ui/SearchPanel'
+import { WasteDetailsModal } from '@/components/modals/WasteDetailsModal'
+import { filtersToSearchParams, searchParamsToFilters } from '@/lib/searchStorage'
+import type { SearchFilters } from '@/lib/searchStorage'
+import type { Waste } from '@/api/types'
+
+const PAGE_SIZE = 10
+
+export function SearchResultsPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Initialise query + filters from URL on mount
+  const { query: initialQuery, filters: initialFilters } = searchParamsToFilters(searchParams)
+
+  const [filters, setFilters] = useState<SearchFilters>(initialFilters)
+  const [wastePage, setWastePage] = useState(1)
+  const [participantPage, setParticipantPage] = useState(1)
+  const [selectedWaste, setSelectedWaste] = useState<Waste | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const query = initialQuery
+
+  // Sync URL whenever filters change
+  useEffect(() => {
+    const next = filtersToSearchParams(query, filters)
+    setSearchParams(next, { replace: true })
+    // Reset pagination when filters change
+    setWastePage(1)
+    setParticipantPage(1)
+  }, [filters, query]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const results = useSearch(query, filters)
+
+  const wastes = results.filter((r) => r.type === 'waste')
+  const participants = results.filter((r) => r.type === 'participant')
+
+  const pagedWastes = wastes.slice(0, wastePage * PAGE_SIZE)
+  const pagedParticipants = participants.slice(0, participantPage * PAGE_SIZE)
+
+  function openWasteModal(waste: Waste) {
+    setSelectedWaste(waste)
+    setModalOpen(true)
+  }
+
+  function handleFiltersChange(next: SearchFilters) {
+    setFilters(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Search Results</h1>
+        {query && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {results.length} result{results.length !== 1 ? 's' : ''} for &ldquo;{query}&rdquo;
+          </p>
+        )}
+      </div>
+
+      {/* Advanced filters panel */}
+      <SearchPanel filters={filters} onChange={handleFiltersChange} />
+
+      {/* Empty state */}
+      {results.length === 0 && query && (
+        <div className="rounded-lg border p-8 text-center">
+          <p className="text-muted-foreground">
+            No results found for &ldquo;{query}&rdquo;. Try broadening your search.
+          </p>
+        </div>
+      )}
+
+      {/* Waste Items section */}
+      {wastes.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Waste Items ({wastes.length})</h2>
+          <ul className="space-y-2">
+            {pagedWastes.map((r) => (
+              <li
+                key={r.id}
+                className="cursor-pointer rounded-md border p-3 transition-colors hover:bg-accent"
+                onClick={() => openWasteModal(r.data as Waste)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') openWasteModal(r.data as Waste)
+                }}
+              >
+                <p className="font-medium">{r.label}</p>
+                <p className="text-sm text-muted-foreground">{r.sublabel}</p>
+              </li>
+            ))}
+          </ul>
+          {pagedWastes.length < wastes.length && (
+            <button
+              className="mt-3 text-sm text-primary hover:underline"
+              onClick={() => setWastePage((p) => p + 1)}
+            >
+              Show more ({wastes.length - pagedWastes.length} remaining)
+            </button>
+          )}
+        </section>
+      )}
+
+      {/* Participants section */}
+      {participants.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Participants ({participants.length})</h2>
+          <ul className="space-y-2">
+            {pagedParticipants.map((r) => (
+              <li key={r.id} className="rounded-md border p-3">
+                <p className="font-medium">{r.label}</p>
+                <p className="text-sm text-muted-foreground">{r.sublabel}</p>
+              </li>
+            ))}
+          </ul>
+          {pagedParticipants.length < participants.length && (
+            <button
+              className="mt-3 text-sm text-primary hover:underline"
+              onClick={() => setParticipantPage((p) => p + 1)}
+            >
+              Show more ({participants.length - pagedParticipants.length} remaining)
+            </button>
+          )}
+        </section>
+      )}
+
+      {/* WasteDetailsModal */}
+      <WasteDetailsModal
+        waste={selectedWaste}
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false)
+          setSelectedWaste(null)
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { NETWORK_CONFIGS } from '@/lib/stellar'
 import { Button } from '@/components/ui/Button'
 import { Switch } from '@/components/ui/Switch'
 import { cn } from '@/lib/utils'
+import { NotificationStore, type NotificationPreferences, type NotificationType } from '@/lib/notifications'
 
 // ── Section wrapper ───────────────────────────────────────────────────────────
 
@@ -56,6 +57,9 @@ export function SettingsPage() {
   const { theme, isDark, isReady, setTheme } = useTheme()
 
   const [copied, setCopied] = useState(false)
+  const [notifPrefs, setNotifPrefs] = useState<NotificationPreferences>(() =>
+    NotificationStore.loadPrefs()
+  )
 
   function copyAddress() {
     if (!address) return
@@ -73,6 +77,12 @@ export function SettingsPage() {
   function handleNetworkChange(network: Network) {
     const netCfg = NETWORK_CONFIGS[network]
     updateConfig({ network, rpcUrl: netCfg.rpcUrl })
+  }
+
+  function handleNotifToggle(type: NotificationType, checked: boolean) {
+    const updated = { ...notifPrefs, [type]: checked }
+    setNotifPrefs(updated)
+    NotificationStore.savePrefs(updated)
   }
 
   return (
@@ -175,6 +185,50 @@ export function SettingsPage() {
             RPC: <span className="font-mono">{config.rpcUrl}</span>
           </p>
         </div>
+      </Section>
+
+      {/* Notifications */}
+      <Section title="Notifications">
+        <Row
+          label="Transfer notifications"
+          description="Notify when waste is transferred to or from you"
+        >
+          <Switch
+            checked={notifPrefs.transfer}
+            onCheckedChange={(checked) => handleNotifToggle('transfer', checked)}
+            aria-label="Toggle transfer notifications"
+          />
+        </Row>
+        <Row
+          label="Confirmation notifications"
+          description="Notify when waste is confirmed"
+        >
+          <Switch
+            checked={notifPrefs.confirmation}
+            onCheckedChange={(checked) => handleNotifToggle('confirmation', checked)}
+            aria-label="Toggle confirmation notifications"
+          />
+        </Row>
+        <Row
+          label="Reward notifications"
+          description="Notify when you earn tokens"
+        >
+          <Switch
+            checked={notifPrefs.reward}
+            onCheckedChange={(checked) => handleNotifToggle('reward', checked)}
+            aria-label="Toggle reward notifications"
+          />
+        </Row>
+        <Row
+          label="System notifications"
+          description="Notify about platform announcements"
+        >
+          <Switch
+            checked={notifPrefs.system}
+            onCheckedChange={(checked) => handleNotifToggle('system', checked)}
+            aria-label="Toggle system notifications"
+          />
+        </Row>
       </Section>
     </div>
   )

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -14,8 +14,8 @@ const HomePage = lazy(() => import('@/pages/HomePage').then((m) => ({ default: m
 const RecyclerDashboard = lazy(() =>
   import('@/pages/RecyclerDashboard').then((m) => ({ default: m.RecyclerDashboard }))
 )
-const IncentivesPage = lazy(() =>
-  import('@/pages/IncentivesPage').then((m) => ({ default: m.IncentivesPage }))
+const IncentivesMarketplacePage = lazy(() =>
+  import('@/pages/IncentivesMarketplacePage').then((m) => ({ default: m.IncentivesMarketplacePage }))
 )
 const WasteListPage = lazy(() =>
   import('@/pages/WasteListPage').then((m) => ({ default: m.WasteListPage }))
@@ -42,6 +42,12 @@ const CommunityPage = lazy(() =>
 )
 const AnalyticsPage = lazy(() =>
   import('@/pages/AnalyticsPage').then((m) => ({ default: m.AnalyticsPage }))
+)
+const ProfilePage = lazy(() =>
+  import('@/pages/ProfilePage').then((m) => ({ default: m.ProfilePage }))
+)
+const SearchResultsPage = lazy(() =>
+  import('@/pages/SearchResultsPage').then((m) => ({ default: m.SearchResultsPage }))
 )
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -75,7 +81,7 @@ export const router = createBrowserRouter([
       { path: 'dashboard', element: <HomePage /> },
       { path: 'submit', element: <div>Submit Waste</div> },
       { path: 'collect', element: <CollectorDashboardPage /> },
-      { path: 'incentives', element: <IncentivesPage /> },
+      { path: 'incentives', element: <IncentivesMarketplacePage /> },
       { path: 'transfer', element: <div>Transfer</div> },
       { path: 'history', element: <div>History</div> },
       { path: 'dashboard/recycler', element: <RecyclerDashboard /> },
@@ -85,7 +91,9 @@ export const router = createBrowserRouter([
       { path: 'rewards', element: <RewardsPage /> },
       { path: 'tracker', element: <SupplyChainTrackerPage /> },
       { path: 'community', element: <CommunityPage /> },
-      { path: 'analytics', element: <AnalyticsPage /> }
+      { path: 'analytics', element: <AnalyticsPage /> },
+      { path: 'profile', element: <ProfilePage /> },
+      { path: 'search', element: <SearchResultsPage /> }
     ]
   },
   { path: '*', element: <NotFoundPage /> }


### PR DESCRIPTION
## Summary

Implements four frontend enhancements for the Scavngr application: Participant Profile Page, Advanced Search and Filtering, Incentives Marketplace, and Notification System.

## Changes

### Participant Profile Page (`/profile`)
- `ProfilePage.tsx` with avatar, stats (Recharts PieChart + BarChart), lazy-loaded waste history timeline, achievements/milestones, and reputation score
- Edit profile flow with name update and image upload (JPEG/PNG ≤ 2 MB), optimistic cache update with rollback
- `useProfileStats` hook, `lib/profile.ts` utilities (`computeReputationScore`, `computeMilestones`, `generateAvatarUrl`)
- Linked from sidebar and mobile bottom nav

### Advanced Search and Filtering
- Global `SearchBar` in header with `Cmd+K`/`Ctrl+K` shortcut, debounced 300ms, history dropdown, inline results preview (capped at 5)
- `SearchPanel` with WasteType multi-select, status, date range, location filters, active filter count badge, saved presets, and "Clear all"
- `SearchResultsPage` at `/search` with paginated grouped results, `WasteDetailsModal` integration, and shareable URL serialisation
- `useSearch` hook (client-side over TanStack Query cache), `lib/searchStorage.ts` with URL round-trip helpers

### Incentives Marketplace Page (`/incentives`)
- Replaces `IncentivesPage` with `IncentivesMarketplacePage`
- Grid/list view toggle (localStorage), sort by reward/budget/waste type, WasteType + rewarder filters
- `react-window` virtualized rendering, skeleton loading states
- `IncentiveDetailModal` with full details and Claim flow (confirmation step, optimistic update, rollback on error)
- Side-by-side comparison panel for up to 3 incentives, "My Claims" section

### Notification System
- `NotificationBell` in header with unread badge (capped at 99+)
- `NotificationPanel` dropdown with type icons, relative timestamps, mark-as-read, delete, "Mark all as read", and link to preferences
- `NotificationStore` (Firestore + localStorage fallback), batching within 10s window, preference filtering
- `useNotifications` hook with real-time `onSnapshot` listener
- Notification preferences section in SettingsPage (4 toggles, persisted in localStorage)

## Testing

60 tests passing across 6 test files covering 23 correctness properties via `fast-check` property-based testing (100 iterations each).

## Related Issues

Closes #390
Closes #391
Closes #392
Closes #393