### PR TITLE
feat: wire up waste certification, subscriptions, charity donations & predictive analytics (#586-#589)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -19,7 +19,11 @@ import {
   ShoppingBag,
   Award,
   BookOpen,
+  CalendarDays,
+  Heart,
+  TrendingUp,
 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { useWallet } from '@/context/WalletContext'
 import { useAuth } from '@/context/AuthContext'
 import { Button } from '@/components/ui/Button'
@@ -93,6 +97,24 @@ const NAV_LINKS = [
     href: '/recycling-guide',
     roles: ['Recycler', 'Collector', 'Manufacturer'],
     icon: BookOpen
+  },
+  {
+    label: 'Subscriptions',
+    href: '/subscriptions',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: CalendarDays
+  },
+  {
+    label: 'Donations',
+    href: '/donations',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: Heart
+  },
+  {
+    label: 'Predictions',
+    href: '/predictions',
+    roles: ['Recycler', 'Collector', 'Manufacturer'],
+    icon: TrendingUp
   }
 ]
 
@@ -116,6 +138,9 @@ function getOnboardingDataAttribute(href: string): string | undefined {
     '/marketplace': 'marketplace',
     '/certifications': 'certifications',
     '/recycling-guide': 'recycling-guide',
+    '/subscriptions': 'subscriptions',
+    '/donations': 'donations',
+    '/predictions': 'predictions',
   }
   return attributeMap[href]
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -73,6 +73,12 @@ const WasteCertificationPage = lazy(() =>
 const RecyclingGuidePage = lazy(() =>
   import('@/pages/RecyclingGuidePage').then((m) => ({ default: m.RecyclingGuidePage }))
 )
+const SubscriptionsPage = lazy(() =>
+  import('@/pages/SubscriptionsPage').then((m) => ({ default: m.SubscriptionsPage }))
+)
+const CharityDonationsPage = lazy(() =>
+  import('@/pages/CharityDonationsPage').then((m) => ({ default: m.CharityDonationsPage }))
+)
 
 // eslint-disable-next-line react-refresh/only-export-components
 function PageFallback() {
@@ -125,7 +131,9 @@ export const router = createBrowserRouter([
       { path: 'predictions', element: <PredictiveAnalyticsPage /> },
       { path: 'marketplace', element: <WasteMarketplacePage /> },
       { path: 'certifications', element: <WasteCertificationPage /> },
-      { path: 'recycling-guide', element: <RecyclingGuidePage /> }
+      { path: 'recycling-guide', element: <RecyclingGuidePage /> },
+      { path: 'subscriptions', element: <SubscriptionsPage /> },
+      { path: 'donations', element: <CharityDonationsPage /> }
     ]
   },
   { path: '*', element: <NotFoundPage /> }


### PR DESCRIPTION
## Summary

- **#586 - Waste Certification**: `WasteCertificationPage` was already fully implemented; route (`/certifications`) and nav link were already wired — no changes needed.
- **#587 - Subscription Management**: Added lazy-loaded route `/subscriptions` → `SubscriptionsPage` and a **Subscriptions** nav entry in `AppShell`.
- **#588 - Charity Donations**: Added lazy-loaded route `/donations` → `CharityDonationsPage` and a **Donations** nav entry in `AppShell`.
- **#589 - Predictive Analytics**: `PredictiveAnalyticsPage` was already routed at `/predictions`; added missing **Predictions** nav entry in `AppShell`.
- Fixed missing `cn` import in `AppShell.tsx` that was causing a silent compile error.

All four pages (with their hooks, storage utilities, and UI components) were already fully implemented in previous PRs. This PR completes the integration by registering routes and navigation entries for the ones that were missing.

## Test plan
- [ ] Navigate to `/subscriptions` — Pickup Subscriptions page loads, wallet-connect gate works, create/pause/resume/cancel flows work
- [ ] Navigate to `/donations` — Charity Donations page loads, charity list and donate dialog work, receipt download works
- [ ] Navigate to `/predictions` — Predictive Analytics page loads with trend cards and forecast detail
- [ ] Navigate to `/certifications` — Waste Certifications page loads with search/filter and detail panel
- [ ] Confirm all four links appear in the sidebar nav

Closes #586 
closes  #587 
closes #588 
closes  #589 

🤖 Generated with [Claude Code](https://claude.com/claude-code)