### PR TITLE
feat(frontend): impact calculator, route planner, messaging & QR scanner

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -19,7 +19,12 @@ import {
   ShoppingBag,
   Award,
   BookOpen,
+  Leaf,
+  Navigation,
+  Mail,
+  QrCode,
 } from 'lucide-react'
+import { cn } from '@/lib/cn'
 import { useWallet } from '@/context/WalletContext'
 import { useAuth } from '@/context/AuthContext'
 import { Button } from '@/components/ui/Button'
@@ -93,6 +98,30 @@ const NAV_LINKS = [
     href: '/recycling-guide',
     roles: ['Recycler', 'Collector', 'Manufacturer'],
     icon: BookOpen
+  },
+  {
+    label: 'Impact',
+    href: '/impact',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: Leaf
+  },
+  {
+    label: 'Route Planner',
+    href: '/route-planner',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: Navigation
+  },
+  {
+    label: 'Messages',
+    href: '/messages',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: Mail
+  },
+  {
+    label: 'QR Scanner',
+    href: '/qr-scanner',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: QrCode
   }
 ]
 

--- a/frontend/src/components/qr/QRGenerator.tsx
+++ b/frontend/src/components/qr/QRGenerator.tsx
@@ -1,40 +1,46 @@
-import { useRef } from 'react';
-import QRCode from 'qrcode.react';
-import { Button } from '../ui/Button';
-import { Card } from '../ui/Card';
+import { useRef } from 'react'
+import { Button } from '../ui/Button'
+import { Card } from '../ui/Card'
 
 interface QRGeneratorProps {
-  wasteId: string;
-  wasteName?: string;
+  wasteId: string
+  wasteName?: string
 }
 
+const QR_API = 'https://api.qrserver.com/v1/create-qr-code/'
+
 export function QRGenerator({ wasteId, wasteName }: QRGeneratorProps) {
-  const qrRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  const src = `${QR_API}?size=200x200&data=${encodeURIComponent(wasteId)}&ecc=H`
 
   const downloadQR = () => {
-    const canvas = qrRef.current?.querySelector('canvas');
-    if (canvas) {
-      const url = canvas.toDataURL('image/png');
-      const link = document.createElement('a');
-      link.download = `waste-${wasteId}.png`;
-      link.href = url;
-      link.click();
-    }
-  };
+    const link = document.createElement('a')
+    link.download = `waste-${wasteId}.png`
+    link.href = src
+    link.click()
+  }
 
   return (
     <Card className="p-6 text-center">
-      <h3 className="text-lg font-semibold mb-4">
+      <h3 className="mb-4 text-lg font-semibold">
         {wasteName ? `QR Code for ${wasteName}` : 'Waste QR Code'}
       </h3>
-      
-      <div ref={qrRef} className="flex justify-center mb-4">
-        <QRCode value={wasteId} size={200} level="H" />
+
+      <div className="mb-4 flex justify-center">
+        <img
+          ref={imgRef}
+          src={src}
+          alt={`QR code for waste ${wasteId}`}
+          width={200}
+          height={200}
+          className="rounded-md border"
+        />
       </div>
-      
-      <p className="text-sm text-gray-600 mb-4">ID: {wasteId}</p>
-      
+
+      <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">ID: {wasteId}</p>
+
       <Button onClick={downloadQR}>Download QR Code</Button>
     </Card>
-  );
+  )
 }

--- a/frontend/src/pages/QRCodePage.tsx
+++ b/frontend/src/pages/QRCodePage.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { QrCode, History, X, ScanLine } from 'lucide-react'
+import { useAppTitle } from '@/hooks/useAppTitle'
+import { useScanHistory } from '@/hooks/useScanHistory'
+import { QRScanner } from '@/components/qr/QRScanner'
+import { QRGenerator } from '@/components/qr/QRGenerator'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+
+function formatTs(ts: number) {
+  return new Date(ts).toLocaleString()
+}
+
+export function QRCodePage() {
+  useAppTitle('QR Code Scanner')
+  const { history, addScan, clearHistory } = useScanHistory()
+  const [showScanner, setShowScanner] = useState(false)
+  const [lastScanned, setLastScanned] = useState<string | null>(null)
+  const [generateId, setGenerateId] = useState('')
+
+  const handleScan = (wasteId: string) => {
+    addScan(wasteId)
+    setLastScanned(wasteId)
+    setShowScanner(false)
+  }
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <div className="flex items-center gap-2">
+        <QrCode className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">QR Code Scanner</h1>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Scanner section */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <ScanLine className="h-4 w-4" /> Scan Waste QR Code
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {lastScanned && (
+                <div className="rounded-md bg-green-50 px-4 py-3 text-sm dark:bg-green-900/20">
+                  <p className="font-medium text-green-700 dark:text-green-400">Last scanned</p>
+                  <p className="font-mono text-green-600 dark:text-green-300">{lastScanned}</p>
+                </div>
+              )}
+              {showScanner ? (
+                <QRScanner onScan={handleScan} onClose={() => setShowScanner(false)} />
+              ) : (
+                <Button className="w-full" onClick={() => setShowScanner(true)}>
+                  <ScanLine className="mr-2 h-4 w-4" /> Open Scanner
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Scan history */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <History className="h-4 w-4" /> Scan History
+                  {history.length > 0 && <Badge variant="secondary">{history.length}</Badge>}
+                </CardTitle>
+                {history.length > 0 && (
+                  <Button size="sm" variant="ghost" onClick={clearHistory}>
+                    <X className="mr-1 h-3 w-3" /> Clear
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              {history.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No scans recorded yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {history.map((record) => (
+                    <div
+                      key={record.id}
+                      className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                    >
+                      <div>
+                        <p className="font-mono font-medium">{record.wasteId}</p>
+                        <p className="text-xs text-muted-foreground">{formatTs(record.timestamp)}</p>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setGenerateId(record.wasteId)}
+                      >
+                        View QR
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Generator section */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <QrCode className="h-4 w-4" /> Generate QR Code
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex gap-2">
+                <input
+                  className="flex-1 rounded-md border bg-background px-3 py-2 text-sm"
+                  placeholder="Enter waste ID…"
+                  value={generateId}
+                  onChange={(e) => setGenerateId(e.target.value)}
+                />
+                <Button
+                  variant="outline"
+                  disabled={!generateId.trim()}
+                  onClick={() => setGenerateId(generateId.trim())}
+                >
+                  Generate
+                </Button>
+              </div>
+              {generateId.trim() && (
+                <QRGenerator wasteId={generateId.trim()} wasteName={`Waste ${generateId.trim()}`} />
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -73,6 +73,12 @@ const WasteCertificationPage = lazy(() =>
 const RecyclingGuidePage = lazy(() =>
   import('@/pages/RecyclingGuidePage').then((m) => ({ default: m.RecyclingGuidePage }))
 )
+const ImpactCalculatorPage = lazy(() =>
+  import('@/pages/ImpactCalculatorPage').then((m) => ({ default: m.ImpactCalculatorPage }))
+)
+const QRCodePage = lazy(() =>
+  import('@/pages/QRCodePage').then((m) => ({ default: m.QRCodePage }))
+)
 
 // eslint-disable-next-line react-refresh/only-export-components
 function PageFallback() {
@@ -125,7 +131,9 @@ export const router = createBrowserRouter([
       { path: 'predictions', element: <PredictiveAnalyticsPage /> },
       { path: 'marketplace', element: <WasteMarketplacePage /> },
       { path: 'certifications', element: <WasteCertificationPage /> },
-      { path: 'recycling-guide', element: <RecyclingGuidePage /> }
+      { path: 'recycling-guide', element: <RecyclingGuidePage /> },
+      { path: 'impact', element: <ImpactCalculatorPage /> },
+      { path: 'qr-scanner', element: <QRCodePage /> }
     ]
   },
   { path: '*', element: <NotFoundPage /> }


### PR DESCRIPTION
## Summary

- **#582 Impact Calculator**: Wired `ImpactCalculatorPage` into the router (`/impact`) and added a nav link with a Leaf icon — the page, hook, and lib already existed but were unreachable
- **#583 Route Planner**: Added nav link for the existing `/route-planner` route (page and route already existed)
- **#584 Messaging System**: Added nav link for the existing `/messages` route (page and route already existed)
- **#585 QR Code Scanner**: Created `QRCodePage` that integrates `QRScanner`, `QRGenerator`, and `useScanHistory`; added `/qr-scanner` route; rewrote `QRGenerator` to remove the missing `qrcode.react` dependency (uses QR image API instead); fixed missing `cn` import in `AppShell`

## Test plan

- [ ] Navigate to `/impact` — environmental impact metrics should render
- [ ] Navigate to `/route-planner` — route planner UI should render
- [ ] Navigate to `/messages` — messaging inbox should render (requires wallet connection)
- [ ] Navigate to `/qr-scanner` — scanner, generator, and scan history should render
- [ ] Sidebar/nav links for all four features appear for Recycler/Collector/Manufacturer roles

Closes #582 
closes  #583 
closes #584 
closes #585 

🤖 Generated with [Claude Code](https://claude.com/claude-code)