### PR TITLE
feat: add visual regression

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,131 @@
+name: Visual Regression
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'frontend/src/**'
+      - 'frontend/e2e/visual-regression.spec.ts'
+      - 'frontend/playwright.config.ts'
+  # Allow manual baseline updates via workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      update_baselines:
+        description: 'Update snapshot baselines (approve new visuals)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+
+jobs:
+  visual-regression:
+    name: Visual Regression (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [visual-chromium, visual-firefox, visual-mobile]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps ${{ matrix.project == 'visual-firefox' && 'firefox' || 'chromium' }}
+
+      # Restore committed baselines from the repo (e2e/__snapshots__)
+      - name: Run visual regression tests
+        run: npx playwright test --project=${{ matrix.project }}
+        env:
+          CI: true
+
+      # On failure: upload diff report as artifact for review
+      - name: Upload diff report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-diff-${{ matrix.project }}
+          path: frontend/playwright-report/
+          retention-days: 30
+
+      # On success: upload updated snapshots (only when update_baselines=true)
+      - name: Upload updated snapshots
+        if: ${{ github.event.inputs.update_baselines == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots-${{ matrix.project }}
+          path: frontend/e2e/__snapshots__/
+          retention-days: 7
+
+  # Approval gate: runs after all matrix jobs pass
+  # Fails the PR check if any visual diff was detected
+  visual-regression-gate:
+    name: Visual Regression Gate
+    runs-on: ubuntu-latest
+    needs: visual-regression
+    if: always()
+    steps:
+      - name: Check visual regression results
+        run: |
+          if [ "${{ needs.visual-regression.result }}" != "success" ]; then
+            echo "::error::Visual regression tests failed. Review diffs in the 'visual-diff-*' artifacts."
+            echo "To approve new visuals, run the workflow manually with update_baselines=true,"
+            echo "download the updated-snapshots artifacts, commit them, and re-run."
+            exit 1
+          fi
+          echo "All visual regression tests passed."
+
+  # Baseline update job: commits new snapshots back to the branch
+  # Only runs when triggered manually with update_baselines=true
+  update-baselines:
+    name: Commit Updated Baselines
+    runs-on: ubuntu-latest
+    needs: visual-regression
+    if: ${{ github.event.inputs.update_baselines == 'true' && needs.visual-regression.result == 'success' }}
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+
+      - name: Download updated snapshots (chromium)
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-snapshots-visual-chromium
+          path: frontend/e2e/__snapshots__/visual-chromium
+
+      - name: Download updated snapshots (firefox)
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-snapshots-visual-firefox
+          path: frontend/e2e/__snapshots__/visual-firefox
+
+      - name: Download updated snapshots (mobile)
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-snapshots-visual-mobile
+          path: frontend/e2e/__snapshots__/visual-mobile
+
+      - name: Commit updated baselines
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ../e2e/__snapshots__/
+          git diff --cached --quiet || git commit -m "chore: update visual regression baselines [skip ci]"
+          git push
+        working-directory: ./frontend

--- a/frontend/VISUAL_REGRESSION.md
+++ b/frontend/VISUAL_REGRESSION.md
@@ -1,0 +1,84 @@
+# Visual Regression Testing
+
+Playwright's built-in screenshot comparison is used — no external service required. Baselines are committed to the repo under `e2e/__snapshots__/`.
+
+## Test coverage (32 tests)
+
+| Group | Tests |
+|---|---|
+| Public pages | Landing (desktop/tablet/mobile), Login (desktop/mobile), 404 |
+| Authenticated pages | Dashboard, Recycler, Waste List (desktop/mobile), Incentives, Collector, Manufacturer, Analytics, Rewards, Supply Chain, Map, Admin, Verification, Settings, Community, Recycling Guide, Marketplace, Certification, Predictive Analytics, Route Planner, Messaging, Comparison |
+| Dark mode | Landing, Dashboard, Settings |
+
+Each test runs across 3 browser projects: `visual-chromium`, `visual-firefox`, `visual-mobile` (Pixel 5).
+
+## Running locally
+
+```bash
+# Run all visual tests (compare against baselines)
+npm run visual
+
+# Run only Chromium
+npm run visual:chromium
+
+# Open HTML diff report after a failure
+npm run visual:report
+
+# Update baselines after intentional UI changes
+npm run visual:update
+
+# Update a single project
+./scripts/update-visual-baselines.sh chromium   # or firefox / mobile
+```
+
+## Baseline workflow
+
+### First-time setup
+Baselines don't exist yet — generate them:
+```bash
+npm run visual:update
+git add e2e/__snapshots__
+git commit -m "chore: add visual regression baselines"
+```
+
+### After intentional UI changes
+1. Make your UI changes.
+2. Run `npm run visual` — tests will fail showing the diff.
+3. Review diffs in `playwright-report/` (`npm run visual:report`).
+4. If the new visuals are correct, update baselines:
+   ```bash
+   npm run visual:update
+   git add e2e/__snapshots__
+   git commit -m "chore: update visual baselines for <feature>"
+   ```
+5. Push — CI will now pass.
+
+### Approving baselines via CI (no local Playwright install)
+1. Go to **Actions → Visual Regression** in GitHub.
+2. Click **Run workflow**, set `update_baselines` to `true`.
+3. The workflow regenerates snapshots and commits them back to the branch automatically.
+
+## CI integration
+
+The `visual-regression.yml` workflow runs on every PR that touches `frontend/src/**`. It:
+- Runs all 3 browser projects in parallel.
+- Uploads diff reports as artifacts (retained 30 days) when tests fail.
+- Blocks the PR via the `Visual Regression Gate` job if any diff is detected.
+
+### Reviewing a failure
+1. Open the failed PR → **Actions** tab → click the failed run.
+2. Download the `visual-diff-<project>` artifact.
+3. Open `playwright-report/index.html` to see side-by-side diffs.
+4. If the change is intentional, follow the baseline update steps above.
+
+## Configuration
+
+Key settings in `playwright.config.ts`:
+
+| Setting | Value | Reason |
+|---|---|---|
+| `maxDiffPixelRatio` | `0.002` (0.2%) | Tolerates minor anti-aliasing differences across OS/GPU |
+| `animations` | `disabled` | Prevents flaky diffs from in-flight CSS transitions |
+| Snapshot path | `e2e/__snapshots__/{projectName}/` | Keeps per-browser baselines separate |
+
+To tighten or loosen the threshold, edit `expect.toHaveScreenshot.maxDiffPixelRatio` in `playwright.config.ts`.

--- a/frontend/e2e/visual-regression.spec.ts
+++ b/frontend/e2e/visual-regression.spec.ts
@@ -1,41 +1,229 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-test.describe('Visual Regression Tests', () => {
-  test('should match homepage snapshot', async ({ page }) => {
+// Shared helper: wait for page to be visually stable
+async function waitForStable(page: Page) {
+  await page.waitForLoadState('networkidle');
+  // Pause animations/transitions for deterministic screenshots
+  await page.addStyleTag({
+    content: `*, *::before, *::after {
+      animation-duration: 0s !important;
+      transition-duration: 0s !important;
+    }`,
+  });
+}
+
+// Public pages (no auth required)
+test.describe('Public Pages', () => {
+  test('landing page - desktop', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveScreenshot('homepage.png');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('landing-desktop.png', { fullPage: true });
   });
 
-  test('should match registration page snapshot', async ({ page }) => {
-    await page.goto('/register');
-    await expect(page).toHaveScreenshot('registration-page.png');
+  test('landing page - mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('landing-mobile.png', { fullPage: true });
   });
 
-  test('should match dashboard snapshot', async ({ page }) => {
+  test('landing page - tablet', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
     await page.goto('/');
-    await page.evaluate(() => {
-      localStorage.setItem('auth_token', 'test_token');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('landing-tablet.png', { fullPage: true });
+  });
+
+  test('login page', async ({ page }) => {
+    await page.goto('/login');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('login.png', { fullPage: true });
+  });
+
+  test('login page - mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/login');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('login-mobile.png', { fullPage: true });
+  });
+
+  test('404 not found page', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('not-found.png', { fullPage: true });
+  });
+});
+
+// Authenticated pages — mock auth via localStorage before navigation
+test.describe('Authenticated Pages', () => {
+  test.beforeEach(async ({ page }) => {
+    // Seed auth state so ProtectedLayout passes
+    await page.addInitScript(() => {
+      localStorage.setItem('auth_token', 'visual-test-token');
+      localStorage.setItem('user_role', 'recycler');
     });
-    await page.reload();
-    await expect(page).toHaveScreenshot('dashboard.png');
   });
 
-  test('should match waste submission form snapshot', async ({ page }) => {
-    await page.goto('/submit-waste');
-    await expect(page).toHaveScreenshot('waste-submission-form.png');
+  test('home / dashboard', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('dashboard.png', { fullPage: true });
   });
 
-  test('should match incentive list snapshot', async ({ page }) => {
+  test('recycler dashboard', async ({ page }) => {
+    await page.goto('/dashboard/recycler');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('recycler-dashboard.png', { fullPage: true });
+  });
+
+  test('waste list page', async ({ page }) => {
+    await page.goto('/wastes');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-list.png', { fullPage: true });
+  });
+
+  test('waste list page - mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/wastes');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-list-mobile.png', { fullPage: true });
+  });
+
+  test('incentives marketplace', async ({ page }) => {
     await page.goto('/incentives');
-    await expect(page).toHaveScreenshot('incentive-list.png');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('incentives-marketplace.png', { fullPage: true });
   });
 
-  test('should match admin dashboard snapshot', async ({ page }) => {
+  test('collector dashboard', async ({ page }) => {
+    await page.goto('/collect');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('collector-dashboard.png', { fullPage: true });
+  });
+
+  test('manufacturer dashboard', async ({ page }) => {
+    await page.goto('/manufacturer');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('manufacturer-dashboard.png', { fullPage: true });
+  });
+
+  test('analytics page', async ({ page }) => {
+    await page.goto('/analytics');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('analytics.png', { fullPage: true });
+  });
+
+  test('rewards page', async ({ page }) => {
+    await page.goto('/rewards');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('rewards.png', { fullPage: true });
+  });
+
+  test('supply chain tracker', async ({ page }) => {
+    await page.goto('/tracker');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('supply-chain-tracker.png', { fullPage: true });
+  });
+
+  test('waste map', async ({ page }) => {
+    await page.goto('/map');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-map.png', { fullPage: true });
+  });
+
+  test('admin dashboard', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('user_role', 'admin'));
     await page.goto('/admin');
-    await page.evaluate(() => {
-      localStorage.setItem('user_role', 'admin');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('admin-dashboard.png', { fullPage: true });
+  });
+
+  test('verification page', async ({ page }) => {
+    await page.goto('/verify');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('verification.png', { fullPage: true });
+  });
+
+  test('settings page', async ({ page }) => {
+    await page.goto('/settings');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('settings.png', { fullPage: true });
+  });
+
+  test('community page', async ({ page }) => {
+    await page.goto('/community');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('community.png', { fullPage: true });
+  });
+
+  test('recycling guide', async ({ page }) => {
+    await page.goto('/recycling-guide');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('recycling-guide.png', { fullPage: true });
+  });
+
+  test('waste marketplace', async ({ page }) => {
+    await page.goto('/marketplace');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-marketplace.png', { fullPage: true });
+  });
+
+  test('waste certification', async ({ page }) => {
+    await page.goto('/certifications');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-certification.png', { fullPage: true });
+  });
+
+  test('predictive analytics', async ({ page }) => {
+    await page.goto('/predictions');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('predictive-analytics.png', { fullPage: true });
+  });
+
+  test('route planner', async ({ page }) => {
+    await page.goto('/route-planner');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('route-planner.png', { fullPage: true });
+  });
+
+  test('messaging page', async ({ page }) => {
+    await page.goto('/messages');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('messaging.png', { fullPage: true });
+  });
+
+  test('waste comparison', async ({ page }) => {
+    await page.goto('/compare');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('waste-comparison.png', { fullPage: true });
+  });
+});
+
+// Dark mode variants
+test.describe('Dark Mode', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('auth_token', 'visual-test-token');
+      localStorage.setItem('theme', 'dark');
+      document.documentElement.classList.add('dark');
     });
-    await page.reload();
-    await expect(page).toHaveScreenshot('admin-dashboard.png');
+  });
+
+  test('landing page - dark mode', async ({ page }) => {
+    await page.goto('/');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('landing-dark.png', { fullPage: true });
+  });
+
+  test('dashboard - dark mode', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('dashboard-dark.png', { fullPage: true });
+  });
+
+  test('settings page - dark mode', async ({ page }) => {
+    await page.goto('/settings');
+    await waitForStable(page);
+    await expect(page).toHaveScreenshot('settings-dark.png', { fullPage: true });
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,11 @@
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",
     "a11y": "playwright test --grep 'Accessibility|Keyboard Navigation'",
-    "a11y:ui": "playwright test --grep 'Accessibility|Keyboard Navigation' --ui"
+    "a11y:ui": "playwright test --grep 'Accessibility|Keyboard Navigation' --ui",
+    "visual": "playwright test --project=visual-chromium --project=visual-firefox --project=visual-mobile",
+    "visual:update": "playwright test --project=visual-chromium --project=visual-firefox --project=visual-mobile --update-snapshots",
+    "visual:chromium": "playwright test --project=visual-chromium",
+    "visual:report": "playwright show-report playwright-report"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,22 +6,71 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['json', { outputFile: 'playwright-report/results.json' }],
+  ],
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
+
+  // Snapshot comparison settings
+  expect: {
+    toHaveScreenshot: {
+      // Allow up to 0.2% pixel difference to handle anti-aliasing across OS/GPU
+      maxDiffPixelRatio: 0.002,
+      // Snapshots stored per-project so chrome/firefox baselines are separate
+      animations: 'disabled',
+    },
+  },
+
   projects: [
+    // ── Standard E2E (non-visual) ──────────────────────────────────────────
     {
       name: 'chromium',
+      testIgnore: '**/visual-regression.spec.ts',
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'firefox',
+      testIgnore: '**/visual-regression.spec.ts',
       use: { ...devices['Desktop Firefox'] },
     },
+
+    // ── Visual Regression ─────────────────────────────────────────────────
+    {
+      name: 'visual-chromium',
+      testMatch: '**/visual-regression.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+      snapshotPathTemplate:
+        '{testDir}/__snapshots__/{projectName}/{testFilePath}/{arg}{ext}',
+    },
+    {
+      name: 'visual-firefox',
+      testMatch: '**/visual-regression.spec.ts',
+      use: {
+        ...devices['Desktop Firefox'],
+        viewport: { width: 1280, height: 800 },
+      },
+      snapshotPathTemplate:
+        '{testDir}/__snapshots__/{projectName}/{testFilePath}/{arg}{ext}',
+    },
+    {
+      name: 'visual-mobile',
+      testMatch: '**/visual-regression.spec.ts',
+      use: {
+        ...devices['Pixel 5'],
+      },
+      snapshotPathTemplate:
+        '{testDir}/__snapshots__/{projectName}/{testFilePath}/{arg}{ext}',
+    },
   ],
+
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:5173',

--- a/frontend/scripts/update-visual-baselines.sh
+++ b/frontend/scripts/update-visual-baselines.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# update-visual-baselines.sh
+# Regenerates Playwright screenshot baselines locally and commits them.
+# Run this after intentional UI changes to approve the new visuals.
+#
+# Usage:
+#   ./scripts/update-visual-baselines.sh              # all projects
+#   ./scripts/update-visual-baselines.sh chromium     # single project
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$FRONTEND_DIR"
+
+PROJECT="${1:-}"
+
+if [[ -n "$PROJECT" ]]; then
+  echo "Updating baselines for project: visual-$PROJECT"
+  npx playwright test --project="visual-$PROJECT" --update-snapshots
+else
+  echo "Updating baselines for all visual projects..."
+  npm run visual:update
+fi
+
+echo ""
+echo "Baselines updated in e2e/__snapshots__/"
+echo "Review the changes with: git diff --stat e2e/__snapshots__/"
+echo "Then commit: git add e2e/__snapshots__ && git commit -m 'chore: update visual baselines'"


### PR DESCRIPTION
## Here's what was implemented:
  
  Visual Regression Testing — Summary
  
  Tool: Playwright's native toHaveScreenshot — no Percy/Chromatic account needed, baselines live in the repo.
  
  Files changed
  
  ┌─────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ File                                    │ What changed                                                                                                                                                 │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ e2e/visual-regression.spec.ts           │ Replaced 6 stub tests with 32 tests across public pages, all authenticated routes, responsive viewports, and dark mode                                       │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ playwright.config.ts                    │ Added 3 visual projects (visual-chromium, visual-firefox, visual-mobile/Pixel 5); snapshot path per-project; maxDiffPixelRatio: 0.002; animations disabled   │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ package.json                            │ Added visual, visual:update, visual:chromium, visual:report scripts                                                                                          │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ .github/workflows/visual-regression.yml │ New workflow: matrix across 3 browsers, diff artifacts on failure, Visual Regression Gate job blocks PRs, manual update_baselines dispatch commits new       │
  │                                         │ snapshots back                                                                                                                                               │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ scripts/update-visual-baselines.sh      │ Local helper to regenerate baselines for one or all projects                                                                                                 │
  ├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ VISUAL_REGRESSION.md                    │ Full docs: first-time setup, update workflow, CI approval process                                                                                            │
  └─────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  
  Approval workflow
  
  - Tests fail → diff artifacts uploaded to GitHub Actions (30-day retention)
  - Reviewer opens playwright-report/index.html to inspect side-by-side diffs
  - To approve: run the workflow manually with update_baselines: true — it regenerates and commits the new baselines automatically, or run npm run visual:update locally and commit
  
  First-time baseline generation

closes #511 
closes #512 