### PR TITLE
feat: performance monitoring, E2E CI, visual regression & component library

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,102 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'frontend/src/**'
+      - 'frontend/e2e/**'
+      - 'frontend/playwright.config.ts'
+      - 'frontend/package*.json'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'frontend/src/**'
+      - 'frontend/e2e/**'
+
+jobs:
+  e2e:
+    name: E2E (${{ matrix.browser }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Build frontend
+        run: npm run build
+        env:
+          VITE_CONTRACT_ID: e2e-placeholder
+          VITE_NETWORK: TESTNET
+          VITE_RPC_URL: https://soroban-testnet.stellar.org
+          VITE_FIREBASE_API_KEY: e2e-placeholder
+          VITE_FIREBASE_AUTH_DOMAIN: e2e-placeholder
+          VITE_FIREBASE_PROJECT_ID: e2e-placeholder
+          VITE_FIREBASE_STORAGE_BUCKET: e2e-placeholder
+          VITE_FIREBASE_MESSAGING_SENDER_ID: e2e-placeholder
+          VITE_FIREBASE_APP_ID: e2e-placeholder
+          VITE_FIREBASE_MEASUREMENT_ID: e2e-placeholder
+
+      - name: Run E2E tests
+        run: npx playwright test --project=${{ matrix.browser }}
+        env:
+          CI: true
+          VITE_CONTRACT_ID: e2e-placeholder
+          VITE_NETWORK: TESTNET
+          VITE_RPC_URL: https://soroban-testnet.stellar.org
+          VITE_FIREBASE_API_KEY: e2e-placeholder
+          VITE_FIREBASE_AUTH_DOMAIN: e2e-placeholder
+          VITE_FIREBASE_PROJECT_ID: e2e-placeholder
+          VITE_FIREBASE_STORAGE_BUCKET: e2e-placeholder
+          VITE_FIREBASE_MESSAGING_SENDER_ID: e2e-placeholder
+          VITE_FIREBASE_APP_ID: e2e-placeholder
+          VITE_FIREBASE_MEASUREMENT_ID: e2e-placeholder
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report-${{ matrix.browser }}-${{ github.run_id }}
+          path: frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-traces-${{ matrix.browser }}-${{ github.run_id }}
+          path: frontend/test-results/
+          retention-days: 7
+
+  e2e-gate:
+    name: E2E Gate
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: always()
+    steps:
+      - name: Check E2E results
+        run: |
+          if [ "${{ needs.e2e.result }}" != "success" ]; then
+            echo "::error::E2E tests failed. Review the 'e2e-report-*' artifacts for details."
+            exit 1
+          fi
+          echo "All E2E tests passed."

--- a/frontend/src/components/ui/EmptyState.stories.tsx
+++ b/frontend/src/components/ui/EmptyState.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Package, Search, Inbox, AlertTriangle } from 'lucide-react'
+import { EmptyState } from './EmptyState'
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Design System/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof EmptyState>
+
+export const Default: Story = {
+  args: {
+    icon: Package,
+    title: 'No waste submissions yet',
+    description: 'Start by submitting recyclable materials to earn tokens.',
+  },
+}
+
+export const WithAction: Story = {
+  args: {
+    icon: Inbox,
+    title: 'No messages',
+    description: 'Your inbox is empty. Messages from collectors will appear here.',
+    action: {
+      label: 'Browse Collectors',
+      onClick: () => {},
+    },
+  },
+}
+
+export const SearchEmpty: Story = {
+  args: {
+    icon: Search,
+    title: 'No results found',
+    description: 'Try adjusting your search terms or filters.',
+    action: {
+      label: 'Clear Filters',
+      onClick: () => {},
+    },
+  },
+}
+
+export const ErrorState: Story = {
+  args: {
+    icon: AlertTriangle,
+    title: 'Something went wrong',
+    description: 'We could not load your data. Please try again.',
+    action: {
+      label: 'Retry',
+      onClick: () => {},
+    },
+  },
+}
+
+export const NoIcon: Story = {
+  args: {
+    title: 'Nothing here yet',
+    description: 'Check back later for updates.',
+  },
+}

--- a/frontend/src/components/ui/PerformanceAlert.stories.tsx
+++ b/frontend/src/components/ui/PerformanceAlert.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { PerformanceAlert, PerformanceSummary } from './PerformanceAlert'
+
+const meta: Meta = {
+  title: 'Design System/PerformanceAlert',
+  tags: ['autodocs'],
+}
+export default meta
+
+export const Good: StoryObj = {
+  render: () => (
+    <PerformanceAlert
+      metric="LCP"
+      value="1,840 ms"
+      severity="good"
+      message="Largest Contentful Paint is within the recommended 2,500 ms budget."
+    />
+  ),
+}
+
+export const Warning: StoryObj = {
+  render: () => (
+    <PerformanceAlert
+      metric="FCP"
+      value="2,300 ms"
+      severity="warning"
+      message="First Contentful Paint exceeds the 1,800 ms good threshold. Consider optimising render-blocking resources."
+    />
+  ),
+}
+
+export const Critical: StoryObj = {
+  render: () => (
+    <PerformanceAlert
+      metric="INP"
+      value="620 ms"
+      severity="critical"
+      message="Interaction to Next Paint is above the 500 ms poor threshold — users will notice sluggish interactions."
+    />
+  ),
+}
+
+export const AllSeverities: StoryObj = {
+  render: () => (
+    <div className="space-y-2 w-96">
+      <PerformanceAlert metric="LCP" value="1,840 ms" severity="good" message="Within budget." />
+      <PerformanceAlert metric="TTFB" value="820 ms" severity="warning" message="Slightly above the 600 ms threshold." />
+      <PerformanceAlert metric="CLS" value="0.31" severity="critical" message="Cumulative Layout Shift exceeds the 0.25 poor threshold." />
+    </div>
+  ),
+}
+
+export const Summary: StoryObj = {
+  render: () => (
+    <div className="space-y-2">
+      <PerformanceSummary passed={4} total={5} />
+      <PerformanceSummary passed={5} total={5} />
+      <PerformanceSummary passed={1} total={5} />
+    </div>
+  ),
+}

--- a/frontend/src/components/ui/PerformanceAlert.tsx
+++ b/frontend/src/components/ui/PerformanceAlert.tsx
@@ -1,0 +1,73 @@
+import { type ReactNode } from 'react'
+import { AlertTriangle, CheckCircle2, XCircle, TrendingUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type AlertSeverity = 'good' | 'warning' | 'critical'
+
+export interface PerformanceAlertProps {
+  metric: string
+  value: string
+  severity: AlertSeverity
+  message: string
+  className?: string
+}
+
+const SEVERITY_STYLES: Record<AlertSeverity, { card: string; icon: ReactNode; label: string }> = {
+  good: {
+    card: 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20',
+    icon: <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />,
+    label: 'Good',
+  },
+  warning: {
+    card: 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-900/20',
+    icon: <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />,
+    label: 'Needs Improvement',
+  },
+  critical: {
+    card: 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20',
+    icon: <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />,
+    label: 'Poor',
+  },
+}
+
+export function PerformanceAlert({ metric, value, severity, message, className }: PerformanceAlertProps) {
+  const styles = SEVERITY_STYLES[severity]
+
+  return (
+    <div className={cn('flex items-start gap-3 rounded-lg border p-3', styles.card, className)}>
+      <span className="mt-0.5 shrink-0">{styles.icon}</span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold">{metric}</span>
+          <span className="font-mono text-xs text-muted-foreground">{value}</span>
+          <span className="ml-auto text-xs font-medium">{styles.label}</span>
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  )
+}
+
+export interface PerformanceSummaryProps {
+  passed: number
+  total: number
+  className?: string
+}
+
+export function PerformanceSummary({ passed, total, className }: PerformanceSummaryProps) {
+  const pct = total > 0 ? Math.round((passed / total) * 100) : 0
+  const allGood = passed === total
+
+  return (
+    <div className={cn('flex items-center gap-2 text-sm', className)}>
+      {allGood ? (
+        <CheckCircle2 className="h-4 w-4 text-green-500" />
+      ) : (
+        <TrendingUp className="h-4 w-4 text-yellow-500" />
+      )}
+      <span className={cn('font-medium', allGood ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400')}>
+        {passed}/{total} metrics passing ({pct}%)
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Skeletons.stories.tsx
+++ b/frontend/src/components/ui/Skeletons.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StatCardSkeleton, WasteCardSkeleton, IncentiveCardSkeleton, PageSkeleton } from './Skeletons'
+
+const meta: Meta = {
+  title: 'Design System/Skeletons',
+  tags: ['autodocs'],
+}
+export default meta
+
+export const StatCard: StoryObj = {
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+    </div>
+  ),
+}
+
+export const WasteCard: StoryObj = {
+  render: () => (
+    <div className="overflow-hidden rounded-lg border">
+      <table className="w-full">
+        <tbody>
+          <WasteCardSkeleton />
+          <WasteCardSkeleton />
+          <WasteCardSkeleton />
+        </tbody>
+      </table>
+    </div>
+  ),
+}
+
+export const IncentiveCard: StoryObj = {
+  render: () => (
+    <div className="overflow-hidden rounded-lg border">
+      <table className="w-full">
+        <tbody>
+          <IncentiveCardSkeleton />
+          <IncentiveCardSkeleton />
+        </tbody>
+      </table>
+    </div>
+  ),
+}
+
+export const FullPage: StoryObj = {
+  render: () => <PageSkeleton />,
+}

--- a/frontend/src/components/ui/StatCard.stories.tsx
+++ b/frontend/src/components/ui/StatCard.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Recycle, Users, TrendingUp, Award, Package, AlertTriangle } from 'lucide-react'
+import { StatCard } from './StatCard'
+
+const meta: Meta<typeof StatCard> = {
+  title: 'Design System/StatCard',
+  component: StatCard,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary', 'success', 'warning', 'destructive'],
+    },
+    trend: {
+      control: 'select',
+      options: [undefined, 'up', 'down'],
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof StatCard>
+
+export const Default: Story = {
+  args: {
+    icon: <Recycle className="h-4 w-4" />,
+    label: 'Total Recycled',
+    value: '1,240 kg',
+  },
+}
+
+export const WithTrend: Story = {
+  args: {
+    icon: <TrendingUp className="h-4 w-4" />,
+    label: 'Tokens Earned',
+    value: '8,420',
+    trend: 'up',
+    trendLabel: '+12% this month',
+    variant: 'success',
+  },
+}
+
+export const NegativeTrend: Story = {
+  args: {
+    icon: <Package className="h-4 w-4" />,
+    label: 'Pending Submissions',
+    value: '34',
+    trend: 'down',
+    trendLabel: '-5 from last week',
+    variant: 'warning',
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    icon: <Users className="h-4 w-4" />,
+    label: 'Active Participants',
+    value: '—',
+    isLoading: true,
+    trendLabel: 'loading...',
+  },
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+      <StatCard icon={<Recycle className="h-4 w-4" />} label="Default" value="1,240 kg" variant="default" />
+      <StatCard icon={<TrendingUp className="h-4 w-4" />} label="Primary" value="8,420" variant="primary" trendLabel="tokens" />
+      <StatCard icon={<Award className="h-4 w-4" />} label="Success" value="92%" variant="success" trend="up" trendLabel="+4% vs last month" />
+      <StatCard icon={<AlertTriangle className="h-4 w-4" />} label="Warning" value="12" variant="warning" trendLabel="pending reviews" />
+      <StatCard icon={<Package className="h-4 w-4" />} label="Destructive" value="3" variant="destructive" trendLabel="failed transfers" />
+    </div>
+  ),
+}

--- a/frontend/src/components/ui/WasteCard.stories.tsx
+++ b/frontend/src/components/ui/WasteCard.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from './Button'
+import { WasteCard } from './WasteCard'
+import { WasteType } from '@/api/types'
+
+const meta: Meta<typeof WasteCard> = {
+  title: 'Design System/WasteCard',
+  component: WasteCard,
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof WasteCard>
+
+const baseWaste = {
+  waste_id: BigInt(1001),
+  waste_type: WasteType.Paper,
+  weight: BigInt(5200),
+  current_owner: 'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQSXUSMIQ75XABZEYYWRB46Z',
+  latitude: BigInt(40712800),
+  longitude: BigInt(-74006000),
+  recycled_timestamp: Date.now(),
+  is_active: true,
+  is_confirmed: false,
+  confirmer: '',
+}
+
+export const Pending: Story = {
+  args: {
+    waste: baseWaste,
+  },
+}
+
+export const Confirmed: Story = {
+  args: {
+    waste: {
+      ...baseWaste,
+      waste_id: BigInt(1002),
+      is_confirmed: true,
+      confirmer: 'GBVNO3XEUPVHPQXGTHFZEPXE4RXQFQFVHIFLZXDSFGK7YKIBLNRJRPH',
+    },
+  },
+}
+
+export const Inactive: Story = {
+  args: {
+    waste: {
+      ...baseWaste,
+      waste_id: BigInt(1003),
+      waste_type: WasteType.Plastic,
+      is_active: false,
+      weight: BigInt(12000),
+    },
+  },
+}
+
+export const WithActions: Story = {
+  args: {
+    waste: {
+      ...baseWaste,
+      waste_id: BigInt(1004),
+      waste_type: WasteType.Metal,
+      weight: BigInt(750),
+    },
+    actions: (
+      <>
+        <Button size="sm" variant="outline" className="flex-1">View</Button>
+        <Button size="sm" className="flex-1">Transfer</Button>
+      </>
+    ),
+  },
+}
+
+export const AllWasteTypes: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {([WasteType.Paper, WasteType.Plastic, WasteType.PetPlastic, WasteType.Metal, WasteType.Glass] as WasteType[]).map(
+        (type, i) => (
+          <WasteCard
+            key={type}
+            waste={{
+              ...baseWaste,
+              waste_id: BigInt(2000 + i),
+              waste_type: type,
+              weight: BigInt(1000 + i * 500),
+              is_confirmed: i % 2 === 0,
+            }}
+          />
+        )
+      )}
+    </div>
+  ),
+}

--- a/frontend/src/pages/PerformanceMonitoringPage.tsx
+++ b/frontend/src/pages/PerformanceMonitoringPage.tsx
@@ -1,0 +1,213 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Activity, Gauge, Timer, Layers, AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
+import { StatCard } from '@/components/ui/StatCard'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
+import { usePerformanceMonitoring } from '@/hooks/usePerformanceMonitoring'
+import { initWebVitals, validatePerformanceBudgets, type WebVital, type PerformanceMetrics } from '@/lib/webVitals'
+
+const METRIC_CONFIG: Record<string, { label: string; unit: string; description: string }> = {
+  LCP: { label: 'Largest Contentful Paint', unit: 'ms', description: 'Time until the largest content element renders' },
+  FCP: { label: 'First Contentful Paint', unit: 'ms', description: 'Time until first content appears on screen' },
+  INP: { label: 'Interaction to Next Paint', unit: 'ms', description: 'Responsiveness to user interactions' },
+  CLS: { label: 'Cumulative Layout Shift', unit: '', description: 'Visual stability — unexpected layout shifts' },
+  TTFB: { label: 'Time to First Byte', unit: 'ms', description: 'Server response time to first byte' },
+}
+
+const RATING_STYLES: Record<string, string> = {
+  good: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400',
+  'needs-improvement': 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400',
+  poor: 'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400',
+}
+
+function RatingIcon({ rating }: { rating?: string }) {
+  if (rating === 'good') return <CheckCircle2 className="h-4 w-4 text-green-500" />
+  if (rating === 'needs-improvement') return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+  return <XCircle className="h-4 w-4 text-red-500" />
+}
+
+function MetricCard({ name, metric }: { name: string; metric?: WebVital }) {
+  const config = METRIC_CONFIG[name]
+  if (!metric || !config) return null
+
+  const displayValue = name === 'CLS'
+    ? metric.value.toFixed(3)
+    : `${metric.value.toFixed(0)}${config.unit}`
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium text-muted-foreground">{config.label}</CardTitle>
+          {metric.rating && <RatingIcon rating={metric.rating} />}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-2xl font-bold">{displayValue}</p>
+        {metric.rating && (
+          <Badge className={`border text-xs font-medium ${RATING_STYLES[metric.rating] ?? ''}`}>
+            {metric.rating.replace('-', ' ')}
+          </Badge>
+        )}
+        <p className="text-xs text-muted-foreground">{config.description}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function PerformanceMonitoringPage() {
+  usePerformanceMonitoring()
+
+  const [metrics, setMetrics] = useState<PerformanceMetrics>({})
+  const [alerts, setAlerts] = useState<string[]>([])
+  const [lastUpdated, setLastUpdated] = useState<Date>(new Date())
+
+  const handleMetric = useCallback((metric: WebVital) => {
+    setMetrics((prev) => ({ ...prev, [metric.name.toLowerCase()]: metric }))
+    setLastUpdated(new Date())
+  }, [])
+
+  useEffect(() => {
+    const cleanup = initWebVitals(handleMetric)
+    return cleanup
+  }, [handleMetric])
+
+  useEffect(() => {
+    const result = validatePerformanceBudgets(metrics)
+    setAlerts(result.violations)
+  }, [metrics])
+
+  const goodCount = Object.values(metrics).filter((m) => m?.rating === 'good').length
+  const needsImprovementCount = Object.values(metrics).filter((m) => m?.rating === 'needs-improvement').length
+  const poorCount = Object.values(metrics).filter((m) => m?.rating === 'poor').length
+  const totalMetrics = goodCount + needsImprovementCount + poorCount
+  const overallScore = totalMetrics > 0 ? Math.round((goodCount / totalMetrics) * 100) : null
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold">Performance Monitoring</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Real-time Core Web Vitals and performance metrics · Last updated {lastUpdated.toLocaleTimeString()}
+        </p>
+      </div>
+
+      {/* Summary stat cards */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          icon={<Gauge className="h-4 w-4" />}
+          label="Overall Score"
+          value={overallScore !== null ? `${overallScore}%` : '—'}
+          variant={overallScore !== null && overallScore >= 80 ? 'success' : overallScore !== null && overallScore >= 50 ? 'warning' : 'default'}
+        />
+        <StatCard
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          label="Good Metrics"
+          value={goodCount}
+          variant="success"
+        />
+        <StatCard
+          icon={<AlertTriangle className="h-4 w-4" />}
+          label="Needs Improvement"
+          value={needsImprovementCount}
+          variant="warning"
+        />
+        <StatCard
+          icon={<XCircle className="h-4 w-4" />}
+          label="Poor Metrics"
+          value={poorCount}
+          variant={poorCount > 0 ? 'destructive' : 'default'}
+        />
+      </div>
+
+      {/* Performance budget alerts */}
+      {alerts.length > 0 && (
+        <Card className="border-destructive/30 bg-destructive/5">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+              Performance Budget Violations
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1">
+              {alerts.map((alert) => (
+                <li key={alert} className="text-sm text-destructive">
+                  {alert}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Core Web Vitals */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">Core Web Vitals</h2>
+        {totalMetrics === 0 ? (
+          <Card>
+            <CardContent className="flex items-center gap-3 py-8 text-muted-foreground">
+              <Activity className="h-5 w-5 animate-pulse" />
+              <span className="text-sm">Collecting metrics — interact with the page to generate data…</span>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {(['LCP', 'FCP', 'INP', 'CLS', 'TTFB'] as const).map((name) => {
+              const key = name.toLowerCase() as 'lcp' | 'fcp' | 'inp' | 'cls' | 'ttfb'
+              return <MetricCard key={name} name={name} metric={metrics[key]} />
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Navigation & resource timing */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">Navigation Timing</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <StatCard
+            icon={<Timer className="h-4 w-4" />}
+            label="Total Load Time"
+            value={metrics.navigationTime ? `${metrics.navigationTime.toFixed(0)} ms` : '—'}
+            variant="primary"
+          />
+          <StatCard
+            icon={<Layers className="h-4 w-4" />}
+            label="Resource Fetch Time"
+            value={metrics.resourceTime ? `${metrics.resourceTime.toFixed(0)} ms` : '—'}
+            variant="primary"
+          />
+        </div>
+      </div>
+
+      {/* Performance thresholds reference */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-semibold">Performance Thresholds</CardTitle>
+          <CardDescription>Targets based on Google Core Web Vitals recommendations</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="pb-2 font-medium">Metric</th>
+                  <th className="pb-2 font-medium">Good</th>
+                  <th className="pb-2 font-medium">Needs Improvement</th>
+                  <th className="pb-2 font-medium">Poor</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                <tr><td className="py-2 font-medium">LCP</td><td className="py-2 text-green-600">≤ 2,500 ms</td><td className="py-2 text-yellow-600">≤ 4,000 ms</td><td className="py-2 text-destructive">&gt; 4,000 ms</td></tr>
+                <tr><td className="py-2 font-medium">FCP</td><td className="py-2 text-green-600">≤ 1,800 ms</td><td className="py-2 text-yellow-600">≤ 3,000 ms</td><td className="py-2 text-destructive">&gt; 3,000 ms</td></tr>
+                <tr><td className="py-2 font-medium">INP</td><td className="py-2 text-green-600">≤ 200 ms</td><td className="py-2 text-yellow-600">≤ 500 ms</td><td className="py-2 text-destructive">&gt; 500 ms</td></tr>
+                <tr><td className="py-2 font-medium">CLS</td><td className="py-2 text-green-600">≤ 0.1</td><td className="py-2 text-yellow-600">≤ 0.25</td><td className="py-2 text-destructive">&gt; 0.25</td></tr>
+                <tr><td className="py-2 font-medium">TTFB</td><td className="py-2 text-green-600">≤ 600 ms</td><td className="py-2 text-yellow-600">≤ 1,800 ms</td><td className="py-2 text-destructive">&gt; 1,800 ms</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -73,6 +73,9 @@ const WasteCertificationPage = lazy(() =>
 const RecyclingGuidePage = lazy(() =>
   import('@/pages/RecyclingGuidePage').then((m) => ({ default: m.RecyclingGuidePage }))
 )
+const PerformanceMonitoringPage = lazy(() =>
+  import('@/pages/PerformanceMonitoringPage').then((m) => ({ default: m.PerformanceMonitoringPage }))
+)
 
 // eslint-disable-next-line react-refresh/only-export-components
 function PageFallback() {
@@ -125,7 +128,8 @@ export const router = createBrowserRouter([
       { path: 'predictions', element: <PredictiveAnalyticsPage /> },
       { path: 'marketplace', element: <WasteMarketplacePage /> },
       { path: 'certifications', element: <WasteCertificationPage /> },
-      { path: 'recycling-guide', element: <RecyclingGuidePage /> }
+      { path: 'recycling-guide', element: <RecyclingGuidePage /> },
+      { path: 'performance', element: <PerformanceMonitoringPage /> }
     ]
   },
   { path: '*', element: <NotFoundPage /> }

--- a/frontend/src/stories/ComponentLibrary.mdx
+++ b/frontend/src/stories/ComponentLibrary.mdx
@@ -1,0 +1,52 @@
+import { Meta } from '@storybook/blocks'
+
+<Meta title="Design System/Introduction" />
+
+# Scavngr Component Library
+
+Scavngr's design system provides a set of reusable, accessible UI components built with
+[Tailwind CSS](https://tailwindcss.com), [Radix UI](https://www.radix-ui.com), and
+[class-variance-authority](https://cva.style).
+
+## Principles
+
+- **Accessible by default** — all interactive components follow WAI-ARIA patterns and are keyboard-navigable.
+- **Themeable** — components respect the `dark` class on `<html>` and adapt automatically.
+- **Composable** — small primitives combine into larger patterns rather than a rigid widget library.
+
+## Tokens
+
+Design tokens (colours, spacing, typography) live in `src/design-system/tokens.ts` and are
+consumed by both Tailwind's config and runtime CSS custom properties. Import them with:
+
+```ts
+import { colors, spacing, cssVar, semanticColor } from '@/design-system'
+```
+
+## Available Components
+
+| Component | Story | Description |
+|-----------|-------|-------------|
+| Badge | Design System/Badge | Status and category labels |
+| Button | Design System/Button | Primary actions |
+| Card | Design System/Card | Content containers |
+| Checkbox | Design System/Checkbox | Toggle inputs |
+| Dialog | Design System/Dialog | Modal dialogs |
+| EmptyState | Design System/EmptyState | Zero-data states |
+| Input | Design System/Input | Text inputs |
+| PerformanceAlert | Design System/PerformanceAlert | Web Vitals status indicators |
+| Select | Design System/Select | Dropdown menus |
+| Skeletons | Design System/Skeletons | Loading placeholders |
+| StatCard | Design System/StatCard | Metric summary cards |
+| Switch | Design System/Switch | Toggle switches |
+| WasteCard | Design System/WasteCard | Waste item display cards |
+
+## Usage
+
+```tsx
+import { Button } from '@/components/ui/Button'
+import { StatCard } from '@/components/ui/StatCard'
+import { EmptyState } from '@/components/ui/EmptyState'
+```
+
+All components are re-exported from `@/components/ui/index.ts`.


### PR DESCRIPTION
## Summary

- **#590** — Add `PerformanceMonitoringPage` with real-time Core Web Vitals dashboard (LCP, FCP, INP, CLS, TTFB), budget violation alerts, navigation timing stats, and `PerformanceAlert` / `PerformanceSummary` UI components; register `/performance` route in the router
- **#591** — Visual regression testing was already fully in place (spec, Playwright `visual-chromium/firefox/mobile` projects, `visual-regression.yml` CI, `VISUAL_REGRESSION.md` docs) — no gaps found
- **#592** — Add `.github/workflows/e2e.yml`: dedicated E2E CI pipeline that runs chromium + firefox in parallel on PRs/pushes, uploads reports & traces on failure, and gates the PR with an `e2e-gate` job
- **#593** — Expand component library: add Storybook stories for `StatCard`, `EmptyState`, `WasteCard`, `Skeletons`, and `PerformanceAlert`; add `ComponentLibrary.mdx` intro doc listing all available design-system components

## Files changed

| File | Issue |
|------|-------|
| `frontend/src/pages/PerformanceMonitoringPage.tsx` | #590 |
| `frontend/src/components/ui/PerformanceAlert.tsx` | #590 |
| `frontend/src/router.tsx` | #590 |
| `.github/workflows/e2e.yml` | #592 |
| `frontend/src/components/ui/StatCard.stories.tsx` | #593 |
| `frontend/src/components/ui/EmptyState.stories.tsx` | #593 |
| `frontend/src/components/ui/WasteCard.stories.tsx` | #593 |
| `frontend/src/components/ui/Skeletons.stories.tsx` | #593 |
| `frontend/src/components/ui/PerformanceAlert.stories.tsx` | #593 |
| `frontend/src/stories/ComponentLibrary.mdx` | #593 |

Closes #590
Closes #591
Closes #592
Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)