### PR TITLE
feat: #734 Set up comprehensive Kubernetes deployment manifests

### DIFF
--- a/docs/K8S_DEPLOYMENT_GUIDE.md
+++ b/docs/K8S_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,178 @@
+# Kubernetes Deployment Guide
+
+## Overview
+
+This guide covers deploying Scavenger on a Kubernetes cluster with complete manifests for production-grade setup.
+
+## Prerequisites
+
+- Kubernetes 1.24+ cluster
+- `kubectl` configured to access your cluster
+- ECR or Docker registry with images pushed
+- AWS EBS (for persistent volumes)
+
+## Deployment Structure
+
+### Manifests Included
+
+1. **complete-deployment.yml**: Main deployment with:
+   - Namespace creation
+   - Backend deployment (3 replicas)
+   - Service definition
+   - Horizontal Pod Autoscaler
+   - Pod Disruption Budget
+   - ConfigMaps and Secrets
+
+2. **ingress-complete.yml**: Ingress and frontend:
+   - Ingress configuration with TLS
+   - Frontend deployment
+   - Service routing
+
+3. **pvc-storage.yml**: Storage configuration:
+   - StorageClass definition
+   - PersistentVolumes
+   - PersistentVolumeClaims
+
+4. **rbac-complete.yml**: Access control:
+   - ServiceAccount
+   - ClusterRoles and Roles
+   - RoleBindings
+
+## Quick Start
+
+### 1. Prepare Images
+
+```bash
+# Build and push Docker images
+docker build -t YOUR_ECR_URI/scavenger-backend:latest backend/
+docker push YOUR_ECR_URI/scavenger-backend:latest
+```
+
+### 2. Update Manifests
+
+Replace `YOUR_ECR_URI` in all YAML files with your actual ECR URI.
+
+### 3. Deploy to Cluster
+
+```bash
+# Create namespace and deploy
+kubectl apply -f k8s/complete-deployment.yml
+kubectl apply -f k8s/pvc-storage.yml
+kubectl apply -f k8s/rbac-complete.yml
+kubectl apply -f k8s/ingress-complete.yml
+```
+
+### 4. Verify Deployment
+
+```bash
+# Run deployment tests
+bash k8s/test-k8s-deployment.sh
+
+# Check pod status
+kubectl get pods -n scavenger
+
+# Check service endpoints
+kubectl get svc -n scavenger
+
+# View logs
+kubectl logs -n scavenger deployment/scavenger-backend
+```
+
+## Configuration
+
+### Environment Variables
+
+Set in complete-deployment.yml:
+- `RUST_LOG`: Logging level (default: info)
+- `DATABASE_URL`: PostgreSQL connection string
+- `STELLAR_NETWORK`: Network (testnet/mainnet)
+
+### Resource Limits
+
+Backend:
+- CPU: 250m request / 500m limit
+- Memory: 512Mi request / 1Gi limit
+
+### Health Checks
+
+- Liveness probe: /health (30s delay, 10s period)
+- Readiness probe: /ready (10s delay, 5s period)
+
+## Rollout Strategy
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+```
+
+## Scaling
+
+### Manual Scaling
+
+```bash
+kubectl scale deployment scavenger-backend --replicas=5 -n scavenger
+```
+
+### Autoscaling
+
+HPA automatically scales between 3-10 replicas based on:
+- CPU utilization: 70%
+- Memory utilization: 80%
+
+## Monitoring & Logs
+
+### View logs
+```bash
+kubectl logs -f deployment/scavenger-backend -n scavenger
+```
+
+### Port forwarding
+```bash
+kubectl port-forward svc/scavenger-backend 8080:80 -n scavenger
+```
+
+### Pod disruption budget
+Ensures minimum 2 replicas are always available during maintenance.
+
+## Troubleshooting
+
+### Pods not starting
+
+```bash
+kubectl describe pod POD_NAME -n scavenger
+kubectl logs POD_NAME -n scavenger
+```
+
+### Service not accessible
+
+```bash
+kubectl get endpoints scavenger-backend -n scavenger
+kubectl get svc scavenger-backend -n scavenger
+```
+
+### Storage issues
+
+```bash
+kubectl get pvc -n scavenger
+kubectl get pv
+```
+
+## Best Practices
+
+1. **Always use namespaces** for isolation
+2. **Set resource limits** to prevent resource exhaustion
+3. **Use health checks** for reliability
+4. **Enable HPA** for automatic scaling
+5. **Use PodDisruptionBudgets** for high availability
+6. **Implement RBAC** for security
+7. **Regular backups** of persistent data
+
+## Cleanup
+
+```bash
+# Delete all resources in namespace
+kubectl delete namespace scavenger
+```

--- a/k8s/complete-deployment.yml
+++ b/k8s/complete-deployment.yml
@@ -1,0 +1,166 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scavenger
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scavenger-backend
+  namespace: scavenger
+  labels:
+    app: scavenger-backend
+    version: v1
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: scavenger-backend
+  template:
+    metadata:
+      labels:
+        app: scavenger-backend
+        version: v1
+    spec:
+      serviceAccountName: scavenger
+      containers:
+      - name: backend
+        image: YOUR_ECR_URI/scavenger-backend:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: RUST_LOG
+          value: "info"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: scavenger-secrets
+              key: database-url
+        - name: STELLAR_NETWORK
+          value: "testnet"
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 2
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+        - name: logs
+          mountPath: /var/log/scavenger
+      volumes:
+      - name: config
+        configMap:
+          name: scavenger-config
+      - name: logs
+        emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scavenger-backend
+  namespace: scavenger
+  labels:
+    app: scavenger-backend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: scavenger-backend
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scavenger-backend-hpa
+  namespace: scavenger
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: scavenger-backend
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: scavenger-backend-pdb
+  namespace: scavenger
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: scavenger-backend
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scavenger-config
+  namespace: scavenger
+data:
+  config.toml: |
+    [server]
+    host = "0.0.0.0"
+    port = 8080
+    
+    [logging]
+    level = "info"
+    format = "json"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scavenger-secrets
+  namespace: scavenger
+type: Opaque
+stringData:
+  database-url: "postgresql://user:password@postgres:5432/scavenger"

--- a/k8s/ingress-complete.yml
+++ b/k8s/ingress-complete.yml
@@ -1,0 +1,90 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: scavenger-ingress
+  namespace: scavenger
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rate-limit: "100"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - scavenger.example.com
+    secretName: scavenger-tls
+  rules:
+  - host: scavenger.example.com
+    http:
+      paths:
+      - path: /api
+        pathType: Prefix
+        backend:
+          service:
+            name: scavenger-backend
+            port:
+              number: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: scavenger-frontend
+            port:
+              number: 3000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scavenger-frontend
+  namespace: scavenger
+  labels:
+    app: scavenger-frontend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    targetPort: 3000
+    protocol: TCP
+  selector:
+    app: scavenger-frontend
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scavenger-frontend
+  namespace: scavenger
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: scavenger-frontend
+  template:
+    metadata:
+      labels:
+        app: scavenger-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: YOUR_ECR_URI/scavenger-frontend:latest
+        ports:
+        - containerPort: 3000
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/k8s/pvc-storage.yml
+++ b/k8s/pvc-storage.yml
@@ -1,0 +1,66 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: scavenger-storage
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  iops: "3000"
+  throughput: "125"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: scavenger-data-pv
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: scavenger-storage
+  awsElasticBlockStore:
+    volumeID: vol-xxxxx
+    fsType: ext4
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scavenger-data-pvc
+  namespace: scavenger
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: scavenger-storage
+  resources:
+    requests:
+      storage: 50Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scavenger-cache-pvc
+  namespace: scavenger
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: scavenger-storage
+  resources:
+    requests:
+      storage: 20Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scavenger-logs-pvc
+  namespace: scavenger
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: scavenger-storage
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/rbac-complete.yml
+++ b/k8s/rbac-complete.yml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scavenger
+  namespace: scavenger
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scavenger-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scavenger-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scavenger-role
+subjects:
+- kind: ServiceAccount
+  name: scavenger
+  namespace: scavenger
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scavenger-pod-role
+  namespace: scavenger
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scavenger-pod-binding
+  namespace: scavenger
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scavenger-pod-role
+subjects:
+- kind: ServiceAccount
+  name: scavenger
+  namespace: scavenger

--- a/k8s/test-k8s-deployment.sh
+++ b/k8s/test-k8s-deployment.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Kubernetes deployment validation and testing script
+
+set -e
+
+NAMESPACE="scavenger"
+CLUSTER_NAME="scavenger-cluster"
+
+echo "=== Kubernetes Deployment Tests ==="
+
+# Check if kubectl is installed
+if ! command -v kubectl &> /dev/null; then
+    echo "ERROR: kubectl is not installed"
+    exit 1
+fi
+
+# Test 1: Check cluster connection
+echo "Test 1: Checking cluster connection..."
+kubectl cluster-info &> /dev/null && echo "✓ Cluster is accessible" || echo "✗ Cluster is not accessible"
+
+# Test 2: Verify namespace exists
+echo "Test 2: Creating/verifying namespace..."
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f - && echo "✓ Namespace verified" || echo "✗ Namespace creation failed"
+
+# Test 3: Check RBAC configuration
+echo "Test 3: Checking RBAC configuration..."
+kubectl get serviceaccount scavenger -n $NAMESPACE &> /dev/null && echo "✓ ServiceAccount exists" || echo "✗ ServiceAccount missing"
+
+# Test 4: Verify persistent volumes
+echo "Test 4: Checking persistent volumes..."
+kubectl get pvc -n $NAMESPACE &> /dev/null && echo "✓ PVCs configured" || echo "✗ PVCs not found"
+
+# Test 5: Check deployment readiness
+echo "Test 5: Checking deployment status..."
+kubectl get deployment scavenger-backend -n $NAMESPACE &> /dev/null && echo "✓ Backend deployment exists" || echo "✗ Backend deployment not found"
+
+# Test 6: Verify service endpoints
+echo "Test 6: Checking service endpoints..."
+ENDPOINTS=$(kubectl get endpoints scavenger-backend -n $NAMESPACE -o jsonpath='{.subsets[0].addresses[*].ip}' 2>/dev/null)
+if [ -n "$ENDPOINTS" ]; then
+    echo "✓ Service endpoints active: $ENDPOINTS"
+else
+    echo "⚠ Service has no active endpoints yet"
+fi
+
+# Test 7: Check ingress configuration
+echo "Test 7: Verifying ingress configuration..."
+kubectl get ingress scavenger-ingress -n $NAMESPACE &> /dev/null && echo "✓ Ingress configured" || echo "✗ Ingress not found"
+
+# Test 8: Validate resource limits
+echo "Test 8: Validating resource limits..."
+kubectl get deployment scavenger-backend -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].resources}' | jq . && echo "✓ Resource limits configured" || echo "✗ Resource limits not set"
+
+# Test 9: Check health probes
+echo "Test 9: Verifying health probes..."
+PROBES=$(kubectl get deployment scavenger-backend -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].livenessProbe}' 2>/dev/null)
+if [ -n "$PROBES" ]; then
+    echo "✓ Health probes configured"
+else
+    echo "✗ Health probes not found"
+fi
+
+# Test 10: Validate HPA
+echo "Test 10: Checking Horizontal Pod Autoscaler..."
+kubectl get hpa scavenger-backend-hpa -n $NAMESPACE &> /dev/null && echo "✓ HPA configured" || echo "✗ HPA not found"
+
+echo ""
+echo "=== Deployment Test Summary ==="
+echo "All critical checks completed. Review any ✗ or ⚠ indicators above."


### PR DESCRIPTION
# [DevOps] Set up Kubernetes Deployment Manifests

Issue: #734

## Overview
Production-grade Kubernetes manifests providing complete infrastructure-as-code with deployments, services, ingress, storage, RBAC, and comprehensive validation.

## Changes

### Manifests
- `k8s/complete-deployment.yml` (166 lines) - 3-replica backend, HPA, PDB, ConfigMap, Secrets
- `k8s/ingress-complete.yml` (90 lines) - TLS, rate limiting, frontend (2 replicas), domain routing
- `k8s/pvc-storage.yml` (66 lines) - StorageClass (GP3 EBS), 3 PVCs (50Gi, 20Gi, 10Gi)
- `k8s/rbac-complete.yml` (70 lines) - ServiceAccount, Roles, RoleBindings

### Testing & Docs
- `k8s/test-k8s-deployment.sh` (70 lines) - 10 validation tests
- `docs/K8S_DEPLOYMENT_GUIDE.md` (178 lines) - Complete guide with examples

## Architecture

### Backend Deployment
- 3 replicas, rolling updates
- Liveness: /health (30s delay), Readiness: /ready (10s delay)
- CPU: 250m request / 500m limit
- Memory: 512Mi request / 1Gi limit

### HPA
- Min: 3, Max: 10 replicas
- CPU: 70%, Memory: 80%

### Storage
- GP3 EBS (3000 IOPS)
- Total: 80Gi capacity

## Validation Tests (10 Total)
✅ Cluster connectivity
✅ Namespace creation
✅ RBAC configuration
✅ Storage validation
✅ Deployment status
✅ Service endpoints
✅ Ingress configuration
✅ Resource limits
✅ Health probes
✅ HPA configuration

## Quick Start
bash
sed -i 's/YOUR_ECR_URI/your-uri/g' k8s/*.yml
kubectl apply -f k8s/complete-deployment.yml
kubectl apply -f k8s/pvc-storage.yml
kubectl apply -f k8s/rbac-complete.yml
kubectl apply -f k8s/ingress-complete.yml
bash k8s/test-k8s-deployment.sh

## Closes #734