### PR TITLE
[Frontend] Extract shared data-fetching hooks

### DIFF
--- a/frontend/src/hooks/useAsync.ts
+++ b/frontend/src/hooks/useAsync.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type AsyncStatus = 'idle' | 'loading' | 'success' | 'error'
+
+export interface AsyncState<T> {
+  status: AsyncStatus
+  data: T | null
+  error: Error | null
+  isLoading: boolean
+}
+
+export interface UseAsyncReturn<T, Args extends unknown[]> extends AsyncState<T> {
+  run: (...args: Args) => Promise<T | undefined>
+  reset: () => void
+}
+
+/**
+ * Manages the lifecycle of an on-demand async operation (loading / error /
+ * success) so pages don't hand-roll `isLoading` + `error` state for every
+ * action. The wrapped function is only invoked when `run` is called.
+ *
+ * Stale completions (a `run` superseded by a newer one) and completions after
+ * unmount never update state. On failure `run` resolves to `undefined` and the
+ * error is exposed via `error`.
+ */
+export function useAsync<T, Args extends unknown[] = []>(
+  fn: (...args: Args) => Promise<T>
+): UseAsyncReturn<T, Args> {
+  const [state, setState] = useState<Omit<AsyncState<T>, 'isLoading'>>({
+    status: 'idle',
+    data: null,
+    error: null,
+  })
+
+  // Always call the latest fn without invalidating `run`'s identity
+  const fnRef = useRef(fn)
+  fnRef.current = fn
+
+  const mountedRef = useRef(true)
+  const callIdRef = useRef(0)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const run = useCallback(async (...args: Args): Promise<T | undefined> => {
+    const callId = ++callIdRef.current
+    setState((prev) => ({ ...prev, status: 'loading', error: null }))
+    try {
+      const data = await fnRef.current(...args)
+      if (mountedRef.current && callId === callIdRef.current) {
+        setState({ status: 'success', data, error: null })
+      }
+      return data
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      if (mountedRef.current && callId === callIdRef.current) {
+        setState((prev) => ({ ...prev, status: 'error', error }))
+      }
+      return undefined
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    callIdRef.current++
+    setState({ status: 'idle', data: null, error: null })
+  }, [])
+
+  return { ...state, isLoading: state.status === 'loading', run, reset }
+}

--- a/frontend/src/hooks/useResource.ts
+++ b/frontend/src/hooks/useResource.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect } from 'react'
+import { useAsync, type AsyncState } from './useAsync'
+
+export interface UseResourceReturn<T> extends AsyncState<T> {
+  reload: () => Promise<T | undefined>
+}
+
+/**
+ * Fetches an async resource on mount and whenever `deps` change, exposing
+ * loading / error / success state plus a `reload` for manual refresh (e.g.
+ * after a mutation). Built on `useAsync`, so stale responses and updates
+ * after unmount are ignored.
+ *
+ * `isLoading` is true until the first fetch settles, so initial renders show
+ * loading UI instead of flashing an empty state.
+ */
+export function useResource<T>(
+  fetcher: () => Promise<T>,
+  deps: unknown[] = []
+): UseResourceReturn<T> {
+  const { run, reset: _reset, ...state } = useAsync(fetcher)
+
+  // `run` is stable and always calls the latest fetcher; deps control refetch
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const reload = useCallback(() => run(), deps)
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  return {
+    ...state,
+    isLoading: state.status === 'idle' || state.status === 'loading',
+    reload,
+  }
+}

--- a/frontend/src/pages/OfflineSettings.tsx
+++ b/frontend/src/pages/OfflineSettings.tsx
@@ -3,69 +3,50 @@
  * Manage offline functionality and storage
  */
 
-import { useState, useEffect } from 'react';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { useAsync } from '../hooks/useAsync';
+import { useResource } from '../hooks/useResource';
 import { getDatabaseSize, clearAllData, getPendingMutations } from '../lib/offline/storage';
 import { syncManager } from '../lib/offline/syncManager';
 import { Download, Trash2, RefreshCw, Database, Wifi } from 'lucide-react';
 
 export function OfflineSettings() {
   const isOnline = useOnlineStatus();
-  const [storageInfo, setStorageInfo] = useState({ bytes: 0, formatted: '0 B' });
-  const [pendingCount, setPendingCount] = useState(0);
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [isClearing, setIsClearing] = useState(false);
+  const storage = useResource(getDatabaseSize);
+  const pending = useResource(async () => (await getPendingMutations()).length);
 
-  useEffect(() => {
-    loadStorageInfo();
-    loadPendingCount();
-  }, []);
+  const storageInfo = storage.data ?? { bytes: 0, formatted: '0 B' };
+  const pendingCount = pending.data ?? 0;
 
-  const loadStorageInfo = async () => {
-    const info = await getDatabaseSize();
-    setStorageInfo(info);
-  };
-
-  const loadPendingCount = async () => {
-    const mutations = await getPendingMutations();
-    setPendingCount(mutations.length);
-  };
-
-  const handleSync = async () => {
+  const { run: handleSync, isLoading: isSyncing } = useAsync(async () => {
     if (!isOnline) {
       alert('Cannot sync while offline');
       return;
     }
 
-    setIsSyncing(true);
     try {
       const result = await syncManager.syncPendingMutations();
       alert(`Sync complete: ${result.success} succeeded, ${result.failed} failed`);
-      await loadPendingCount();
+      await pending.reload();
     } catch (error) {
       alert('Sync failed: ' + (error instanceof Error ? error.message : 'Unknown error'));
-    } finally {
-      setIsSyncing(false);
     }
-  };
+  });
 
-  const handleClearData = async () => {
+  const { run: handleClearData, isLoading: isClearing } = useAsync(async () => {
     if (!confirm('Are you sure you want to clear all offline data? This action cannot be undone.')) {
       return;
     }
 
-    setIsClearing(true);
     try {
       await clearAllData();
-      await loadStorageInfo();
-      await loadPendingCount();
+      await storage.reload();
+      await pending.reload();
       alert('All offline data cleared successfully');
     } catch (error) {
       alert('Failed to clear data: ' + (error instanceof Error ? error.message : 'Unknown error'));
-    } finally {
-      setIsClearing(false);
     }
-  };
+  });
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">

--- a/frontend/src/pages/PlatformHealthDashboardPage.tsx
+++ b/frontend/src/pages/PlatformHealthDashboardPage.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card'
 import { Badge } from '@/components/ui/Badge'
+import { useAsync } from '@/hooks/useAsync'
 import {
   DEFAULT_SERVICES,
   SAMPLE_INCIDENTS,
@@ -146,35 +147,33 @@ function IncidentCard({ incident }: { incident: Incident }) {
 export function PlatformHealthDashboardPage() {
   const [services, setServices] = useState<ServiceHealth[]>(DEFAULT_SERVICES)
   const [lastRefreshed, setLastRefreshed] = useState(new Date())
-  const [isRefreshing, setIsRefreshing] = useState(false)
 
   const overallStatus = computeOverallStatus(services)
 
   // Group services
   const groups = [...new Set(services.map((s) => s.group))]
 
-  const refresh = async () => {
-    setIsRefreshing(true)
+  const { run: refresh, isLoading: isRefreshing } = useAsync(async () => {
     await new Promise((r) => setTimeout(r, 600)) // simulate network call
-    const refreshed = services.map((s) => ({
-      ...s,
-      lastChecked: Date.now(),
-      responseTimeMs: s.responseTimeMs
-        ? Math.max(1, s.responseTimeMs + Math.round((Math.random() - 0.5) * 20))
-        : undefined,
-    }))
-    setServices(refreshed)
-    recordHealthSnapshot(refreshed)
+    setServices((prev) => {
+      const refreshed = prev.map((s) => ({
+        ...s,
+        lastChecked: Date.now(),
+        responseTimeMs: s.responseTimeMs
+          ? Math.max(1, s.responseTimeMs + Math.round((Math.random() - 0.5) * 20))
+          : undefined,
+      }))
+      recordHealthSnapshot(refreshed)
+      return refreshed
+    })
     setLastRefreshed(new Date())
-    setIsRefreshing(false)
-  }
+  })
 
   // Auto-refresh every 60 seconds
   useEffect(() => {
     const id = setInterval(refresh, 60_000)
     return () => clearInterval(id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [refresh])
 
   const operationalCount = services.filter((s) => s.status === 'operational').length
   const avgUptime =

--- a/frontend/src/pages/RecyclerDashboard.tsx
+++ b/frontend/src/pages/RecyclerDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
 import { Plus, Coins, Recycle, Weight, Zap } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
@@ -9,6 +9,7 @@ import { RegisterWasteModal } from '@/components/modals/RegisterWasteModal'
 import { TransferWasteModal } from '@/components/modals/TransferWasteModal'
 import { useAuth } from '@/context/AuthContext'
 import { useAppTitle } from '@/hooks/useAppTitle'
+import { useResource } from '@/hooks/useResource'
 import { ScavengerClient } from '@/api/client'
 import { Material, Incentive, ParticipantStats, WasteType } from '@/api/types'
 import { config } from '@/config'
@@ -47,40 +48,34 @@ export function RecyclerDashboard() {
   const { user } = useAuth()
   const address = user?.address ?? ''
 
-  const [stats, setStats] = useState<ParticipantStats | null>(null)
-  const [wastes, setWastes] = useState<Material[]>([])
-  const [incentives, setIncentives] = useState<Incentive[]>([])
-  const [loading, setLoading] = useState(true)
   const [modalOpen, setModalOpen] = useState(false)
   const [transferWasteId, setTransferWasteId] = useState<bigint | null>(null)
 
-  const load = useCallback(async () => {
-    if (!address) return
-    setLoading(true)
-    try {
-      const [participantStats, wasteIds, activeIncentives] = await Promise.all([
-        client.getStats(address),
-        client.getParticipantWastes(address),
-        client.getActiveIncentives()
-      ])
-      setStats(participantStats)
-      setIncentives(activeIncentives.slice(0, 5))
+  const { data, isLoading: loading, reload: load } = useResource(async () => {
+    if (!address) return null
+    const [participantStats, wasteIds, activeIncentives] = await Promise.all([
+      client.getStats(address),
+      client.getParticipantWastes(address),
+      client.getActiveIncentives()
+    ])
 
-      const materials = await Promise.all(
-        wasteIds
-          .slice(-10)
-          .reverse()
-          .map((id) => client.getMaterial(id))
-      )
-      setWastes(materials.filter(Boolean) as Material[])
-    } finally {
-      setLoading(false)
+    const materials = await Promise.all(
+      wasteIds
+        .slice(-10)
+        .reverse()
+        .map((id) => client.getMaterial(id))
+    )
+
+    return {
+      stats: participantStats,
+      incentives: activeIncentives.slice(0, 5),
+      wastes: materials.filter(Boolean) as Material[]
     }
   }, [address])
 
-  useEffect(() => {
-    load()
-  }, [load])
+  const stats: ParticipantStats | null = data?.stats ?? null
+  const wastes: Material[] = data?.wastes ?? []
+  const incentives: Incentive[] = data?.incentives ?? []
 
   return (
     <div className="space-y-6 overflow-x-hidden px-4 py-6 sm:px-0 sm:py-0">


### PR DESCRIPTION
## Description
Fetch/loading/error boilerplate was duplicated across pages (hand-rolled `useState` + `useEffect` + try/finally). This centralizes that lifecycle into two reusable hooks.

## Changes
- Added `hooks/useAsync.ts` — manages an on-demand async operation (idle/loading/success/error, `run`, `reset`), ignoring stale completions and updates after unmount.
- Added `hooks/useResource.ts` — built on `useAsync`; fetches on mount and when deps change, exposes `reload` for post-mutation refresh, and reports loading until the first fetch settles.
- Migrated 3 pages off hand-rolled state:
  - `RecyclerDashboard.tsx` — stats/wastes/incentives load via `useResource`; modals call `reload`.
  - `OfflineSettings.tsx` — storage size and pending-mutation count via `useResource`; sync and clear-data actions via `useAsync`.
  - `PlatformHealthDashboardPage.tsx` — refresh action via `useAsync` (manual + 60s auto-refresh), dropping the manual `isRefreshing` flag.

## Acceptance Criteria
- [x] `useAsync` and `useResource` created, covering loading/error/success
- [x] Duplicated fetch logic removed from 3 pages

Closes #868