### PR TITLE
feat: implement multi-language support with i18next

### DIFF
--- a/frontend/src/components/ui/LanguageSelector.tsx
+++ b/frontend/src/components/ui/LanguageSelector.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { Select } from './Select';
+
+const languages = [
+  { value: 'en', label: 'English' },
+  { value: 'es', label: 'Español' },
+  { value: 'fr', label: 'Français' },
+  { value: 'zh', label: '中文' },
+];
+
+export function LanguageSelector() {
+  const { i18n } = useTranslation();
+
+  const handleLanguageChange = (value: string) => {
+    i18n.changeLanguage(value);
+  };
+
+  return (
+    <Select
+      value={i18n.language}
+      onValueChange={handleLanguageChange}
+      options={languages}
+      placeholder="Select language"
+    />
+  );
+}

--- a/frontend/src/i18n/__tests__/i18n.test.ts
+++ b/frontend/src/i18n/__tests__/i18n.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import i18n from '../config';
+
+describe('i18n Configuration', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('should initialize with English as default', () => {
+    expect(i18n.language).toBe('en');
+  });
+
+  it('should change language to Spanish', async () => {
+    await i18n.changeLanguage('es');
+    expect(i18n.language).toBe('es');
+  });
+
+  it('should change language to French', async () => {
+    await i18n.changeLanguage('fr');
+    expect(i18n.language).toBe('fr');
+  });
+
+  it('should change language to Chinese', async () => {
+    await i18n.changeLanguage('zh');
+    expect(i18n.language).toBe('zh');
+  });
+
+  it('should translate common.loading in English', () => {
+    expect(i18n.t('common.loading')).toBe('Loading...');
+  });
+
+  it('should translate common.loading in Spanish', async () => {
+    await i18n.changeLanguage('es');
+    expect(i18n.t('common.loading')).toBe('Cargando...');
+  });
+
+  it('should translate error messages', () => {
+    expect(i18n.t('errors.network')).toBe('Network error occurred');
+  });
+
+  it('should fallback to English for missing translations', async () => {
+    await i18n.changeLanguage('invalid');
+    expect(i18n.language).toContain('en');
+  });
+
+  it('should persist language preference', async () => {
+    await i18n.changeLanguage('fr');
+    const stored = localStorage.getItem('i18nextLng');
+    expect(stored).toBe('fr');
+  });
+});

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,32 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import en from './locales/en.json';
+import es from './locales/es.json';
+import fr from './locales/fr.json';
+import zh from './locales/zh.json';
+
+const resources = {
+  en: { translation: en },
+  es: { translation: es },
+  fr: { translation: fr },
+  zh: { translation: zh },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+    },
+  });
+
+export default i18n;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,0 +1,47 @@
+{
+  "common": {
+    "loading": "Loading...",
+    "error": "Error",
+    "success": "Success",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "search": "Search",
+    "filter": "Filter",
+    "export": "Export",
+    "download": "Download"
+  },
+  "nav": {
+    "home": "Home",
+    "dashboard": "Dashboard",
+    "analytics": "Analytics",
+    "incentives": "Incentives",
+    "community": "Community",
+    "settings": "Settings"
+  },
+  "waste": {
+    "title": "Waste Management",
+    "register": "Register Waste",
+    "transfer": "Transfer Waste",
+    "details": "Waste Details",
+    "type": "Waste Type",
+    "quantity": "Quantity",
+    "location": "Location",
+    "status": "Status"
+  },
+  "errors": {
+    "network": "Network error occurred",
+    "unauthorized": "Unauthorized access",
+    "notFound": "Resource not found",
+    "validation": "Validation error",
+    "unknown": "An unknown error occurred"
+  },
+  "settings": {
+    "language": "Language",
+    "theme": "Theme",
+    "notifications": "Notifications"
+  }
+}

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,0 +1,47 @@
+{
+  "common": {
+    "loading": "Cargando...",
+    "error": "Error",
+    "success": "Éxito",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "export": "Exportar",
+    "download": "Descargar"
+  },
+  "nav": {
+    "home": "Inicio",
+    "dashboard": "Panel",
+    "analytics": "Análisis",
+    "incentives": "Incentivos",
+    "community": "Comunidad",
+    "settings": "Configuración"
+  },
+  "waste": {
+    "title": "Gestión de Residuos",
+    "register": "Registrar Residuo",
+    "transfer": "Transferir Residuo",
+    "details": "Detalles del Residuo",
+    "type": "Tipo de Residuo",
+    "quantity": "Cantidad",
+    "location": "Ubicación",
+    "status": "Estado"
+  },
+  "errors": {
+    "network": "Error de red",
+    "unauthorized": "Acceso no autorizado",
+    "notFound": "Recurso no encontrado",
+    "validation": "Error de validación",
+    "unknown": "Ocurrió un error desconocido"
+  },
+  "settings": {
+    "language": "Idioma",
+    "theme": "Tema",
+    "notifications": "Notificaciones"
+  }
+}

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1,0 +1,47 @@
+{
+  "common": {
+    "loading": "Chargement...",
+    "error": "Erreur",
+    "success": "Succès",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "search": "Rechercher",
+    "filter": "Filtrer",
+    "export": "Exporter",
+    "download": "Télécharger"
+  },
+  "nav": {
+    "home": "Accueil",
+    "dashboard": "Tableau de bord",
+    "analytics": "Analytique",
+    "incentives": "Incitatifs",
+    "community": "Communauté",
+    "settings": "Paramètres"
+  },
+  "waste": {
+    "title": "Gestion des déchets",
+    "register": "Enregistrer les déchets",
+    "transfer": "Transférer les déchets",
+    "details": "Détails des déchets",
+    "type": "Type de déchet",
+    "quantity": "Quantité",
+    "location": "Emplacement",
+    "status": "Statut"
+  },
+  "errors": {
+    "network": "Erreur réseau",
+    "unauthorized": "Accès non autorisé",
+    "notFound": "Ressource introuvable",
+    "validation": "Erreur de validation",
+    "unknown": "Une erreur inconnue s'est produite"
+  },
+  "settings": {
+    "language": "Langue",
+    "theme": "Thème",
+    "notifications": "Notifications"
+  }
+}

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1,0 +1,47 @@
+{
+  "common": {
+    "loading": "加载中...",
+    "error": "错误",
+    "success": "成功",
+    "cancel": "取消",
+    "confirm": "确认",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "close": "关闭",
+    "search": "搜索",
+    "filter": "筛选",
+    "export": "导出",
+    "download": "下载"
+  },
+  "nav": {
+    "home": "首页",
+    "dashboard": "仪表板",
+    "analytics": "分析",
+    "incentives": "激励",
+    "community": "社区",
+    "settings": "设置"
+  },
+  "waste": {
+    "title": "废物管理",
+    "register": "登记废物",
+    "transfer": "转移废物",
+    "details": "废物详情",
+    "type": "废物类型",
+    "quantity": "数量",
+    "location": "位置",
+    "status": "状态"
+  },
+  "errors": {
+    "network": "网络错误",
+    "unauthorized": "未授权访问",
+    "notFound": "资源未找到",
+    "validation": "验证错误",
+    "unknown": "发生未知错误"
+  },
+  "settings": {
+    "language": "语言",
+    "theme": "主题",
+    "notifications": "通知"
+  }
+}


### PR DESCRIPTION
- Add i18next configuration with language detection
- Support English, Spanish, French, and Chinese translations
- Create LanguageSelector component for settings
- Add translation files for all UI text and error messages
- Implement localStorage persistence for language preference
- Add comprehensive test suite with 9+ tests
- Prepare foundation for future RTL support

Closes #412