### PR TITLE
[CI/CD] Load balancing, backup/recovery, secret management, cost optimization (#614–#617)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,109 @@
+name: Automated Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      verify_only:
+        description: 'Only run backup verification (skip new backup)'
+        required: false
+        default: 'false'
+
+jobs:
+  backup:
+    name: Database Backup
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.verify_only != 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Run database backup
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_NAME: ${{ secrets.DB_NAME || 'scavenger' }}
+          BACKUP_DIR: /tmp/backups
+          RETENTION_DAYS: '30'
+        run: bash scripts/backup-database.sh
+
+      - name: Publish backup metrics
+        run: |
+          aws cloudwatch put-metric-data \
+            --namespace "Scavenger/Backups" \
+            --metric-name "BackupSuccess" \
+            --value 1 \
+            --unit Count \
+            --region ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+  verify:
+    name: Backup Verification
+    runs-on: ubuntu-latest
+    needs: [backup]
+    if: ${{ always() && (needs.backup.result == 'success' || github.event.inputs.verify_only == 'true') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Verify backup restore
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+        run: bash scripts/verify-backup-restore.sh
+
+      - name: Publish verification metrics
+        if: always()
+        run: |
+          VALUE=${{ job.status == 'success' && '1' || '0' }}
+          aws cloudwatch put-metric-data \
+            --namespace "Scavenger/Backups" \
+            --metric-name "BackupVerificationSuccess" \
+            --value "$VALUE" \
+            --unit Count \
+            --region ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+  weekly-restore-test:
+    name: Weekly Full Restore Test
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 2 * * 0' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Full restore test
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+        run: bash scripts/verify-backup-restore.sh
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Weekly backup restore test FAILED',
+              body: 'The weekly full backup restore test failed. See workflow run: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId,
+              labels: ['bug', 'backup']
+            })

--- a/.github/workflows/cost-report.yml
+++ b/.github/workflows/cost-report.yml
@@ -1,0 +1,98 @@
+name: Cost Report
+
+on:
+  schedule:
+    - cron: '0 8 1 * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days to analyze'
+        required: false
+        default: '30'
+
+jobs:
+  cost-report:
+    name: Generate Cost Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Run cost analysis
+        env:
+          ENVIRONMENT: ${{ vars.ENVIRONMENT || 'prod' }}
+          COST_ANALYSIS_DAYS: ${{ github.event.inputs.days || '30' }}
+        run: bash scripts/cost-analysis.sh | tee /tmp/cost-report.txt
+
+      - name: Upload cost report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cost-report-${{ github.run_id }}
+          path: /tmp/cost-report.txt
+          retention-days: 90
+
+      - name: Check for cost anomalies
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+          MONITORS=$(aws ce get-anomaly-monitors \
+            --query 'AnomalyMonitors[?MonitorName==`scavenger-anomaly-monitor`].MonitorArn' \
+            --output text 2>/dev/null || echo "")
+
+          if [ -n "$MONITORS" ]; then
+            ANOMALIES=$(aws ce get-anomalies \
+              --monitor-arn-list "$MONITORS" \
+              --date-interval "StartDate=$(date -d '-7 days' +%Y-%m-%d 2>/dev/null || date -v-7d +%Y-%m-%d)" \
+              --query 'Anomalies[?AnomalyScore.CurrentScore>`0.5`] | length(@)' \
+              --output text 2>/dev/null || echo "0")
+
+            echo "Cost anomalies detected in past 7 days: $ANOMALIES"
+            if [ "$ANOMALIES" -gt 0 ]; then
+              echo "::warning::$ANOMALIES cost anomalies detected — review Cost Explorer"
+            fi
+          fi
+
+  check-budget-alerts:
+    name: Check Budget Thresholds
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Check budget utilization
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+          UTIL=$(aws budgets describe-budgets \
+            --account-id "$ACCOUNT_ID" \
+            --query 'Budgets[?contains(BudgetName,`scavenger`)].{limit:BudgetLimit.Amount,actual:CalculatedSpend.ActualSpend.Amount}' \
+            --output json 2>/dev/null || echo "[]")
+
+          echo "$UTIL" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          for b in data:
+              limit = float(b.get('limit') or 0)
+              actual = float(b.get('actual') or 0)
+              if limit > 0:
+                  pct = (actual / limit) * 100
+                  print(f'Budget utilization: \${actual:.2f} / \${limit:.2f} ({pct:.1f}%)')
+                  if pct >= 90:
+                      print(f'::error::Budget is at {pct:.1f}% — immediate action required')
+                  elif pct >= 80:
+                      print(f'::warning::Budget is at {pct:.1f}% — review spending')
+          "

--- a/.github/workflows/load-balancer-health.yml
+++ b/.github/workflows/load-balancer-health.yml
@@ -1,0 +1,54 @@
+name: Load Balancer Health Check
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    name: Check Load Balancer Health
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Check ALB target group health
+        run: bash scripts/check-load-balancer.sh
+
+      - name: Verify healthy target count
+        run: |
+          TG_ARN=$(aws elbv2 describe-target-groups \
+            --names "${{ vars.ENVIRONMENT || 'prod' }}-scavenger-tg" \
+            --query 'TargetGroups[0].TargetGroupArn' \
+            --output text)
+
+          HEALTHY=$(aws elbv2 describe-target-health \
+            --target-group-arn "$TG_ARN" \
+            --query 'TargetHealthDescriptions[?TargetHealth.State==`healthy`] | length(@)' \
+            --output text)
+
+          echo "Healthy targets: $HEALTHY"
+          if [ "$HEALTHY" -lt 1 ]; then
+            echo "::error::No healthy targets in load balancer"
+            exit 1
+          fi
+
+      - name: Check ALB response time alarm
+        run: |
+          STATE=$(aws cloudwatch describe-alarms \
+            --alarm-names "${{ vars.ENVIRONMENT || 'prod' }}-alb-response-time" \
+            --query 'MetricAlarms[0].StateValue' \
+            --output text 2>/dev/null || echo "MISSING")
+
+          echo "ALB response time alarm state: $STATE"
+          if [ "$STATE" = "ALARM" ]; then
+            echo "::warning::ALB response time alarm is in ALARM state"
+          fi

--- a/config/vault-rotation-policy.hcl
+++ b/config/vault-rotation-policy.hcl
@@ -1,0 +1,64 @@
+# Secret rotation policies for Scavenger
+
+# Rotate all API secrets every 30 days
+path "secret/data/scavenger/api" {
+  capabilities = ["read", "create", "update"]
+
+  min_writable_secret_id_entries = 1
+
+  metadata {
+    max_versions = 5
+    delete_version_after = "720h"  # 30 days
+    custom_metadata = {
+      rotation_interval = "720h"
+      auto_rotate = "true"
+    }
+  }
+}
+
+# Rotate Stellar signing key every 90 days
+path "secret/data/scavenger/stellar" {
+  capabilities = ["read", "create", "update"]
+
+  metadata {
+    max_versions = 3
+    delete_version_after = "2160h"  # 90 days
+    custom_metadata = {
+      rotation_interval = "2160h"
+      auto_rotate = "true"
+    }
+  }
+}
+
+# Database credentials — rotated every 7 days
+path "secret/data/scavenger/database" {
+  capabilities = ["read", "create", "update"]
+
+  metadata {
+    max_versions = 5
+    delete_version_after = "168h"  # 7 days
+    custom_metadata = {
+      rotation_interval = "168h"
+      auto_rotate = "true"
+    }
+  }
+}
+
+# Read-only access for applications
+path "secret/data/scavenger/*" {
+  capabilities = ["read", "list"]
+}
+
+path "secret/metadata/scavenger/*" {
+  capabilities = ["list", "read"]
+}
+
+# Allow token self-renewal
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+# Allow checking own token
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}

--- a/docs/BACKUP_STRATEGY.md
+++ b/docs/BACKUP_STRATEGY.md
@@ -1,0 +1,82 @@
+# Backup Strategy
+
+## Overview
+
+Scavenger uses automated daily backups with verification to protect against data loss. Backups are encrypted, stored in S3, and tested weekly via full restore.
+
+## Backup Schedule
+
+| Backup type | Schedule | Retention |
+|---|---|---|
+| Full database dump | Daily at 02:00 UTC | 30 days |
+| RDS automated snapshots | Daily (AWS managed) | 7 days |
+| Restore verification | Daily (after backup) | — |
+| Full restore test | Weekly (Sunday 02:00 UTC) | — |
+
+## Backup Storage
+
+- **Bucket**: `scavenger-backups-<env>-<account_id>` (S3)
+- **Encryption**: AES-256 server-side encryption
+- **Versioning**: Enabled
+- **Public access**: Blocked
+
+## Backup Process
+
+1. `scripts/backup-database.sh` runs pg_dump, gzip-compresses the output, verifies integrity, then uploads to S3.
+2. The GitHub Actions workflow `.github/workflows/backup.yml` runs it on schedule and publishes a `BackupSuccess` metric to CloudWatch.
+3. `scripts/verify-backup-restore.sh` downloads the latest backup to a temporary database and counts rows to confirm data integrity.
+
+## Recovery Procedures
+
+### Standard restore (from latest backup)
+
+```bash
+# Download latest backup
+LATEST=$(aws s3 ls s3://scavenger-backups-prod/database/ --recursive | sort | tail -n1 | awk '{print $4}')
+aws s3 cp "s3://scavenger-backups-prod/$LATEST" /tmp/restore.sql.gz
+
+# Restore to target database
+gunzip -c /tmp/restore.sql.gz | psql -h "$DB_HOST" -U postgres -d scavenger
+```
+
+### Point-in-time recovery (RDS)
+
+```bash
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier prod-scavenger-db \
+  --target-db-instance-identifier prod-scavenger-db-restored \
+  --restore-time "2026-01-15T03:00:00Z"
+```
+
+### Restore to specific backup
+
+```bash
+# List available backups
+aws s3 ls s3://scavenger-backups-prod/database/ --recursive
+
+# Pick a timestamp and restore
+aws s3 cp "s3://scavenger-backups-prod/database/20260115_020000/db_backup_20260115_020000.sql.gz" /tmp/restore.sql.gz
+gunzip -c /tmp/restore.sql.gz | psql -h "$DB_HOST" -U postgres -d scavenger
+```
+
+## Backup Monitoring
+
+CloudWatch alarms trigger if:
+- No successful backup in 24 hours (`scavenger-backup-failure-<env>`)
+- Backup verification failed (`scavenger-backup-verify-failure-<env>`)
+
+The `scavenger-backups-<env>` CloudWatch dashboard shows backup success rate and alarm status.
+
+## Terraform
+
+The `terraform/modules/backup` module provisions the S3 bucket, lifecycle rules, and CloudWatch alarms.
+
+```hcl
+module "backup" {
+  source         = "./modules/backup"
+  environment    = var.environment
+  account_id     = data.aws_caller_identity.current.account_id
+  retention_days = 30
+  alarm_sns_arns = [var.alerts_sns_arn]
+}
+```

--- a/docs/SECRET_MANAGEMENT.md
+++ b/docs/SECRET_MANAGEMENT.md
@@ -44,26 +44,63 @@ vault write auth/kubernetes/config \
 
 ## Secret Rotation
 
-Secrets are automatically rotated every 30 days. Configure rotation policies:
+Rotation intervals per secret type:
+
+| Secret | Interval | Policy file |
+|---|---|---|
+| API keys / Firebase | 30 days | `config/vault-rotation-policy.hcl` |
+| Stellar signing key | 90 days | `config/vault-rotation-policy.hcl` |
+| Database credentials | 7 days | `config/vault-rotation-policy.hcl` |
+
+Apply rotation policy:
 
 ```bash
-vault write secret/config/rotation \
-  auto_rotate=true \
-  rotate_interval=2592000  # 30 days in seconds
+vault policy write scavenger-rotation config/vault-rotation-policy.hcl
 ```
+
+Check which secrets need rotation:
+
+```bash
+VAULT_TOKEN=<token> ./scripts/rotate-secrets.sh
+```
+
+The script exits with code `2` if any secret exceeds its rotation window.
+
+## Secret Injection (Kubernetes)
+
+Vault Agent is configured as a sidecar injector. Apply the manifest:
+
+```bash
+kubectl apply -f k8s/vault-agent-injector.yaml
+```
+
+Secrets are mounted at `/vault/secrets/` inside the pod and sourced into the environment at startup. The injector uses pod annotations — see `k8s/vault-agent-injector.yaml` for the full annotation set.
+
+The agent config is in `config/vault-config.hcl`. Templates that render `.env`-style files live in `config/vault-templates/`.
 
 ## Access Control
 
-Secrets are accessed via Kubernetes service account authentication.
+Secrets are accessed via Kubernetes service account authentication. The `scavenger` service account is bound to the `scavenger-app` Vault role, which grants read-only access to `secret/data/scavenger/*`.
 
 ## Audit Logging
 
 All secret access is logged to `/vault/logs/audit.log`.
 
+Enable during setup:
+
+```bash
+vault audit enable file file_path=/vault/logs/audit.log
+```
+
 ## Local Development
 
-For local development, use environment variables or `.env` file.
+For local development, use environment variables or a `.env` file. Do not run `scripts/init-vault.sh` against production Vault.
 
 ## Emergency Access
 
-In case of emergency, use break-glass procedure with root token.
+In an emergency, use the break-glass procedure with the root token. The root token must be regenerated after use:
+
+```bash
+vault token revoke <root-token>
+vault operator generate-root
+```

--- a/k8s/vault-agent-injector.yaml
+++ b/k8s/vault-agent-injector.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scavenger
+  namespace: default
+  annotations:
+    vault.hashicorp.com/agent-inject: "true"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scavenger-backend
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: scavenger-backend
+  template:
+    metadata:
+      labels:
+        app: scavenger-backend
+      annotations:
+        # Enable vault agent injection
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "scavenger-app"
+        vault.hashicorp.com/agent-inject-status: "update"
+
+        # Inject API secrets as .env file
+        vault.hashicorp.com/agent-inject-secret-api.env: "secret/data/scavenger/api"
+        vault.hashicorp.com/agent-inject-template-api.env: |
+          {{- with secret "secret/data/scavenger/api" -}}
+          CONTRACT_ID={{ .Data.data.contract_id }}
+          NETWORK={{ .Data.data.network }}
+          RPC_URL={{ .Data.data.rpc_url }}
+          FIREBASE_API_KEY={{ .Data.data.firebase_api_key }}
+          FIREBASE_PROJECT_ID={{ .Data.data.firebase_project_id }}
+          {{- end }}
+
+        # Inject Stellar secrets
+        vault.hashicorp.com/agent-inject-secret-stellar.env: "secret/data/scavenger/stellar"
+        vault.hashicorp.com/agent-inject-template-stellar.env: |
+          {{- with secret "secret/data/scavenger/stellar" -}}
+          STELLAR_SECRET_KEY={{ .Data.data.secret_key }}
+          STELLAR_NETWORK={{ .Data.data.network }}
+          {{- end }}
+
+        # Inject database credentials
+        vault.hashicorp.com/agent-inject-secret-db.env: "secret/data/scavenger/database"
+        vault.hashicorp.com/agent-inject-template-db.env: |
+          {{- with secret "secret/data/scavenger/database" -}}
+          DB_HOST={{ .Data.data.host }}
+          DB_NAME={{ .Data.data.name }}
+          DB_USERNAME={{ .Data.data.username }}
+          DB_PASSWORD={{ .Data.data.password }}
+          {{- end }}
+
+        # Agent configuration
+        vault.hashicorp.com/agent-pre-populate-only: "false"
+        vault.hashicorp.com/agent-cache-enable: "true"
+        vault.hashicorp.com/agent-cache-use-auto-auth-token: "force"
+    spec:
+      serviceAccountName: scavenger
+      containers:
+        - name: scavenger-backend
+          image: scavenger-backend:latest
+          ports:
+            - containerPort: 8080
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -a
+              source /vault/secrets/api.env
+              source /vault/secrets/stellar.env
+              source /vault/secrets/db.env
+              set +a
+              exec ./scavenger-backend
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-agent-config
+  namespace: default
+data:
+  config.hcl: |
+    vault {
+      address = "http://vault.vault.svc.cluster.local:8200"
+    }
+
+    auto_auth {
+      method {
+        type = "kubernetes"
+        config = {
+          role = "scavenger-app"
+        }
+      }
+
+      sink {
+        type = "file"
+        config = {
+          path = "/tmp/vault-token"
+          mode = 0640
+        }
+      }
+    }
+
+    cache {
+      use_auto_auth_token = true
+    }
+
+    listener "tcp" {
+      address     = "127.0.0.1:8100"
+      tls_disable = true
+    }

--- a/scripts/cost-analysis.sh
+++ b/scripts/cost-analysis.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Analyze current AWS costs for the Scavenger project
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ENVIRONMENT="${ENVIRONMENT:-prod}"
+DAYS="${COST_ANALYSIS_DAYS:-30}"
+
+END_DATE=$(date +%Y-%m-%d)
+START_DATE=$(date -d "-${DAYS} days" +%Y-%m-%d 2>/dev/null || date -v-"${DAYS}"d +%Y-%m-%d)
+
+echo "======================================"
+echo " Scavenger Cost Analysis"
+echo " Period: $START_DATE → $END_DATE"
+echo " Environment: $ENVIRONMENT"
+echo "======================================"
+echo ""
+
+# Total cost for the project tag
+echo "--- Total Cost (Project=scavenger) ---"
+aws ce get-cost-and-usage \
+  --time-period "Start=$START_DATE,End=$END_DATE" \
+  --granularity MONTHLY \
+  --filter '{"Tags":{"Key":"Project","Values":["scavenger"]}}' \
+  --metrics "UnblendedCost" \
+  --query 'ResultsByTime[*].{Period:TimePeriod.Start,Cost:Total.UnblendedCost.Amount,Unit:Total.UnblendedCost.Unit}' \
+  --output table \
+  --region "$REGION"
+
+echo ""
+echo "--- Cost Breakdown by Service ---"
+aws ce get-cost-and-usage \
+  --time-period "Start=$START_DATE,End=$END_DATE" \
+  --granularity MONTHLY \
+  --filter '{"Tags":{"Key":"Project","Values":["scavenger"]}}' \
+  --metrics "UnblendedCost" \
+  --group-by '[{"Type":"DIMENSION","Key":"SERVICE"}]' \
+  --query 'ResultsByTime[0].Groups[?Metrics.UnblendedCost.Amount>`0.01`] | sort_by(@, &Metrics.UnblendedCost.Amount) | reverse(@) | [*].{Service:Keys[0],Cost:Metrics.UnblendedCost.Amount}' \
+  --output table \
+  --region "$REGION"
+
+echo ""
+echo "--- ECS Spot vs On-Demand Split ---"
+aws ce get-cost-and-usage \
+  --time-period "Start=$START_DATE,End=$END_DATE" \
+  --granularity MONTHLY \
+  --filter '{"And":[{"Tags":{"Key":"Project","Values":["scavenger"]}},{"Dimensions":{"Key":"SERVICE","Values":["Amazon Elastic Container Service"]}}]}' \
+  --metrics "UnblendedCost" \
+  --group-by '[{"Type":"DIMENSION","Key":"PURCHASE_TYPE"}]' \
+  --query 'ResultsByTime[0].Groups[*].{PurchaseType:Keys[0],Cost:Metrics.UnblendedCost.Amount}' \
+  --output table \
+  --region "$REGION"
+
+echo ""
+echo "--- RDS Cost ---"
+aws ce get-cost-and-usage \
+  --time-period "Start=$START_DATE,End=$END_DATE" \
+  --granularity MONTHLY \
+  --filter '{"And":[{"Tags":{"Key":"Project","Values":["scavenger"]}},{"Dimensions":{"Key":"SERVICE","Values":["Amazon Relational Database Service"]}}]}' \
+  --metrics "UnblendedCost" \
+  --query 'ResultsByTime[*].{Period:TimePeriod.Start,Cost:Total.UnblendedCost.Amount}' \
+  --output table \
+  --region "$REGION"
+
+echo ""
+echo "--- Budget Status ---"
+aws budgets describe-budgets \
+  --account-id "$(aws sts get-caller-identity --query Account --output text)" \
+  --query 'Budgets[?contains(BudgetName,`scavenger`)].{Name:BudgetName,Limit:BudgetLimit.Amount,Actual:CalculatedSpend.ActualSpend.Amount,Forecasted:CalculatedSpend.ForecastedSpend.Amount}' \
+  --output table \
+  --region "$REGION"
+
+echo ""
+echo "Cost analysis complete."

--- a/scripts/rotate-secrets.sh
+++ b/scripts/rotate-secrets.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Rotate secrets in HashiCorp Vault
+
+set -euo pipefail
+
+VAULT_ADDR="${VAULT_ADDR:-http://localhost:8200}"
+VAULT_TOKEN="${VAULT_TOKEN:?VAULT_TOKEN must be set}"
+SECRET_PATH="${SECRET_PATH:-secret/scavenger}"
+
+rotate_secret() {
+  local path="$1"
+  local key="$2"
+  local new_value="$3"
+
+  echo "Rotating $path/$key..."
+  vault kv patch "$path" "$key=$new_value"
+  echo "  rotated $key"
+}
+
+check_rotation_needed() {
+  local path="$1"
+  local threshold_days="${2:-30}"
+
+  metadata=$(vault kv metadata get -format=json "$path" 2>/dev/null || echo '{}')
+  created=$(echo "$metadata" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('data',{}).get('updated_time',''))" 2>/dev/null || echo "")
+
+  if [ -z "$created" ]; then
+    echo "new"
+    return
+  fi
+
+  age_days=$(( ( $(date +%s) - $(date -d "$created" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "${created%%.*}" +%s 2>/dev/null || echo 0) ) / 86400 ))
+
+  if [ "$age_days" -ge "$threshold_days" ]; then
+    echo "stale ($age_days days)"
+  else
+    echo "fresh ($age_days days)"
+  fi
+}
+
+echo "Checking secret ages..."
+
+api_status=$(check_rotation_needed "secret/scavenger/api" 30)
+stellar_status=$(check_rotation_needed "secret/scavenger/stellar" 90)
+db_status=$(check_rotation_needed "secret/scavenger/database" 7)
+
+echo "  API secrets:      $api_status"
+echo "  Stellar secrets:  $stellar_status"
+echo "  DB credentials:   $db_status"
+
+if [[ "$api_status" == stale* ]]; then
+  echo "API secrets require rotation — update via Vault UI or CI/CD pipeline"
+  exit 2
+fi
+
+if [[ "$stellar_status" == stale* ]]; then
+  echo "Stellar secrets require rotation — update via Vault UI or CI/CD pipeline"
+  exit 2
+fi
+
+if [[ "$db_status" == stale* ]]; then
+  echo "Database credentials require rotation — update via Vault UI or CI/CD pipeline"
+  exit 2
+fi
+
+echo "All secrets are within rotation window."

--- a/terraform/modules/backup/main.tf
+++ b/terraform/modules/backup/main.tf
@@ -1,0 +1,121 @@
+resource "aws_s3_bucket" "backups" {
+  bucket = "scavenger-backups-${var.environment}-${var.account_id}"
+
+  tags = {
+    Name = "scavenger-backups-${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    id     = "backup-retention"
+    status = "Enabled"
+
+    expiration {
+      days = var.retention_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudwatch_metric_alarm" "backup_failure" {
+  alarm_name          = "scavenger-backup-failure-${var.environment}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BackupSuccess"
+  namespace           = "Scavenger/Backups"
+  period              = "86400"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "breaching"
+  alarm_description   = "Triggers if no successful backup in 24 hours"
+  alarm_actions       = var.alarm_sns_arns
+
+  tags = {
+    Name = "scavenger-backup-failure-${var.environment}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "backup_verification_failure" {
+  alarm_name          = "scavenger-backup-verify-failure-${var.environment}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BackupVerificationSuccess"
+  namespace           = "Scavenger/Backups"
+  period              = "86400"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "breaching"
+  alarm_description   = "Triggers if backup verification failed in last 24 hours"
+  alarm_actions       = var.alarm_sns_arns
+
+  tags = {
+    Name = "scavenger-backup-verify-failure-${var.environment}"
+  }
+}
+
+resource "aws_cloudwatch_dashboard" "backups" {
+  dashboard_name = "scavenger-backups-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Backup Success Rate"
+          period = 86400
+          stat   = "Sum"
+          metrics = [
+            ["Scavenger/Backups", "BackupSuccess"],
+            ["Scavenger/Backups", "BackupVerificationSuccess"]
+          ]
+        }
+      },
+      {
+        type   = "alarm"
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Backup Alarms"
+          alarms = [
+            aws_cloudwatch_metric_alarm.backup_failure.arn,
+            aws_cloudwatch_metric_alarm.backup_verification_failure.arn
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/backup/outputs.tf
+++ b/terraform/modules/backup/outputs.tf
@@ -1,0 +1,11 @@
+output "bucket_name" {
+  value = aws_s3_bucket.backups.bucket
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.backups.arn
+}
+
+output "backup_failure_alarm_arn" {
+  value = aws_cloudwatch_metric_alarm.backup_failure.arn
+}

--- a/terraform/modules/backup/variables.tf
+++ b/terraform/modules/backup/variables.tf
@@ -1,0 +1,20 @@
+variable "environment" {
+  type = string
+}
+
+variable "account_id" {
+  type        = string
+  description = "AWS account ID used to create a globally unique S3 bucket name"
+}
+
+variable "retention_days" {
+  type        = number
+  default     = 30
+  description = "Days to retain backups in S3"
+}
+
+variable "alarm_sns_arns" {
+  type        = list(string)
+  default     = []
+  description = "SNS topic ARNs to notify on backup alarm"
+}

--- a/terraform/modules/cost_optimization/main.tf
+++ b/terraform/modules/cost_optimization/main.tf
@@ -180,3 +180,68 @@ resource "aws_cloudwatch_event_target" "rds_start" {
     InstanceId = [var.rds_instance_id]
   })
 }
+
+# ── Cost anomaly detection ────────────────────────────────────────────────────
+
+resource "aws_ce_anomaly_monitor" "scavenger" {
+  name              = "scavenger-anomaly-monitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+}
+
+resource "aws_ce_anomaly_subscription" "scavenger" {
+  name      = "scavenger-anomaly-alerts"
+  frequency = "DAILY"
+
+  monitor_arn_list = [aws_ce_anomaly_monitor.scavenger.arn]
+
+  subscriber {
+    type    = "EMAIL"
+    address = var.budget_alert_emails[0]
+  }
+
+  threshold_expression {
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_PERCENTAGE"
+      values        = ["10"]
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+    }
+  }
+}
+
+# ── Cost monitoring dashboard ─────────────────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "cost" {
+  dashboard_name = "scavenger-cost-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ECS CPU Utilization"
+          period = 300
+          stat   = "Average"
+          metrics = [
+            ["AWS/ECS", "CPUUtilization", "ClusterName", var.ecs_cluster_name]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ECS Memory Utilization"
+          period = 300
+          stat   = "Average"
+          metrics = [
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.ecs_cluster_name]
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/cost_optimization/outputs.tf
+++ b/terraform/modules/cost_optimization/outputs.tf
@@ -5,3 +5,11 @@ output "spot_capacity_provider_name" {
 output "budget_name" {
   value = aws_budgets_budget.monthly.name
 }
+
+output "anomaly_monitor_arn" {
+  value = aws_ce_anomaly_monitor.scavenger.arn
+}
+
+output "cost_dashboard_name" {
+  value = aws_cloudwatch_dashboard.cost.dashboard_name
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -157,14 +157,49 @@ resource "aws_lb_target_group" "main" {
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    timeout             = 3
+    timeout             = 5
     interval            = 30
     path                = "/health"
     matcher             = "200"
+    protocol            = "HTTP"
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
   }
 
   tags = {
     Name = "${var.environment}-scavenger-tg"
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${var.environment}-scavenger-api-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    path                = "/api/health"
+    matcher             = "200-299"
+    protocol            = "HTTP"
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
+  }
+
+  tags = {
+    Name = "${var.environment}-scavenger-api-tg"
   }
 }
 
@@ -236,6 +271,38 @@ resource "aws_lb_listener" "https" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+resource "aws_lb_listener_rule" "api" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "health" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/health", "/health/*"]
+    }
   }
 }
 

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -5,3 +5,19 @@ output "cluster_name" {
 output "target_group_arn" {
   value = aws_lb_target_group.main.arn
 }
+
+output "api_target_group_arn" {
+  value = aws_lb_target_group.api.arn
+}
+
+output "alb_dns_name" {
+  value = aws_lb.main.dns_name
+}
+
+output "alb_arn" {
+  value = aws_lb.main.arn
+}
+
+output "service_name" {
+  value = aws_ecs_service.main.name
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -41,3 +41,8 @@ variable "db_host" {
 variable "db_name" {
   type = string
 }
+
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for HTTPS listener"
+}


### PR DESCRIPTION
## Summary

This PR resolves four CI/CD infrastructure tasks: load balancing setup, automated backup and recovery, HashiCorp Vault secret management, and cost optimization.

---

## #614 — Setup load balancing

**`terraform/modules/ecs/`**
- Added `stickiness` block (`lb_cookie`, 1-day duration) to the ECS target group for session persistence
- Added a dedicated `aws_lb_target_group.api` for `/api/*` routes with enhanced health checks (`/api/health`, 3 unhealthy threshold)
- Added `aws_lb_listener_rule.api` (priority 100) — routes `/api/*` → API target group
- Added `aws_lb_listener_rule.health` (priority 10) — routes `/health` and `/health/*` → main target group
- Added missing `certificate_arn` variable declaration to `variables.tf`
- Extended `outputs.tf` with `api_target_group_arn`, `alb_dns_name`, `alb_arn`, `service_name`

**`.github/workflows/load-balancer-health.yml`** — scheduled every 5 minutes; checks healthy target count and ALB response-time alarm state via AWS CLI

---

## #615 — Implement backup and recovery

**`.github/workflows/backup.yml`**
- Daily backup job at 02:00 UTC running `scripts/backup-database.sh`, publishes `BackupSuccess` metric to CloudWatch
- Verification job runs after each backup using `scripts/verify-backup-restore.sh`, publishes `BackupVerificationSuccess` metric
- Weekly full restore test (Sundays); auto-opens a GitHub issue labeled `bug,backup` on failure

**`terraform/modules/backup/`** _(new module)_
- S3 bucket with AES-256 encryption, versioning, public-access block, and 30-day lifecycle expiration
- CloudWatch alarms: `BackupSuccess < 1` and `BackupVerificationSuccess < 1` over 24 hours, both `treat_missing_data = breaching`
- CloudWatch dashboard showing backup success rate and alarm status

**`docs/BACKUP_STRATEGY.md`** — backup schedule table, S3 storage config, step-by-step recovery procedures, point-in-time RDS restore commands, and Terraform usage example

---

## #616 — Setup secret management

**`config/vault-rotation-policy.hcl`** — Vault policy defining rotation intervals (API keys 30 days, Stellar signing key 90 days, DB credentials 7 days), max version limits, and read-only app access paths

**`k8s/vault-agent-injector.yaml`**
- `ServiceAccount` annotated for Vault injection
- `Deployment` with full Vault Agent sidecar annotation set: injects API, Stellar, and DB secrets as `/vault/secrets/*.env` files
- `ConfigMap` with Vault Agent config (Kubernetes auth, token sink, TCP cache listener)

**`scripts/rotate-secrets.sh`** — checks metadata age of each secret path against its rotation threshold; exits with code `2` if any secret is stale

**`docs/SECRET_MANAGEMENT.md`** — added rotation interval table, `vault policy write` command, injection setup instructions, `kubectl apply` usage, and emergency root-token revocation procedure

---

## #617 — Implement cost optimization

**`scripts/cost-analysis.sh`** — queries AWS Cost Explorer for: total project cost, per-service breakdown (sorted by spend), ECS Spot vs On-Demand split, RDS cost, and budget utilization — all scoped to the `Project=scavenger` tag

**`.github/workflows/cost-report.yml`**
- Monthly scheduled run (1st of each month at 08:00 UTC), also dispatchable with a configurable `days` input
- Uploads cost report as a 90-day artifact
- Checks Cost Anomaly Monitor for anomalies with score > 0.5 in the past 7 days
- Second job checks budget utilization and emits `::warning` at 80% and `::error` at 90%

**`terraform/modules/cost_optimization/`**
- Added `aws_ce_anomaly_monitor` (dimensional, by SERVICE) and `aws_ce_anomaly_subscription` (daily email at ≥10% impact percentage)
- Added `aws_cloudwatch_dashboard.cost` with ECS CPU and memory utilization widgets
- Extended `outputs.tf` with `anomaly_monitor_arn` and `cost_dashboard_name`

---

Closes #614
Closes #615
Closes #616
Closes #617