### PR TITLE
feat: add route planner, messaging, waste comparison, predictive analytics

### DIFF
--- a/frontend/src/components/ui/WasteComparison.tsx
+++ b/frontend/src/components/ui/WasteComparison.tsx
@@ -1,0 +1,123 @@
+import { Waste, WasteType } from '@/api/types'
+import { wasteTypeLabel, formatDate } from '@/lib/helpers'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Download } from 'lucide-react'
+
+export interface WasteComparisonProps {
+  wastes: Waste[]
+}
+
+interface Row {
+  label: string
+  values: (string | number)[]
+  highlight?: boolean
+}
+
+function numericValues(values: (string | number)[]): number[] {
+  return values.map((v) => (typeof v === 'number' ? v : parseFloat(String(v)) || 0))
+}
+
+function cellClass(value: string | number, values: (string | number)[], highlight?: boolean): string {
+  if (!highlight) return ''
+  const nums = numericValues(values)
+  const max = Math.max(...nums)
+  const min = Math.min(...nums)
+  const n = typeof value === 'number' ? value : parseFloat(String(value)) || 0
+  if (n === max && max !== min) return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+  if (n === min && max !== min) return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+  return ''
+}
+
+function buildRows(wastes: Waste[]): Row[] {
+  return [
+    {
+      label: 'Waste Type',
+      values: wastes.map((w) => wasteTypeLabel(w.waste_type)),
+    },
+    {
+      label: 'Weight (kg)',
+      values: wastes.map((w) => Math.round((Number(w.weight) / 1000) * 100) / 100),
+      highlight: true,
+    },
+    {
+      label: 'Status',
+      values: wastes.map((w) => (!w.is_active ? 'Inactive' : w.is_confirmed ? 'Confirmed' : 'Pending')),
+    },
+    {
+      label: 'Date',
+      values: wastes.map((w) => formatDate(w.recycled_timestamp)),
+    },
+    {
+      label: 'Waste ID',
+      values: wastes.map((w) => `#${String(w.waste_id)}`),
+    },
+  ]
+}
+
+function exportCsv(wastes: Waste[], rows: Row[]) {
+  const headers = ['Field', ...wastes.map((w) => `Waste #${String(w.waste_id)}`)]
+  const lines = [
+    headers.join(','),
+    ...rows.map((r) => [r.label, ...r.values.map((v) => `"${v}"`)].join(',')),
+  ]
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'waste-comparison.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function WasteComparison({ wastes }: WasteComparisonProps) {
+  if (wastes.length === 0) return null
+  const rows = buildRows(wastes)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Comparing {wastes.length} waste item{wastes.length !== 1 ? 's' : ''}</p>
+        <Button size="sm" variant="outline" onClick={() => exportCsv(wastes, rows)}>
+          <Download className="mr-2 h-3 w-3" /> Export CSV
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Field</th>
+              {wastes.map((w) => (
+                <th key={String(w.waste_id)} className="px-4 py-2 text-left font-medium">
+                  <div className="flex items-center gap-1.5">
+                    <Badge variant="secondary">{wasteTypeLabel(w.waste_type)}</Badge>
+                    <span className="text-xs text-muted-foreground">#{String(w.waste_id)}</span>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label} className="border-b last:border-0 hover:bg-muted/30">
+                <td className="px-4 py-2 font-medium text-muted-foreground">{row.label}</td>
+                {row.values.map((val, i) => (
+                  <td
+                    key={i}
+                    className={`px-4 py-2 ${cellClass(val, row.values, row.highlight)}`}
+                  >
+                    {String(val)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// Re-export helpers for tests
+export { buildRows, cellClass, numericValues }

--- a/frontend/src/components/ui/__tests__/WasteComparison.test.tsx
+++ b/frontend/src/components/ui/__tests__/WasteComparison.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WasteComparison, buildRows, cellClass, numericValues } from '@/components/ui/WasteComparison'
+import { Waste, WasteType } from '@/api/types'
+
+function makeWaste(overrides: Partial<Waste> = {}): Waste {
+  return {
+    waste_id: 1n,
+    waste_type: WasteType.Paper,
+    weight: 2000n,
+    current_owner: 'ADDR_A',
+    latitude: 0n,
+    longitude: 0n,
+    recycled_timestamp: 1700000000,
+    is_active: true,
+    is_confirmed: false,
+    confirmer: '',
+    ...overrides,
+  }
+}
+
+// ── Pure helper tests ─────────────────────────────────────────────────────────
+
+describe('numericValues', () => {
+  it('converts numbers to numbers', () => {
+    expect(numericValues([1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('parses numeric strings', () => {
+    expect(numericValues(['1.5', '2.5'])).toEqual([1.5, 2.5])
+  })
+
+  it('returns 0 for non-numeric strings', () => {
+    expect(numericValues(['abc'])).toEqual([0])
+  })
+})
+
+describe('cellClass', () => {
+  it('returns green class for max value', () => {
+    const cls = cellClass(10, [5, 10, 7], true)
+    expect(cls).toContain('green')
+  })
+
+  it('returns red class for min value', () => {
+    const cls = cellClass(5, [5, 10, 7], true)
+    expect(cls).toContain('red')
+  })
+
+  it('returns empty string when all values are equal', () => {
+    const cls = cellClass(5, [5, 5, 5], true)
+    expect(cls).toBe('')
+  })
+
+  it('returns empty string when highlight is false', () => {
+    const cls = cellClass(10, [5, 10], false)
+    expect(cls).toBe('')
+  })
+})
+
+describe('buildRows', () => {
+  it('returns rows for each field', () => {
+    const rows = buildRows([makeWaste()])
+    expect(rows.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('weight row has highlight flag', () => {
+    const rows = buildRows([makeWaste()])
+    const weightRow = rows.find((r) => r.label === 'Weight (kg)')
+    expect(weightRow?.highlight).toBe(true)
+  })
+
+  it('weight is converted from grams to kg', () => {
+    const rows = buildRows([makeWaste({ weight: 5000n })])
+    const weightRow = rows.find((r) => r.label === 'Weight (kg)')
+    expect(weightRow?.values[0]).toBe(5)
+  })
+})
+
+// ── Component tests ───────────────────────────────────────────────────────────
+
+describe('WasteComparison component', () => {
+  it('renders nothing for empty wastes', () => {
+    const { container } = render(<WasteComparison wastes={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders table with waste IDs', () => {
+    render(<WasteComparison wastes={[makeWaste({ waste_id: 42n }), makeWaste({ waste_id: 99n })]} />)
+    expect(screen.getAllByText('#42').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('#99').length).toBeGreaterThan(0)
+  })
+
+  it('shows correct number of columns', () => {
+    render(<WasteComparison wastes={[makeWaste({ waste_id: 1n }), makeWaste({ waste_id: 2n }), makeWaste({ waste_id: 3n })]} />)
+    // 3 waste columns + 1 label column = 4 th elements
+    const headers = document.querySelectorAll('th')
+    expect(headers.length).toBe(4)
+  })
+
+  it('shows export button', () => {
+    render(<WasteComparison wastes={[makeWaste(), makeWaste({ waste_id: 2n })]} />)
+    expect(screen.getByText(/Export CSV/i)).toBeTruthy()
+  })
+
+  it('export button triggers download', () => {
+    const click = vi.fn()
+    const mockAnchor = { href: '', download: '', click, style: {} }
+    const origCreate = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockAnchor as unknown as HTMLElement
+      return origCreate(tag)
+    })
+    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:url'), revokeObjectURL: vi.fn() })
+    render(<WasteComparison wastes={[makeWaste(), makeWaste({ waste_id: 2n })]} />)
+    fireEvent.click(screen.getByText(/Export CSV/i))
+    expect(click).toHaveBeenCalled()
+    vi.restoreAllMocks()
+  })
+})

--- a/frontend/src/hooks/__tests__/useMessaging.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessaging.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React, { useState } from 'react'
+
+// ── Hoisted mocks (must be declared before vi.mock calls) ─────────────────────
+
+const mocks = vi.hoisted(() => ({
+  onSnapshot: vi.fn(),
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  getDocs: vi.fn(),
+  query: vi.fn((...args: unknown[]) => args),
+  where: vi.fn((...args: unknown[]) => args),
+  orderBy: vi.fn((...args: unknown[]) => args),
+  collection: vi.fn(() => 'col'),
+  doc: vi.fn(() => 'docRef'),
+  serverTimestamp: vi.fn(() => ({ _type: 'serverTimestamp' })),
+}))
+
+vi.mock('@/lib/firebase', () => ({ db: {} }))
+vi.mock('firebase/firestore', () => ({
+  collection: mocks.collection,
+  addDoc: mocks.addDoc,
+  query: mocks.query,
+  where: mocks.where,
+  orderBy: mocks.orderBy,
+  onSnapshot: mocks.onSnapshot,
+  updateDoc: mocks.updateDoc,
+  doc: mocks.doc,
+  serverTimestamp: mocks.serverTimestamp,
+  getDocs: mocks.getDocs,
+  Timestamp: { now: () => ({ toMillis: () => Date.now() }) },
+}))
+
+import { useMessaging, Message } from '@/hooks/useMessaging'
+
+function makeMsg(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg1',
+    from: 'ADDR_A',
+    to: 'ADDR_B',
+    subject: 'Hello',
+    body: 'World',
+    read: false,
+    archived: false,
+    createdAt: 1700000000000,
+    threadId: 'thread1',
+    ...overrides,
+  }
+}
+
+function setupSnapshots(inboxMsgs: Message[], sentMsgs: Message[] = [], archivedMsgs: Message[] = []) {
+  let callCount = 0
+  mocks.onSnapshot.mockImplementation((_q: unknown, cb: (snap: unknown) => void) => {
+    const idx = callCount++
+    const msgs = [inboxMsgs, sentMsgs, archivedMsgs][idx] ?? []
+    cb({ docs: msgs.map((m) => ({ id: m.id, data: () => ({ ...m, createdAt: { toMillis: () => m.createdAt } }) })) })
+    return vi.fn()
+  })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useMessaging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.addDoc.mockResolvedValue({ id: 'new_msg' })
+    mocks.updateDoc.mockResolvedValue(undefined)
+  })
+
+  it('returns empty state when no address', async () => {
+    mocks.onSnapshot.mockImplementation(() => vi.fn())
+    const { result } = renderHook(() => useMessaging(null))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.inbox).toHaveLength(0)
+  })
+
+  it('loads inbox messages from snapshot', async () => {
+    setupSnapshots([makeMsg()])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.inbox).toHaveLength(1)
+    expect(result.current.inbox[0].subject).toBe('Hello')
+  })
+
+  it('counts unread messages correctly', async () => {
+    setupSnapshots([makeMsg({ read: false }), makeMsg({ id: 'msg2', read: true })])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.unreadCount).toBe(1)
+  })
+
+  it('getFolder returns inbox messages', async () => {
+    setupSnapshots([makeMsg()])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.getFolder('inbox')).toHaveLength(1)
+  })
+
+  it('getFolder returns sent messages', async () => {
+    setupSnapshots([], [makeMsg({ from: 'ADDR_B', to: 'ADDR_A' })])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.getFolder('sent')).toHaveLength(1)
+  })
+
+  it('getFolder returns archived messages', async () => {
+    setupSnapshots([], [], [makeMsg({ archived: true })])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.getFolder('archived')).toHaveLength(1)
+  })
+
+  it('sendMessage calls addDoc with correct fields', async () => {
+    setupSnapshots([])
+    const { result } = renderHook(() => useMessaging('ADDR_A'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    await act(async () => {
+      await result.current.sendMessage({ to: 'ADDR_B', subject: 'Hi', body: 'Test' })
+    })
+    expect(mocks.addDoc).toHaveBeenCalledOnce()
+    const payload = mocks.addDoc.mock.calls[0][1] as Record<string, unknown>
+    expect(payload.from).toBe('ADDR_A')
+    expect(payload.to).toBe('ADDR_B')
+    expect(payload.subject).toBe('Hi')
+  })
+
+  it('markRead calls updateDoc with read: true', async () => {
+    setupSnapshots([])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    await act(async () => { await result.current.markRead('msg1') })
+    expect(mocks.updateDoc).toHaveBeenCalledWith('docRef', { read: true })
+  })
+
+  it('archiveMessage calls updateDoc with archived: true', async () => {
+    setupSnapshots([])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    await act(async () => { await result.current.archiveMessage('msg1') })
+    expect(mocks.updateDoc).toHaveBeenCalledWith('docRef', { archived: true })
+  })
+
+  it('blockUser hides messages from that sender', async () => {
+    setupSnapshots([makeMsg({ from: 'SPAMMER' })])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.getFolder('inbox')).toHaveLength(1)
+    act(() => result.current.blockUser('SPAMMER'))
+    expect(result.current.getFolder('inbox')).toHaveLength(0)
+  })
+
+  it('unblockUser restores messages', async () => {
+    setupSnapshots([makeMsg({ from: 'SPAMMER' })])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.blockUser('SPAMMER'))
+    act(() => result.current.unblockUser('SPAMMER'))
+    expect(result.current.getFolder('inbox')).toHaveLength(1)
+  })
+
+  it('searchMessages filters by subject', async () => {
+    setupSnapshots([])
+    mocks.getDocs.mockResolvedValue({
+      docs: [
+        { id: 'msg1', data: () => ({ ...makeMsg(), createdAt: { toMillis: () => 0 } }) },
+        { id: 'msg2', data: () => ({ ...makeMsg({ id: 'msg2', subject: 'Other' }), createdAt: { toMillis: () => 0 } }) },
+      ],
+    })
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const results = await result.current.searchMessages('Hello')
+    expect(results.some((m) => m.subject === 'Hello')).toBe(true)
+  })
+
+  it('searchMessages returns empty for blank term', async () => {
+    setupSnapshots([])
+    const { result } = renderHook(() => useMessaging('ADDR_B'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const results = await result.current.searchMessages('')
+    expect(results).toHaveLength(0)
+  })
+})
+
+// ── ComposeModal unit test ────────────────────────────────────────────────────
+
+function ComposeStub({ onSend }: { onSend: (d: { to: string; subject: string; body: string }) => Promise<void> }) {
+  const [to, setTo] = useState('')
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+  return (
+    <div>
+      <input aria-label="to" value={to} onChange={(e) => setTo(e.target.value)} />
+      <input aria-label="subject" value={subject} onChange={(e) => setSubject(e.target.value)} />
+      <textarea aria-label="body" value={body} onChange={(e) => setBody(e.target.value)} />
+      <button onClick={() => onSend({ to, subject, body })}>Send</button>
+    </div>
+  )
+}
+
+describe('ComposeModal stub', () => {
+  it('calls onSend with entered values', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(<ComposeStub onSend={onSend} />)
+    fireEvent.change(screen.getByLabelText('to'), { target: { value: 'ADDR_X' } })
+    fireEvent.change(screen.getByLabelText('subject'), { target: { value: 'Test Subject' } })
+    fireEvent.change(screen.getByLabelText('body'), { target: { value: 'Test body' } })
+    fireEvent.click(screen.getByText('Send'))
+    expect(onSend).toHaveBeenCalledWith({ to: 'ADDR_X', subject: 'Test Subject', body: 'Test body' })
+  })
+})

--- a/frontend/src/hooks/__tests__/usePredictiveAnalytics.test.ts
+++ b/frontend/src/hooks/__tests__/usePredictiveAnalytics.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  linearRegression,
+  usePredictiveAnalytics,
+  DataPoint,
+} from '@/hooks/usePredictiveAnalytics'
+import { Waste, WasteType } from '@/api/types'
+
+// ── linearRegression tests ────────────────────────────────────────────────────
+
+describe('linearRegression', () => {
+  it('returns slope 0 and y-value for single point', () => {
+    const result = linearRegression([{ x: 0, y: 5 }])
+    expect(result.slope).toBe(0)
+    expect(result.intercept).toBe(5)
+  })
+
+  it('fits a perfect line y = 2x + 1', () => {
+    const points: DataPoint[] = [
+      { x: 0, y: 1 },
+      { x: 1, y: 3 },
+      { x: 2, y: 5 },
+      { x: 3, y: 7 },
+    ]
+    const { slope, intercept, r2 } = linearRegression(points)
+    expect(slope).toBeCloseTo(2, 2)
+    expect(intercept).toBeCloseTo(1, 2)
+    expect(r2).toBeCloseTo(1, 2)
+  })
+
+  it('returns r2 = 0 for flat line (no variance)', () => {
+    const points: DataPoint[] = [
+      { x: 0, y: 3 },
+      { x: 1, y: 3 },
+      { x: 2, y: 3 },
+    ]
+    const { r2 } = linearRegression(points)
+    expect(r2).toBe(1) // perfect fit for flat line
+  })
+
+  it('returns negative slope for decreasing data', () => {
+    const points: DataPoint[] = [
+      { x: 0, y: 10 },
+      { x: 1, y: 8 },
+      { x: 2, y: 6 },
+    ]
+    expect(linearRegression(points).slope).toBeLessThan(0)
+  })
+
+  it('r2 is between 0 and 1 for noisy data', () => {
+    const points: DataPoint[] = [
+      { x: 0, y: 1 },
+      { x: 1, y: 5 },
+      { x: 2, y: 2 },
+      { x: 3, y: 8 },
+    ]
+    const { r2 } = linearRegression(points)
+    expect(r2).toBeGreaterThanOrEqual(0)
+    expect(r2).toBeLessThanOrEqual(1)
+  })
+})
+
+// ── usePredictiveAnalytics hook tests ─────────────────────────────────────────
+
+function makeWaste(overrides: Partial<Waste> = {}): Waste {
+  return {
+    waste_id: 1n,
+    waste_type: WasteType.Paper,
+    weight: 1000n,
+    current_owner: 'ADDR',
+    latitude: 0n,
+    longitude: 0n,
+    recycled_timestamp: 1700000000,
+    is_active: true,
+    is_confirmed: false,
+    confirmer: '',
+    ...overrides,
+  }
+}
+
+describe('usePredictiveAnalytics', () => {
+  it('returns predictions for all 5 waste types', () => {
+    const { result } = renderHook(() => usePredictiveAnalytics([]))
+    expect(result.current.predictions).toHaveLength(5)
+  })
+
+  it('returns empty historicalPoints for types with no data', () => {
+    const { result } = renderHook(() => usePredictiveAnalytics([]))
+    result.current.predictions.forEach((p) => {
+      expect(p.historicalPoints).toHaveLength(0)
+    })
+  })
+
+  it('groups wastes into weekly buckets', () => {
+    const wastes = [
+      makeWaste({ waste_id: 1n, recycled_timestamp: 1700000000 }),
+      makeWaste({ waste_id: 2n, recycled_timestamp: 1700000000 + 7 * 24 * 3600 }),
+    ]
+    const { result } = renderHook(() => usePredictiveAnalytics(wastes))
+    const paperPred = result.current.predictions.find((p) => p.wasteType === WasteType.Paper)!
+    expect(paperPred.historicalPoints.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('produces 4 forecast points', () => {
+    const wastes = [makeWaste(), makeWaste({ waste_id: 2n, recycled_timestamp: 1700000000 + 7 * 24 * 3600 })]
+    const { result } = renderHook(() => usePredictiveAnalytics(wastes))
+    const paperPred = result.current.predictions.find((p) => p.wasteType === WasteType.Paper)!
+    expect(paperPred.forecastPoints).toHaveLength(4)
+  })
+
+  it('confidence interval has same length as forecast', () => {
+    const wastes = [makeWaste(), makeWaste({ waste_id: 2n, recycled_timestamp: 1700000000 + 7 * 24 * 3600 })]
+    const { result } = renderHook(() => usePredictiveAnalytics(wastes))
+    const paperPred = result.current.predictions.find((p) => p.wasteType === WasteType.Paper)!
+    expect(paperPred.confidenceInterval).toHaveLength(4)
+  })
+
+  it('trend is flat when slope is near zero', () => {
+    // Same weight every week → flat
+    const wastes = Array.from({ length: 4 }, (_, i) =>
+      makeWaste({ waste_id: BigInt(i), recycled_timestamp: 1700000000 + i * 7 * 24 * 3600 })
+    )
+    const { result } = renderHook(() => usePredictiveAnalytics(wastes))
+    const paperPred = result.current.predictions.find((p) => p.wasteType === WasteType.Paper)!
+    expect(paperPred.trend).toBe('flat')
+  })
+
+  it('optimalTimes only includes types with data', () => {
+    const { result } = renderHook(() => usePredictiveAnalytics([makeWaste()]))
+    result.current.optimalTimes.forEach((ot) => {
+      const pred = result.current.predictions.find((p) => p.wasteType === ot.wasteType)!
+      expect(pred.historicalPoints.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useRoutePlanner.test.ts
+++ b/frontend/src/hooks/__tests__/useRoutePlanner.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  haversineKm,
+  optimizeRoute,
+  computeRouteStats,
+  buildDirections,
+  useRoutePlanner,
+  RouteStop,
+} from '@/hooks/useRoutePlanner'
+
+// ── Pure function tests ───────────────────────────────────────────────────────
+
+describe('haversineKm', () => {
+  it('returns 0 for identical points', () => {
+    expect(haversineKm(10, 20, 10, 20)).toBe(0)
+  })
+
+  it('returns ~111 km per degree of latitude', () => {
+    const d = haversineKm(0, 0, 1, 0)
+    expect(d).toBeGreaterThan(110)
+    expect(d).toBeLessThan(112)
+  })
+
+  it('is symmetric', () => {
+    const d1 = haversineKm(10, 20, 30, 40)
+    const d2 = haversineKm(30, 40, 10, 20)
+    expect(Math.abs(d1 - d2)).toBeLessThan(0.001)
+  })
+
+  it('handles negative coordinates', () => {
+    const d = haversineKm(-33.87, 151.21, -37.81, 144.96) // Sydney to Melbourne
+    expect(d).toBeGreaterThan(700)
+    expect(d).toBeLessThan(800)
+  })
+})
+
+describe('optimizeRoute', () => {
+  const stops: RouteStop[] = [
+    { id: 'a', lat: 0, lng: 0, label: 'A' },
+    { id: 'b', lat: 10, lng: 0, label: 'B' },
+    { id: 'c', lat: 5, lng: 0, label: 'C' },
+  ]
+
+  it('returns empty array for empty input', () => {
+    expect(optimizeRoute([])).toEqual([])
+  })
+
+  it('returns single stop unchanged', () => {
+    expect(optimizeRoute([stops[0]])).toEqual([stops[0]])
+  })
+
+  it('starts with the first stop', () => {
+    const result = optimizeRoute(stops)
+    expect(result[0].id).toBe('a')
+  })
+
+  it('visits nearest neighbour next (C is closer to A than B)', () => {
+    const result = optimizeRoute(stops)
+    expect(result[1].id).toBe('c')
+    expect(result[2].id).toBe('b')
+  })
+
+  it('returns all stops', () => {
+    const result = optimizeRoute(stops)
+    expect(result).toHaveLength(stops.length)
+  })
+})
+
+describe('computeRouteStats', () => {
+  it('returns 0 distance and 0 minutes for empty stops', () => {
+    const { totalDistanceKm, estimatedMinutes } = computeRouteStats([])
+    expect(totalDistanceKm).toBe(0)
+    expect(estimatedMinutes).toBe(0)
+  })
+
+  it('returns 0 distance for single stop but adds per-stop time', () => {
+    const { totalDistanceKm, estimatedMinutes } = computeRouteStats([
+      { id: 'a', lat: 0, lng: 0, label: 'A' },
+    ])
+    expect(totalDistanceKm).toBe(0)
+    expect(estimatedMinutes).toBe(5) // 1 stop × 5 min
+  })
+
+  it('computes distance for two stops', () => {
+    const { totalDistanceKm } = computeRouteStats([
+      { id: 'a', lat: 0, lng: 0, label: 'A' },
+      { id: 'b', lat: 1, lng: 0, label: 'B' },
+    ])
+    expect(totalDistanceKm).toBeGreaterThan(110)
+    expect(totalDistanceKm).toBeLessThan(112)
+  })
+})
+
+describe('buildDirections', () => {
+  it('returns empty array for no stops', () => {
+    expect(buildDirections([])).toEqual([])
+  })
+
+  it('starts with "Start at" for first stop', () => {
+    const dirs = buildDirections([{ id: 'a', lat: 0, lng: 0, label: 'Home' }])
+    expect(dirs[0]).toContain('Start at Home')
+  })
+
+  it('ends with "Route complete"', () => {
+    const dirs = buildDirections([
+      { id: 'a', lat: 0, lng: 0, label: 'A' },
+      { id: 'b', lat: 1, lng: 0, label: 'B' },
+    ])
+    expect(dirs[dirs.length - 1]).toBe('Route complete')
+  })
+
+  it('includes intermediate stop labels', () => {
+    const dirs = buildDirections([
+      { id: 'a', lat: 0, lng: 0, label: 'Alpha' },
+      { id: 'b', lat: 1, lng: 0, label: 'Beta' },
+    ])
+    expect(dirs[1]).toContain('Beta')
+  })
+})
+
+// ── Hook tests ────────────────────────────────────────────────────────────────
+
+const mockStop = (id: string): RouteStop => ({ id, lat: Number(id), lng: 0, label: `Stop ${id}` })
+
+describe('useRoutePlanner hook', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('starts with empty stops and no result', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    expect(result.current.selectedStops).toHaveLength(0)
+    expect(result.current.routeResult).toBeNull()
+  })
+
+  it('addStop adds a stop', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    expect(result.current.selectedStops).toHaveLength(1)
+  })
+
+  it('addStop does not add duplicate', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.addStop(mockStop('1')))
+    expect(result.current.selectedStops).toHaveLength(1)
+  })
+
+  it('removeStop removes a stop', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.removeStop('1'))
+    expect(result.current.selectedStops).toHaveLength(0)
+  })
+
+  it('clearStops empties all stops', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.addStop(mockStop('2')))
+    act(() => result.current.clearStops())
+    expect(result.current.selectedStops).toHaveLength(0)
+  })
+
+  it('optimizeAndPlan produces a route result', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.addStop(mockStop('2')))
+    act(() => result.current.optimizeAndPlan())
+    expect(result.current.routeResult).not.toBeNull()
+    expect(result.current.routeResult?.orderedStops).toHaveLength(2)
+  })
+
+  it('saveRoute persists to localStorage', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.optimizeAndPlan())
+    act(() => result.current.saveRoute('My Route'))
+    expect(result.current.savedRoutes).toHaveLength(1)
+    expect(result.current.savedRoutes[0].name).toBe('My Route')
+    expect(localStorage.getItem('scavngr_saved_routes')).not.toBeNull()
+  })
+
+  it('deleteRoute removes from savedRoutes', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.optimizeAndPlan())
+    act(() => result.current.saveRoute('Route A'))
+    const id = result.current.savedRoutes[0].id
+    act(() => result.current.deleteRoute(id))
+    expect(result.current.savedRoutes).toHaveLength(0)
+  })
+
+  it('loadRoute restores stops and result', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.addStop(mockStop('2')))
+    act(() => result.current.optimizeAndPlan())
+    act(() => result.current.saveRoute('Saved'))
+    const saved = result.current.savedRoutes[0]
+    act(() => result.current.clearStops())
+    act(() => result.current.loadRoute(saved))
+    expect(result.current.selectedStops).toHaveLength(2)
+    expect(result.current.routeResult).not.toBeNull()
+  })
+
+  it('shareRoute returns a string with stop labels', () => {
+    const { result } = renderHook(() => useRoutePlanner())
+    act(() => result.current.addStop(mockStop('1')))
+    act(() => result.current.optimizeAndPlan())
+    const text = result.current.shareRoute(result.current.routeResult!)
+    expect(text).toContain('Stop 1')
+  })
+})

--- a/frontend/src/hooks/useMessaging.ts
+++ b/frontend/src/hooks/useMessaging.ts
@@ -1,0 +1,173 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  updateDoc,
+  doc,
+  serverTimestamp,
+  Timestamp,
+  getDocs,
+} from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+
+export type MessageFolder = 'inbox' | 'sent' | 'archived'
+
+export interface Message {
+  id: string
+  from: string
+  to: string
+  subject: string
+  body: string
+  read: boolean
+  archived: boolean
+  createdAt: number
+  threadId: string
+}
+
+export interface ComposeData {
+  to: string
+  subject: string
+  body: string
+  threadId?: string
+}
+
+function toMessage(id: string, data: Record<string, unknown>): Message {
+  const ts = data.createdAt as Timestamp | null
+  return {
+    id,
+    from: (data.from as string) ?? '',
+    to: (data.to as string) ?? '',
+    subject: (data.subject as string) ?? '',
+    body: (data.body as string) ?? '',
+    read: (data.read as boolean) ?? false,
+    archived: (data.archived as boolean) ?? false,
+    createdAt: ts ? ts.toMillis() : 0,
+    threadId: (data.threadId as string) ?? id,
+  }
+}
+
+export function useMessaging(userAddress: string | null) {
+  const [inbox, setInbox] = useState<Message[]>([])
+  const [sent, setSent] = useState<Message[]>([])
+  const [archived, setArchived] = useState<Message[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [blockedUsers, setBlockedUsers] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!userAddress) { setIsLoading(false); return }
+
+    const col = collection(db, 'messages')
+
+    const inboxQ = query(
+      col,
+      where('to', '==', userAddress),
+      where('archived', '==', false),
+      orderBy('createdAt', 'desc')
+    )
+    const sentQ = query(col, where('from', '==', userAddress), orderBy('createdAt', 'desc'))
+    const archivedQ = query(
+      col,
+      where('to', '==', userAddress),
+      where('archived', '==', true),
+      orderBy('createdAt', 'desc')
+    )
+
+    let loaded = 0
+    const done = () => { if (++loaded === 3) setIsLoading(false) }
+
+    const unsub1 = onSnapshot(inboxQ, (snap) => {
+      setInbox(snap.docs.map((d) => toMessage(d.id, d.data() as Record<string, unknown>)))
+      done()
+    })
+    const unsub2 = onSnapshot(sentQ, (snap) => {
+      setSent(snap.docs.map((d) => toMessage(d.id, d.data() as Record<string, unknown>)))
+      done()
+    })
+    const unsub3 = onSnapshot(archivedQ, (snap) => {
+      setArchived(snap.docs.map((d) => toMessage(d.id, d.data() as Record<string, unknown>)))
+      done()
+    })
+
+    return () => { unsub1(); unsub2(); unsub3() }
+  }, [userAddress])
+
+  const sendMessage = useCallback(async (data: ComposeData) => {
+    if (!userAddress) throw new Error('Not authenticated')
+    const threadId = data.threadId ?? `thread_${Date.now()}_${Math.random().toString(36).slice(2)}`
+    await addDoc(collection(db, 'messages'), {
+      from: userAddress,
+      to: data.to,
+      subject: data.subject,
+      body: data.body,
+      read: false,
+      archived: false,
+      threadId,
+      createdAt: serverTimestamp(),
+    })
+  }, [userAddress])
+
+  const markRead = useCallback(async (messageId: string) => {
+    await updateDoc(doc(db, 'messages', messageId), { read: true })
+  }, [])
+
+  const archiveMessage = useCallback(async (messageId: string) => {
+    await updateDoc(doc(db, 'messages', messageId), { archived: true })
+  }, [])
+
+  const blockUser = useCallback((address: string) => {
+    setBlockedUsers((prev) => (prev.includes(address) ? prev : [...prev, address]))
+  }, [])
+
+  const unblockUser = useCallback((address: string) => {
+    setBlockedUsers((prev) => prev.filter((a) => a !== address))
+  }, [])
+
+  const searchMessages = useCallback(async (term: string): Promise<Message[]> => {
+    if (!userAddress || !term.trim()) return []
+    const col = collection(db, 'messages')
+    const [inboxSnap, sentSnap] = await Promise.all([
+      getDocs(query(col, where('to', '==', userAddress))),
+      getDocs(query(col, where('from', '==', userAddress))),
+    ])
+    const all = [
+      ...inboxSnap.docs.map((d) => toMessage(d.id, d.data() as Record<string, unknown>)),
+      ...sentSnap.docs.map((d) => toMessage(d.id, d.data() as Record<string, unknown>)),
+    ]
+    const lower = term.toLowerCase()
+    return all.filter(
+      (m) =>
+        m.subject.toLowerCase().includes(lower) ||
+        m.body.toLowerCase().includes(lower) ||
+        m.from.toLowerCase().includes(lower)
+    )
+  }, [userAddress])
+
+  const unreadCount = inbox.filter((m) => !m.read && !blockedUsers.includes(m.from)).length
+
+  const getFolder = (folder: MessageFolder) => {
+    const filter = (msgs: Message[]) => msgs.filter((m) => !blockedUsers.includes(m.from))
+    if (folder === 'inbox') return filter(inbox)
+    if (folder === 'sent') return filter(sent)
+    return filter(archived)
+  }
+
+  return {
+    inbox,
+    sent,
+    archived,
+    isLoading,
+    unreadCount,
+    blockedUsers,
+    getFolder,
+    sendMessage,
+    markRead,
+    archiveMessage,
+    blockUser,
+    unblockUser,
+    searchMessages,
+  }
+}

--- a/frontend/src/hooks/usePredictiveAnalytics.ts
+++ b/frontend/src/hooks/usePredictiveAnalytics.ts
@@ -1,0 +1,123 @@
+import { useMemo } from 'react'
+import { Waste, WasteType } from '@/api/types'
+
+export interface DataPoint {
+  x: number // time index (0-based)
+  y: number // value
+}
+
+export interface RegressionResult {
+  slope: number
+  intercept: number
+  r2: number
+}
+
+export interface Prediction {
+  wasteType: WasteType
+  historicalPoints: DataPoint[]
+  regression: RegressionResult
+  forecastPoints: DataPoint[] // next N periods
+  trend: 'up' | 'down' | 'flat'
+  confidenceInterval: { lower: number; upper: number }[]
+}
+
+export interface OptimalCollectionTime {
+  wasteType: WasteType
+  suggestedPeriod: string
+  reason: string
+}
+
+/** Simple OLS linear regression: y = slope * x + intercept */
+export function linearRegression(points: DataPoint[]): RegressionResult {
+  const n = points.length
+  if (n < 2) return { slope: 0, intercept: points[0]?.y ?? 0, r2: 0 }
+
+  const sumX = points.reduce((s, p) => s + p.x, 0)
+  const sumY = points.reduce((s, p) => s + p.y, 0)
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0)
+  const sumX2 = points.reduce((s, p) => s + p.x * p.x, 0)
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
+  const intercept = (sumY - slope * sumX) / n
+
+  const yMean = sumY / n
+  const ssTot = points.reduce((s, p) => s + (p.y - yMean) ** 2, 0)
+  const ssRes = points.reduce((s, p) => s + (p.y - (slope * p.x + intercept)) ** 2, 0)
+  const r2 = ssTot === 0 ? 1 : Math.max(0, 1 - ssRes / ssTot)
+
+  return { slope: Math.round(slope * 1000) / 1000, intercept: Math.round(intercept * 1000) / 1000, r2: Math.round(r2 * 1000) / 1000 }
+}
+
+/** Group wastes by waste type and week, returning volume (kg) per period */
+function groupByWeek(wastes: Waste[], type: WasteType): DataPoint[] {
+  const filtered = wastes.filter((w) => w.waste_type === type)
+  if (filtered.length === 0) return []
+
+  const minTs = Math.min(...filtered.map((w) => w.recycled_timestamp))
+  const weekMs = 7 * 24 * 3600
+
+  const buckets = new Map<number, number>()
+  for (const w of filtered) {
+    const week = Math.floor((w.recycled_timestamp - minTs) / weekMs)
+    buckets.set(week, (buckets.get(week) ?? 0) + Number(w.weight) / 1000)
+  }
+
+  const maxWeek = Math.max(...buckets.keys())
+  return Array.from({ length: maxWeek + 1 }, (_, i) => ({
+    x: i,
+    y: Math.round((buckets.get(i) ?? 0) * 100) / 100,
+  }))
+}
+
+function computeStdDev(points: DataPoint[], reg: RegressionResult): number {
+  if (points.length < 2) return 0
+  const residuals = points.map((p) => p.y - (reg.slope * p.x + reg.intercept))
+  const mean = residuals.reduce((s, r) => s + r, 0) / residuals.length
+  const variance = residuals.reduce((s, r) => s + (r - mean) ** 2, 0) / residuals.length
+  return Math.sqrt(variance)
+}
+
+const WASTE_TYPES = [WasteType.Paper, WasteType.PetPlastic, WasteType.Plastic, WasteType.Metal, WasteType.Glass]
+const FORECAST_PERIODS = 4
+
+export function usePredictiveAnalytics(wastes: Waste[]) {
+  const predictions = useMemo<Prediction[]>(() => {
+    return WASTE_TYPES.map((type) => {
+      const historicalPoints = groupByWeek(wastes, type)
+      const reg = linearRegression(historicalPoints)
+      const stdDev = computeStdDev(historicalPoints, reg)
+      const lastX = historicalPoints.length > 0 ? historicalPoints[historicalPoints.length - 1].x : 0
+
+      const forecastPoints: DataPoint[] = Array.from({ length: FORECAST_PERIODS }, (_, i) => ({
+        x: lastX + i + 1,
+        y: Math.max(0, Math.round((reg.slope * (lastX + i + 1) + reg.intercept) * 100) / 100),
+      }))
+
+      const confidenceInterval = forecastPoints.map((p) => ({
+        lower: Math.max(0, Math.round((p.y - 1.96 * stdDev) * 100) / 100),
+        upper: Math.round((p.y + 1.96 * stdDev) * 100) / 100,
+      }))
+
+      const trend: Prediction['trend'] =
+        Math.abs(reg.slope) < 0.01 ? 'flat' : reg.slope > 0 ? 'up' : 'down'
+
+      return { wasteType: type, historicalPoints, regression: reg, forecastPoints, trend, confidenceInterval }
+    })
+  }, [wastes])
+
+  const optimalTimes = useMemo<OptimalCollectionTime[]>(() => {
+    return predictions
+      .filter((p) => p.historicalPoints.length > 0)
+      .map((p) => {
+        const bestForecast = p.forecastPoints.reduce((best, cur) => (cur.y > best.y ? cur : best), p.forecastPoints[0])
+        const period = `Week +${bestForecast?.x - (p.historicalPoints.length > 0 ? p.historicalPoints[p.historicalPoints.length - 1].x : 0)}`
+        return {
+          wasteType: p.wasteType,
+          suggestedPeriod: period,
+          reason: p.trend === 'up' ? 'Volume is increasing' : p.trend === 'down' ? 'Collect before volume drops further' : 'Stable volume',
+        }
+      })
+  }, [predictions])
+
+  return { predictions, optimalTimes }
+}

--- a/frontend/src/hooks/useRoutePlanner.ts
+++ b/frontend/src/hooks/useRoutePlanner.ts
@@ -1,0 +1,176 @@
+import { useState, useCallback } from 'react'
+import { WasteMapPoint } from './useMapData'
+
+export interface RouteStop {
+  id: string
+  lat: number
+  lng: number
+  label: string
+  wastePoint?: WasteMapPoint
+}
+
+export interface SavedRoute {
+  id: string
+  name: string
+  stops: RouteStop[]
+  totalDistanceKm: number
+  estimatedMinutes: number
+  createdAt: number
+}
+
+export interface RouteResult {
+  orderedStops: RouteStop[]
+  totalDistanceKm: number
+  estimatedMinutes: number
+  directions: string[]
+}
+
+/** Haversine distance in km between two lat/lng points */
+export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLng = ((lng2 - lng1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
+  return R * 2 * Math.asin(Math.sqrt(a))
+}
+
+/** Nearest-neighbour TSP heuristic */
+export function optimizeRoute(stops: RouteStop[]): RouteStop[] {
+  if (stops.length <= 1) return stops
+  const remaining = [...stops]
+  const ordered: RouteStop[] = [remaining.shift()!]
+  while (remaining.length > 0) {
+    const last = ordered[ordered.length - 1]
+    let nearestIdx = 0
+    let nearestDist = Infinity
+    remaining.forEach((s, i) => {
+      const d = haversineKm(last.lat, last.lng, s.lat, s.lng)
+      if (d < nearestDist) { nearestDist = d; nearestIdx = i }
+    })
+    ordered.push(remaining.splice(nearestIdx, 1)[0])
+  }
+  return ordered
+}
+
+export function computeRouteStats(stops: RouteStop[]): { totalDistanceKm: number; estimatedMinutes: number } {
+  let totalDistanceKm = 0
+  for (let i = 1; i < stops.length; i++) {
+    totalDistanceKm += haversineKm(stops[i - 1].lat, stops[i - 1].lng, stops[i].lat, stops[i].lng)
+  }
+  // Assume avg 40 km/h + 5 min per stop
+  const estimatedMinutes = Math.round((totalDistanceKm / 40) * 60 + stops.length * 5)
+  return { totalDistanceKm: Math.round(totalDistanceKm * 10) / 10, estimatedMinutes }
+}
+
+export function buildDirections(stops: RouteStop[]): string[] {
+  if (stops.length === 0) return []
+  const dirs: string[] = [`Start at ${stops[0].label}`]
+  for (let i = 1; i < stops.length; i++) {
+    const dist = haversineKm(stops[i - 1].lat, stops[i - 1].lng, stops[i].lat, stops[i].lng)
+    dirs.push(`Head to ${stops[i].label} (~${dist.toFixed(1)} km)`)
+  }
+  dirs.push('Route complete')
+  return dirs
+}
+
+const STORAGE_KEY = 'scavngr_saved_routes'
+
+function loadSavedRoutes(): SavedRoute[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function persistRoutes(routes: SavedRoute[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(routes))
+}
+
+export function useRoutePlanner() {
+  const [selectedStops, setSelectedStops] = useState<RouteStop[]>([])
+  const [routeResult, setRouteResult] = useState<RouteResult | null>(null)
+  const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>(loadSavedRoutes)
+
+  const addStop = useCallback((stop: RouteStop) => {
+    setSelectedStops((prev) => (prev.find((s) => s.id === stop.id) ? prev : [...prev, stop]))
+    setRouteResult(null)
+  }, [])
+
+  const removeStop = useCallback((id: string) => {
+    setSelectedStops((prev) => prev.filter((s) => s.id !== id))
+    setRouteResult(null)
+  }, [])
+
+  const clearStops = useCallback(() => {
+    setSelectedStops([])
+    setRouteResult(null)
+  }, [])
+
+  const optimizeAndPlan = useCallback(() => {
+    if (selectedStops.length === 0) return
+    const orderedStops = optimizeRoute(selectedStops)
+    const { totalDistanceKm, estimatedMinutes } = computeRouteStats(orderedStops)
+    const directions = buildDirections(orderedStops)
+    setRouteResult({ orderedStops, totalDistanceKm, estimatedMinutes, directions })
+  }, [selectedStops])
+
+  const saveRoute = useCallback((name: string) => {
+    if (!routeResult) return
+    const route: SavedRoute = {
+      id: `route_${Date.now()}`,
+      name,
+      stops: routeResult.orderedStops,
+      totalDistanceKm: routeResult.totalDistanceKm,
+      estimatedMinutes: routeResult.estimatedMinutes,
+      createdAt: Date.now(),
+    }
+    setSavedRoutes((prev) => {
+      const updated = [route, ...prev]
+      persistRoutes(updated)
+      return updated
+    })
+    return route
+  }, [routeResult])
+
+  const loadRoute = useCallback((route: SavedRoute) => {
+    setSelectedStops(route.stops)
+    const directions = buildDirections(route.stops)
+    setRouteResult({
+      orderedStops: route.stops,
+      totalDistanceKm: route.totalDistanceKm,
+      estimatedMinutes: route.estimatedMinutes,
+      directions,
+    })
+  }, [])
+
+  const deleteRoute = useCallback((id: string) => {
+    setSavedRoutes((prev) => {
+      const updated = prev.filter((r) => r.id !== id)
+      persistRoutes(updated)
+      return updated
+    })
+  }, [])
+
+  const shareRoute = useCallback((route: SavedRoute | RouteResult) => {
+    const stops = 'orderedStops' in route ? route.orderedStops : (route as SavedRoute).stops
+    const text = stops.map((s, i) => `${i + 1}. ${s.label} (${s.lat.toFixed(4)}, ${s.lng.toFixed(4)})`).join('\n')
+    return `Scavngr Route:\n${text}`
+  }, [])
+
+  return {
+    selectedStops,
+    routeResult,
+    savedRoutes,
+    addStop,
+    removeStop,
+    clearStops,
+    optimizeAndPlan,
+    saveRoute,
+    loadRoute,
+    deleteRoute,
+    shareRoute,
+  }
+}

--- a/frontend/src/pages/MessagingPage.tsx
+++ b/frontend/src/pages/MessagingPage.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Mail, Send, Archive, Search, Pencil, X, Reply, Ban } from 'lucide-react'
+import { useAppTitle } from '@/hooks/useAppTitle'
+import { useMessaging, Message, MessageFolder, ComposeData } from '@/hooks/useMessaging'
+import { useWallet } from '@/context/WalletContext'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatDate } from '@/lib/helpers'
+
+function ComposeModal({
+  initial,
+  onSend,
+  onClose,
+}: {
+  initial?: Partial<ComposeData>
+  onSend: (data: ComposeData) => Promise<void>
+  onClose: () => void
+}) {
+  const [to, setTo] = useState(initial?.to ?? '')
+  const [subject, setSubject] = useState(initial?.subject ?? '')
+  const [body, setBody] = useState(initial?.body ?? '')
+  const [sending, setSending] = useState(false)
+
+  const handleSend = async () => {
+    if (!to.trim() || !subject.trim() || !body.trim()) return
+    setSending(true)
+    try {
+      await onSend({ to: to.trim(), subject: subject.trim(), body: body.trim(), threadId: initial?.threadId })
+      onClose()
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-xl border bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h2 className="font-semibold">Compose Message</h2>
+          <Button size="sm" variant="ghost" onClick={onClose}><X className="h-4 w-4" /></Button>
+        </div>
+        <div className="space-y-3 p-4">
+          <input
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="To (address)"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+          />
+          <input
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="Subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+          />
+          <textarea
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            rows={5}
+            placeholder="Message…"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={onClose}>Cancel</Button>
+            <Button onClick={handleSend} disabled={sending || !to || !subject || !body}>
+              <Send className="mr-2 h-4 w-4" /> {sending ? 'Sending…' : 'Send'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MessageRow({
+  msg,
+  onSelect,
+  onArchive,
+  onBlock,
+}: {
+  msg: Message
+  onSelect: (m: Message) => void
+  onArchive: (id: string) => void
+  onBlock: (addr: string) => void
+}) {
+  return (
+    <div
+      className={`flex cursor-pointer items-start justify-between gap-3 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-muted/50 ${!msg.read ? 'font-medium' : ''}`}
+      onClick={() => onSelect(msg)}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          {!msg.read && <span className="h-2 w-2 rounded-full bg-primary" />}
+          <span className="truncate">{msg.subject}</span>
+        </div>
+        <p className="truncate text-xs text-muted-foreground">{msg.from}</p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <span className="text-xs text-muted-foreground">{formatDate(msg.createdAt / 1000)}</span>
+        <Button size="sm" variant="ghost" onClick={(e) => { e.stopPropagation(); onArchive(msg.id) }}>
+          <Archive className="h-3 w-3" />
+        </Button>
+        <Button size="sm" variant="ghost" onClick={(e) => { e.stopPropagation(); onBlock(msg.from) }}>
+          <Ban className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function MessagingPage() {
+  useAppTitle('Messages')
+  const { address } = useWallet()
+  const {
+    isLoading,
+    unreadCount,
+    getFolder,
+    sendMessage,
+    markRead,
+    archiveMessage,
+    blockUser,
+    searchMessages,
+  } = useMessaging(address)
+
+  const [folder, setFolder] = useState<MessageFolder>('inbox')
+  const [selected, setSelected] = useState<Message | null>(null)
+  const [composing, setComposing] = useState<Partial<ComposeData> | null>(null)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searchResults, setSearchResults] = useState<Message[] | null>(null)
+
+  const handleSelect = async (msg: Message) => {
+    setSelected(msg)
+    if (!msg.read) await markRead(msg.id)
+  }
+
+  const handleSearch = async () => {
+    const results = await searchMessages(searchTerm)
+    setSearchResults(results)
+  }
+
+  const handleReply = () => {
+    if (!selected) return
+    setComposing({ to: selected.from, subject: `Re: ${selected.subject}`, threadId: selected.threadId })
+  }
+
+  const messages = searchResults ?? getFolder(folder)
+
+  if (!address) {
+    return (
+      <div className="flex h-64 items-center justify-center text-muted-foreground">
+        Connect your wallet to use messaging.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-3.5rem)] flex-col gap-4 p-4 sm:p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Mail className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold">Messages</h1>
+          {unreadCount > 0 && <Badge>{unreadCount} unread</Badge>}
+        </div>
+        <Button onClick={() => setComposing({})}>
+          <Pencil className="mr-2 h-4 w-4" /> Compose
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="flex gap-2">
+        <input
+          className="flex-1 rounded-md border bg-background px-3 py-2 text-sm"
+          placeholder="Search messages…"
+          value={searchTerm}
+          onChange={(e) => { setSearchTerm(e.target.value); if (!e.target.value) setSearchResults(null) }}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+        />
+        <Button variant="outline" onClick={handleSearch}><Search className="h-4 w-4" /></Button>
+        {searchResults && <Button variant="ghost" onClick={() => { setSearchResults(null); setSearchTerm('') }}><X className="h-4 w-4" /></Button>}
+      </div>
+
+      <div className="flex min-h-0 flex-1 gap-4">
+        {/* Folder sidebar */}
+        <div className="w-36 shrink-0 space-y-1">
+          {(['inbox', 'sent', 'archived'] as MessageFolder[]).map((f) => (
+            <button
+              key={f}
+              className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm capitalize transition-colors ${folder === f && !searchResults ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
+              onClick={() => { setFolder(f); setSearchResults(null); setSearchTerm('') }}
+            >
+              {f === 'inbox' && <Mail className="h-4 w-4" />}
+              {f === 'sent' && <Send className="h-4 w-4" />}
+              {f === 'archived' && <Archive className="h-4 w-4" />}
+              {f}
+            </button>
+          ))}
+        </div>
+
+        {/* Message list */}
+        <Card className="flex min-h-0 flex-1 flex-col">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm capitalize">
+              {searchResults ? `Search results (${searchResults.length})` : folder}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="min-h-0 flex-1 overflow-y-auto space-y-2">
+            {isLoading && (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => <div key={i} className="h-12 animate-pulse rounded bg-muted" />)}
+              </div>
+            )}
+            {!isLoading && messages.length === 0 && (
+              <EmptyState icon={Mail} title="No messages" description="Nothing here yet" />
+            )}
+            {messages.map((msg) => (
+              <MessageRow
+                key={msg.id}
+                msg={msg}
+                onSelect={handleSelect}
+                onArchive={archiveMessage}
+                onBlock={blockUser}
+              />
+            ))}
+          </CardContent>
+        </Card>
+
+        {/* Message detail */}
+        {selected && (
+          <Card className="flex min-h-0 w-96 shrink-0 flex-col">
+            <CardHeader className="pb-2">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <CardTitle className="text-sm">{selected.subject}</CardTitle>
+                  <p className="text-xs text-muted-foreground">From: {selected.from}</p>
+                  <p className="text-xs text-muted-foreground">{formatDate(selected.createdAt / 1000)}</p>
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => setSelected(null)}><X className="h-4 w-4" /></Button>
+              </div>
+            </CardHeader>
+            <CardContent className="min-h-0 flex-1 overflow-y-auto">
+              <p className="whitespace-pre-wrap text-sm">{selected.body}</p>
+            </CardContent>
+            <div className="border-t p-3">
+              <Button size="sm" onClick={handleReply}>
+                <Reply className="mr-2 h-3 w-3" /> Reply
+              </Button>
+            </div>
+          </Card>
+        )}
+      </div>
+
+      {composing !== null && (
+        <ComposeModal
+          initial={composing}
+          onSend={sendMessage}
+          onClose={() => setComposing(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/PredictiveAnalyticsPage.tsx
+++ b/frontend/src/pages/PredictiveAnalyticsPage.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react'
+import { TrendingUp, TrendingDown, Minus, Download } from 'lucide-react'
+import { useAppTitle } from '@/hooks/useAppTitle'
+import { useWastes } from '@/hooks/useWastes'
+import { usePredictiveAnalytics, Prediction } from '@/hooks/usePredictiveAnalytics'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { wasteTypeLabel } from '@/lib/helpers'
+
+function TrendIcon({ trend }: { trend: Prediction['trend'] }) {
+  if (trend === 'up') return <TrendingUp className="h-4 w-4 text-green-500" />
+  if (trend === 'down') return <TrendingDown className="h-4 w-4 text-red-500" />
+  return <Minus className="h-4 w-4 text-muted-foreground" />
+}
+
+function MiniChart({ points, forecast }: { points: { x: number; y: number }[]; forecast: { x: number; y: number }[] }) {
+  const all = [...points, ...forecast]
+  if (all.length === 0) return null
+  const maxY = Math.max(...all.map((p) => p.y), 1)
+  const W = 200
+  const H = 60
+  const pad = 4
+
+  const toSvg = (p: { x: number; y: number }, total: number) => ({
+    sx: pad + (p.x / (total - 1 || 1)) * (W - 2 * pad),
+    sy: H - pad - (p.y / maxY) * (H - 2 * pad),
+  })
+
+  const total = all.length
+  const histPath = points.map((p, i) => {
+    const { sx, sy } = toSvg({ x: i, y: p.y }, total)
+    return `${i === 0 ? 'M' : 'L'}${sx.toFixed(1)},${sy.toFixed(1)}`
+  }).join(' ')
+
+  const forecastPath = forecast.map((p, i) => {
+    const { sx, sy } = toSvg({ x: points.length + i, y: p.y }, total)
+    return `${i === 0 ? 'M' : 'L'}${sx.toFixed(1)},${sy.toFixed(1)}`
+  }).join(' ')
+
+  return (
+    <svg width={W} height={H} className="overflow-visible">
+      {histPath && <path d={histPath} fill="none" stroke="currentColor" strokeWidth="1.5" className="text-primary" />}
+      {forecastPath && <path d={forecastPath} fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 2" className="text-orange-400" />}
+    </svg>
+  )
+}
+
+function exportPredictions(predictions: Prediction[]) {
+  const lines = ['Waste Type,Trend,Slope,R²,Forecast W1,Forecast W2,Forecast W3,Forecast W4']
+  for (const p of predictions) {
+    if (p.historicalPoints.length === 0) continue
+    const forecasts = p.forecastPoints.map((f) => f.y).join(',')
+    lines.push(`${wasteTypeLabel(p.wasteType)},${p.trend},${p.regression.slope},${p.regression.r2},${forecasts}`)
+  }
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'predictions.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function PredictiveAnalyticsPage() {
+  useAppTitle('Predictive Analytics')
+  const { wastes, isLoading } = useWastes()
+  const { predictions, optimalTimes } = usePredictiveAnalytics(wastes)
+  const [activeType, setActiveType] = useState<number | null>(null)
+
+  const activePrediction = activeType !== null ? predictions.find((p) => p.wasteType === activeType) : null
+  const hasData = predictions.some((p) => p.historicalPoints.length > 0)
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold">Predictive Analytics</h1>
+        </div>
+        {hasData && (
+          <Button size="sm" variant="outline" onClick={() => exportPredictions(predictions)}>
+            <Download className="mr-2 h-3 w-3" /> Export
+          </Button>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => <div key={i} className="h-32 animate-pulse rounded-xl bg-muted" />)}
+        </div>
+      )}
+
+      {!isLoading && !hasData && (
+        <EmptyState icon={TrendingUp} title="No data yet" description="Submit waste items to see predictions" />
+      )}
+
+      {!isLoading && hasData && (
+        <>
+          {/* Trend cards */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+            {predictions.map((p) => (
+              <Card
+                key={p.wasteType}
+                className={`cursor-pointer transition-shadow hover:shadow-md ${activeType === p.wasteType ? 'ring-2 ring-primary' : ''}`}
+                onClick={() => setActiveType(activeType === p.wasteType ? null : p.wasteType)}
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center justify-between text-sm">
+                    <span>{wasteTypeLabel(p.wasteType)}</span>
+                    <TrendIcon trend={p.trend} />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {p.historicalPoints.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No data</p>
+                  ) : (
+                    <>
+                      <MiniChart points={p.historicalPoints} forecast={p.forecastPoints} />
+                      <div className="flex gap-2 text-xs text-muted-foreground">
+                        <span>R²: {p.regression.r2}</span>
+                        <span>·</span>
+                        <span className={p.trend === 'up' ? 'text-green-600' : p.trend === 'down' ? 'text-red-600' : ''}>
+                          {p.trend === 'up' ? '↑ Growing' : p.trend === 'down' ? '↓ Declining' : '→ Stable'}
+                        </span>
+                      </div>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {/* Detail panel */}
+          {activePrediction && activePrediction.historicalPoints.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  {wasteTypeLabel(activePrediction.wasteType)} — Forecast Detail
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-wrap gap-4 text-sm">
+                  <div className="rounded-md bg-muted px-3 py-2">
+                    <p className="text-xs text-muted-foreground">Slope</p>
+                    <p className="font-bold">{activePrediction.regression.slope} kg/week</p>
+                  </div>
+                  <div className="rounded-md bg-muted px-3 py-2">
+                    <p className="text-xs text-muted-foreground">R² (fit quality)</p>
+                    <p className="font-bold">{activePrediction.regression.r2}</p>
+                  </div>
+                  <div className="rounded-md bg-muted px-3 py-2">
+                    <p className="text-xs text-muted-foreground">Historical weeks</p>
+                    <p className="font-bold">{activePrediction.historicalPoints.length}</p>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-2 text-sm font-medium">4-Week Forecast with 95% Confidence Interval</p>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b">
+                          <th className="px-3 py-1.5 text-left text-muted-foreground">Period</th>
+                          <th className="px-3 py-1.5 text-left text-muted-foreground">Predicted (kg)</th>
+                          <th className="px-3 py-1.5 text-left text-muted-foreground">Lower</th>
+                          <th className="px-3 py-1.5 text-left text-muted-foreground">Upper</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {activePrediction.forecastPoints.map((fp, i) => (
+                          <tr key={fp.x} className="border-b last:border-0">
+                            <td className="px-3 py-1.5">Week +{i + 1}</td>
+                            <td className="px-3 py-1.5 font-medium">{fp.y}</td>
+                            <td className="px-3 py-1.5 text-muted-foreground">{activePrediction.confidenceInterval[i]?.lower}</td>
+                            <td className="px-3 py-1.5 text-muted-foreground">{activePrediction.confidenceInterval[i]?.upper}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Optimal collection times */}
+          {optimalTimes.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Suggested Collection Times</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {optimalTimes.map((ot) => (
+                  <div key={ot.wasteType} className="rounded-md border p-3 text-sm">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{wasteTypeLabel(ot.wasteType)}</Badge>
+                      <span className="font-medium">{ot.suggestedPeriod}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{ot.reason}</p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/RoutePlannerPage.tsx
+++ b/frontend/src/pages/RoutePlannerPage.tsx
@@ -1,0 +1,240 @@
+import { useState } from 'react'
+import { Navigation, Trash2, Play, Save, Share2, FolderOpen, X, MapPin } from 'lucide-react'
+import { useAppTitle } from '@/hooks/useAppTitle'
+import { useMapData } from '@/hooks/useMapData'
+import { useRoutePlanner, RouteStop } from '@/hooks/useRoutePlanner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { wasteTypeLabel } from '@/lib/helpers'
+
+export function RoutePlannerPage() {
+  useAppTitle('Route Planner')
+  const { wastes, isLoading } = useMapData()
+  const {
+    selectedStops,
+    routeResult,
+    savedRoutes,
+    addStop,
+    removeStop,
+    clearStops,
+    optimizeAndPlan,
+    saveRoute,
+    loadRoute,
+    deleteRoute,
+    shareRoute,
+  } = useRoutePlanner()
+
+  const [saveName, setSaveName] = useState('')
+  const [showSaved, setShowSaved] = useState(false)
+  const [shareText, setShareText] = useState('')
+
+  const handleAddWaste = (stop: RouteStop) => addStop(stop)
+
+  const handleSave = () => {
+    if (!saveName.trim()) return
+    saveRoute(saveName.trim())
+    setSaveName('')
+  }
+
+  const handleShare = () => {
+    if (!routeResult) return
+    const text = shareRoute(routeResult)
+    setShareText(text)
+    navigator.clipboard?.writeText(text).catch(() => {})
+  }
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <div className="flex items-center gap-2">
+        <Navigation className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">Route Planner</h1>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Left: waste selection */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Available Waste Locations</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {isLoading && (
+                <div className="space-y-2">
+                  {[1, 2, 3].map((i) => (
+                    <div key={i} className="h-12 animate-pulse rounded bg-muted" />
+                  ))}
+                </div>
+              )}
+              {!isLoading && wastes.length === 0 && (
+                <EmptyState icon={MapPin} title="No waste locations" description="No waste items with coordinates found" />
+              )}
+              {wastes.map((w) => {
+                const alreadyAdded = selectedStops.some((s) => s.id === w.id)
+                return (
+                  <div key={w.id} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{wasteTypeLabel(w.waste.waste_type)}</Badge>
+                      <span className="text-muted-foreground">#{w.id}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {w.lat.toFixed(3)}, {w.lng.toFixed(3)}
+                      </span>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant={alreadyAdded ? 'ghost' : 'outline'}
+                      disabled={alreadyAdded}
+                      onClick={() =>
+                        handleAddWaste({
+                          id: w.id,
+                          lat: w.lat,
+                          lng: w.lng,
+                          label: `${wasteTypeLabel(w.waste.waste_type)} #${w.id}`,
+                          wastePoint: w,
+                        })
+                      }
+                    >
+                      {alreadyAdded ? 'Added' : 'Add'}
+                    </Button>
+                  </div>
+                )
+              })}
+            </CardContent>
+          </Card>
+
+          {/* Saved routes */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">Saved Routes</CardTitle>
+                <Button size="sm" variant="ghost" onClick={() => setShowSaved((v) => !v)}>
+                  <FolderOpen className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardHeader>
+            {showSaved && (
+              <CardContent className="space-y-2">
+                {savedRoutes.length === 0 && (
+                  <p className="text-sm text-muted-foreground">No saved routes yet.</p>
+                )}
+                {savedRoutes.map((r) => (
+                  <div key={r.id} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                    <div>
+                      <p className="font-medium">{r.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {r.stops.length} stops · {r.totalDistanceKm} km · {r.estimatedMinutes} min
+                      </p>
+                    </div>
+                    <div className="flex gap-1">
+                      <Button size="sm" variant="outline" onClick={() => loadRoute(r)}>Load</Button>
+                      <Button size="sm" variant="ghost" onClick={() => deleteRoute(r.id)}>
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            )}
+          </Card>
+        </div>
+
+        {/* Right: selected stops + result */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">Selected Stops ({selectedStops.length})</CardTitle>
+                {selectedStops.length > 0 && (
+                  <Button size="sm" variant="ghost" onClick={clearStops}>
+                    <X className="h-4 w-4" /> Clear
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {selectedStops.length === 0 && (
+                <p className="text-sm text-muted-foreground">Add waste locations from the left panel.</p>
+              )}
+              {selectedStops.map((s, i) => (
+                <div key={s.id} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                  <span className="flex items-center gap-2">
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
+                      {i + 1}
+                    </span>
+                    {s.label}
+                  </span>
+                  <Button size="sm" variant="ghost" onClick={() => removeStop(s.id)}>
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+              {selectedStops.length > 0 && (
+                <Button className="mt-2 w-full" onClick={optimizeAndPlan}>
+                  <Play className="mr-2 h-4 w-4" /> Optimize Route
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+
+          {routeResult && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Route Result</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex gap-4 text-sm">
+                  <div className="rounded-md bg-muted px-3 py-2 text-center">
+                    <p className="text-xs text-muted-foreground">Distance</p>
+                    <p className="font-bold">{routeResult.totalDistanceKm} km</p>
+                  </div>
+                  <div className="rounded-md bg-muted px-3 py-2 text-center">
+                    <p className="text-xs text-muted-foreground">Est. Time</p>
+                    <p className="font-bold">{routeResult.estimatedMinutes} min</p>
+                  </div>
+                  <div className="rounded-md bg-muted px-3 py-2 text-center">
+                    <p className="text-xs text-muted-foreground">Stops</p>
+                    <p className="font-bold">{routeResult.orderedStops.length}</p>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-2 text-sm font-medium">Turn-by-turn Directions</p>
+                  <ol className="space-y-1">
+                    {routeResult.directions.map((d, i) => (
+                      <li key={i} className="flex gap-2 text-sm">
+                        <span className="text-muted-foreground">{i + 1}.</span>
+                        <span>{d}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+
+                <div className="flex gap-2">
+                  <div className="flex flex-1 gap-2">
+                    <input
+                      className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm"
+                      placeholder="Route name…"
+                      value={saveName}
+                      onChange={(e) => setSaveName(e.target.value)}
+                    />
+                    <Button size="sm" onClick={handleSave} disabled={!saveName.trim()}>
+                      <Save className="mr-1 h-3 w-3" /> Save
+                    </Button>
+                  </div>
+                  <Button size="sm" variant="outline" onClick={handleShare}>
+                    <Share2 className="mr-1 h-3 w-3" /> Share
+                  </Button>
+                </div>
+
+                {shareText && (
+                  <pre className="rounded-md bg-muted p-3 text-xs whitespace-pre-wrap">{shareText}</pre>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/WasteComparisonPage.tsx
+++ b/frontend/src/pages/WasteComparisonPage.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { GitCompare, X } from 'lucide-react'
+import { useAppTitle } from '@/hooks/useAppTitle'
+import { useWastes } from '@/hooks/useWastes'
+import { Waste } from '@/api/types'
+import { WasteComparison } from '@/components/ui/WasteComparison'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { wasteTypeLabel } from '@/lib/helpers'
+
+const MAX_COMPARE = 4
+
+export function WasteComparisonPage() {
+  useAppTitle('Waste Comparison')
+  const { wastes, isLoading } = useWastes()
+  const [selected, setSelected] = useState<Waste[]>([])
+
+  const toggle = (waste: Waste) => {
+    setSelected((prev) => {
+      const exists = prev.find((w) => w.waste_id === waste.waste_id)
+      if (exists) return prev.filter((w) => w.waste_id !== waste.waste_id)
+      if (prev.length >= MAX_COMPARE) return prev
+      return [...prev, waste]
+    })
+  }
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <div className="flex items-center gap-2">
+        <GitCompare className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">Waste Comparison</h1>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Selection panel */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Select Wastes{' '}
+              <span className="text-muted-foreground font-normal text-xs">
+                ({selected.length}/{MAX_COMPARE})
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {isLoading && (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => <div key={i} className="h-10 animate-pulse rounded bg-muted" />)}
+              </div>
+            )}
+            {!isLoading && wastes.length === 0 && (
+              <EmptyState icon={GitCompare} title="No wastes" description="No waste items found" />
+            )}
+            {wastes.map((w) => {
+              const isSelected = selected.some((s) => s.waste_id === w.waste_id)
+              const disabled = !isSelected && selected.length >= MAX_COMPARE
+              return (
+                <button
+                  key={String(w.waste_id)}
+                  disabled={disabled}
+                  onClick={() => toggle(w)}
+                  className={`flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors ${
+                    isSelected
+                      ? 'border-primary bg-primary/10'
+                      : disabled
+                      ? 'cursor-not-allowed opacity-40'
+                      : 'hover:bg-muted/50'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">{wasteTypeLabel(w.waste_type)}</Badge>
+                    <span className="text-muted-foreground">#{String(w.waste_id)}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {(Number(w.weight) / 1000).toFixed(2)} kg
+                  </span>
+                </button>
+              )
+            })}
+          </CardContent>
+        </Card>
+
+        {/* Comparison table */}
+        <div className="lg:col-span-2">
+          {selected.length < 2 ? (
+            <div className="flex h-48 items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">
+              Select at least 2 waste items to compare
+            </div>
+          ) : (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">Comparison</CardTitle>
+                  <Button size="sm" variant="ghost" onClick={() => setSelected([])}>
+                    <X className="mr-1 h-3 w-3" /> Clear
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <WasteComparison wastes={selected} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -52,6 +52,18 @@ const AdminDashboardPage = lazy(() =>
 const VerificationPage = lazy(() =>
   import('@/pages/VerificationPage').then((m) => ({ default: m.VerificationPage }))
 )
+const RoutePlannerPage = lazy(() =>
+  import('@/pages/RoutePlannerPage').then((m) => ({ default: m.RoutePlannerPage }))
+)
+const MessagingPage = lazy(() =>
+  import('@/pages/MessagingPage').then((m) => ({ default: m.MessagingPage }))
+)
+const WasteComparisonPage = lazy(() =>
+  import('@/pages/WasteComparisonPage').then((m) => ({ default: m.WasteComparisonPage }))
+)
+const PredictiveAnalyticsPage = lazy(() =>
+  import('@/pages/PredictiveAnalyticsPage').then((m) => ({ default: m.PredictiveAnalyticsPage }))
+)
 
 // eslint-disable-next-line react-refresh/only-export-components
 function PageFallback() {
@@ -97,7 +109,11 @@ export const router = createBrowserRouter([
       { path: 'analytics', element: <AnalyticsPage /> },
       { path: 'map', element: <WasteMapPage /> },
       { path: 'admin', element: <AdminDashboardPage /> },
-      { path: 'verify', element: <VerificationPage /> }
+      { path: 'verify', element: <VerificationPage /> },
+      { path: 'route-planner', element: <RoutePlannerPage /> },
+      { path: 'messages', element: <MessagingPage /> },
+      { path: 'compare', element: <WasteComparisonPage /> },
+      { path: 'predictions', element: <PredictiveAnalyticsPage /> }
     ]
   },
   { path: '*', element: <NotFoundPage /> }


### PR DESCRIPTION
closes #421 
closes #422 
closes #423 
closes #424 


- Route planner with nearest-neighbour TSP, haversine distances, turn-by-turn directions, save/load/share routes (localStorage)
- Messaging with Firebase Firestore real-time inbox/sent/archived, compose, reply, archive, block/unblock, full-text search
- Waste comparison table (up to 4 items) with color-coded diffs and CSV export
- Predictive analytics with OLS linear regression, 4-week forecast, 95% confidence intervals, trend detection, optimal collection times
- 67 tests across 4 test files (26 + 13 + 15 + 12)
- Routes: /route-planner, /messages, /compare, /predictions