### PR TITLE
[Documentation] Add contribution + module ownership map

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Module ownership map — see CONTRIBUTING.md "Module Ownership Map" for details.
+# Later rules take precedence over earlier ones.
+
 # Global owners
 * @Xoulomon
 
@@ -8,8 +11,42 @@
 # Frontend
 /frontend/ @Xoulomon
 
+# Backend services
+/backend/ @Xoulomon
+
+# Indexer
+/indexer/ @Xoulomon
+
+# Mobile app
+/mobile/ @Xoulomon
+
+# Shared packages (SDK)
+/packages/ @Xoulomon
+
+# Website
+/website/ @Xoulomon
+
+# Operational scripts
+/scripts/ @Xoulomon
+
+# Infrastructure
+/k8s/ @Xoulomon
+/terraform/ @Xoulomon
+/config/ @Xoulomon
+/docker-compose*.yml @Xoulomon
+
+# Test suites
+/integration-tests/ @Xoulomon
+/performance/ @Xoulomon
+/security-tests/ @Xoulomon
+
+# Demo
+/demo/ @Xoulomon
+
 # CI/CD
 /.github/ @Xoulomon
 
 # Docs
 /docs/ @Xoulomon
+CONTRIBUTING.md @Xoulomon
+SECURITY.md @Xoulomon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ Thank you for your interest in contributing to Scavenger — a Rust/Soroban smar
 5. [Commit Message Conventions](#commit-message-conventions)
 6. [Development Workflow](#development-workflow)
 7. [Review Process](#review-process)
-8. [Contributor Recognition](#contributor-recognition)
-9. [Code of Conduct](#code-of-conduct)
+8. [Module Ownership Map](#module-ownership-map)
+9. [Contributor Recognition](#contributor-recognition)
+10. [Code of Conduct](#code-of-conduct)
 
 ---
 
@@ -548,6 +549,35 @@ All checks must pass before merge.
 - [ ] No breaking changes
 - [ ] Performance impact acceptable
 - [ ] Security concerns addressed
+
+---
+
+## Module Ownership Map
+
+Use this map to route issues, questions, and review requests to the right area of the codebase. Each top-level directory has a designated owner (see [`.github/CODEOWNERS`](.github/CODEOWNERS)) who is automatically requested for review on PRs touching that area.
+
+| Directory | Responsibility | Owner |
+|---|---|---|
+| `stellar-contract/`, `contracts/` | Soroban smart contracts (Rust): waste registration, transfers, rewards, incentives | @Xoulomon |
+| `frontend/` | React/TypeScript web app: pages, components, hooks, client-side services | @Xoulomon |
+| `backend/` | Rust backend services and APIs | @Xoulomon |
+| `indexer/` | Blockchain event indexer (TypeScript) | @Xoulomon |
+| `mobile/` | Mobile application | @Xoulomon |
+| `packages/` | Shared packages, including `scavenger-sdk` | @Xoulomon |
+| `website/` | Marketing/landing website | @Xoulomon |
+| `docs/` | Project documentation | @Xoulomon |
+| `scripts/` | Operational and build scripts (deploy, backup, cost, CDN, …) | @Xoulomon |
+| `k8s/`, `terraform/`, `config/` | Infrastructure: Kubernetes manifests, Terraform, service configuration | @Xoulomon |
+| `.github/`, `docker-compose*.yml` | CI/CD workflows, PR templates, local orchestration | @Xoulomon |
+| `integration-tests/`, `performance/`, `security-tests/` | Cross-cutting test suites: integration, performance, security | @Xoulomon |
+| `demo/` | Demo assets and example flows | @Xoulomon |
+
+### Routing guidelines
+
+- **Filing an issue:** prefix the title with the affected area (e.g. `[Frontend]`, `[Contract]`, `[Indexer]`) so it reaches the right owner.
+- **Opening a PR:** keep changes scoped to one area where possible; CODEOWNERS will request the owner's review automatically.
+- **Cross-cutting changes** (e.g. contract + frontend types): mention every affected owner in the PR description.
+- **Unsure where something belongs?** Open an issue and the global owner (@Xoulomon) will triage it.
 
 ---
 


### PR DESCRIPTION
## Description
Contributors don't know which module owns which concern. This adds an ownership map to route issues and reviews to the right area.

## Changes
- Added a **Module Ownership Map** section to `CONTRIBUTING.md` mapping every top-level directory to its responsibility and owner, plus routing guidelines for issues, PRs, and cross-cutting changes.
- Expanded `.github/CODEOWNERS` to cover all top-level modules (backend, indexer, mobile, packages, website, scripts, infrastructure, test suites, demo) so owners are auto-requested for review.

## Acceptance Criteria
- [x] Ownership map merged
- [x] CODEOWNERS added
- [x] Tested (n/a)

Closes #866