### PR TITLE
[Frontend] Modularize AnalyticsPage charts

### DIFF
--- a/frontend/src/components/analytics/ParticipantContributionChart.tsx
+++ b/frontend/src/components/analytics/ParticipantContributionChart.tsx
@@ -1,0 +1,54 @@
+import { Users } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import {
+  PARTICIPANT_CONTRIBUTIONS,
+  ROLE_COLORS,
+  roleColor,
+  type ParticipantContribution,
+} from '@/lib/analytics'
+
+interface ParticipantContributionChartProps {
+  contributions?: ParticipantContribution[]
+}
+
+export function ParticipantContributionChart({
+  contributions = PARTICIPANT_CONTRIBUTIONS,
+}: ParticipantContributionChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Users className="h-4 w-4" />
+          Participant Contributions
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {contributions.map(({ address, role, items, pct }) => (
+          <div key={address} className="space-y-1">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-mono text-xs">{address}</span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">{role}</span>
+                <span className="font-medium text-xs">{items} items</span>
+              </div>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={`h-full ${roleColor(role)} transition-all duration-500`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        ))}
+        <div className="flex items-center gap-3 pt-2 flex-wrap">
+          {Object.entries(ROLE_COLORS).map(([role, color]) => (
+            <span key={role} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className={`h-2 w-2 rounded-full ${color}`} />
+              {role}
+            </span>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/analytics/QuickStatsCard.tsx
+++ b/frontend/src/components/analytics/QuickStatsCard.tsx
@@ -1,0 +1,33 @@
+import { Activity } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { TOP_MATERIALS, type MaterialVolume } from '@/lib/analytics'
+
+interface QuickStatsCardProps {
+  stats?: MaterialVolume[]
+}
+
+export function QuickStatsCard({ stats = TOP_MATERIALS }: QuickStatsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Activity className="h-4 w-4" />
+          Quick Stats
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {stats.map(({ label, value, color }) => (
+          <div key={label} className="space-y-1">
+            <div className="flex justify-between text-sm">
+              <span>{label}</span>
+              <span className="font-medium">{value}%</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div className={`h-full ${color} transition-all duration-500`} style={{ width: `${value}%` }} />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/analytics/TopMaterialsChart.tsx
+++ b/frontend/src/components/analytics/TopMaterialsChart.tsx
@@ -1,0 +1,40 @@
+import { Medal } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { TOP_MATERIALS, maxValue, percentOfMax, type MaterialVolume } from '@/lib/analytics'
+
+interface TopMaterialsChartProps {
+  materials?: MaterialVolume[]
+}
+
+export function TopMaterialsChart({ materials = TOP_MATERIALS }: TopMaterialsChartProps) {
+  const max = maxValue(materials)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Medal className="h-4 w-4" />
+          Top Materials by Volume
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {materials.map(({ label, value, color }, i) => (
+          <div key={label} className="space-y-1">
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-1.5">
+                <span className="text-muted-foreground text-xs w-4">#{i + 1}</span>
+                {label}
+              </span>
+              <span className="font-medium text-xs">{value} t</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={`h-full ${color} transition-all duration-500`}
+                style={{ width: `${percentOfMax(value, max)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,55 @@
+// ── Analytics data shaping ────────────────────────────────────────────────────
+// Chart datasets and the transforms that turn them into renderable bar widths.
+// Kept separate from the chart components so they can be unit tested and later
+// swapped for live contract/indexer data without touching the UI.
+
+export interface MaterialVolume {
+  label: string
+  value: number
+  color: string
+}
+
+export const TOP_MATERIALS: MaterialVolume[] = [
+  { label: 'Plastic', value: 73, color: 'bg-blue-500' },
+  { label: 'Metal', value: 51, color: 'bg-green-500' },
+  { label: 'Glass', value: 42, color: 'bg-purple-500' },
+  { label: 'Paper', value: 38, color: 'bg-orange-500' },
+  { label: 'E-Waste', value: 22, color: 'bg-red-500' },
+]
+
+export interface ParticipantContribution {
+  address: string
+  role: string
+  items: number
+  pct: number
+}
+
+export const PARTICIPANT_CONTRIBUTIONS: ParticipantContribution[] = [
+  { address: '0xAB12…CD34', role: 'Recycler', items: 142, pct: 34 },
+  { address: '0xEF56…GH78', role: 'Collector', items: 98, pct: 23 },
+  { address: '0xIJ90…KL12', role: 'Recycler', items: 76, pct: 18 },
+  { address: '0xMN34…OP56', role: 'Manufacturer', items: 54, pct: 13 },
+  { address: '0xQR78…ST90', role: 'Collector', items: 50, pct: 12 },
+]
+
+export const ROLE_COLORS: Record<string, string> = {
+  Recycler: 'bg-blue-500',
+  Collector: 'bg-green-500',
+  Manufacturer: 'bg-purple-500',
+}
+
+/** Largest `value` in a dataset; 0 for an empty one. */
+export function maxValue(items: { value: number }[]): number {
+  return items.reduce((max, item) => Math.max(max, item.value), 0)
+}
+
+/** Bar width (0–100) for `value` relative to the dataset maximum. */
+export function percentOfMax(value: number, max: number): number {
+  if (max <= 0) return 0
+  return (value / max) * 100
+}
+
+/** Tailwind color class for a participant role, with a neutral fallback. */
+export function roleColor(role: string): string {
+  return ROLE_COLORS[role] ?? 'bg-primary'
+}

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,7 +1,6 @@
-import { BarChart3, TrendingUp, Package, Users, Download, Activity, Medal } from 'lucide-react'
+import { BarChart3, TrendingUp, Package, Users, Download } from 'lucide-react'
 import { UserBehaviorDashboard } from '@/components/analytics/UserBehaviorDashboard'
 import { StatCard } from '@/components/ui/StatCard'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { useStats } from '@/hooks/useStats'
 import { useAppTitle } from '@/hooks/useAppTitle'
@@ -12,110 +11,10 @@ import { CarbonImpactCard } from '@/components/analytics/CarbonImpactCard'
 import { WasteTypeChart } from '@/components/analytics/WasteTypeChart'
 import { MonthlyTrendsChart } from '@/components/analytics/MonthlyTrendsChart'
 import { RecyclingRateChart } from '@/components/analytics/RecyclingRateChart'
+import { TopMaterialsChart } from '@/components/analytics/TopMaterialsChart'
+import { ParticipantContributionChart } from '@/components/analytics/ParticipantContributionChart'
+import { QuickStatsCard } from '@/components/analytics/QuickStatsCard'
 import { useState } from 'react'
-
-// ── Static mock data for new charts ──────────────────────────────────────────
-
-const TOP_MATERIALS = [
-  { label: 'Plastic', value: 73, color: 'bg-blue-500' },
-  { label: 'Metal', value: 51, color: 'bg-green-500' },
-  { label: 'Glass', value: 42, color: 'bg-purple-500' },
-  { label: 'Paper', value: 38, color: 'bg-orange-500' },
-  { label: 'E-Waste', value: 22, color: 'bg-red-500' },
-]
-
-const PARTICIPANT_CONTRIBUTIONS = [
-  { address: '0xAB12…CD34', role: 'Recycler', items: 142, pct: 34 },
-  { address: '0xEF56…GH78', role: 'Collector', items: 98, pct: 23 },
-  { address: '0xIJ90…KL12', role: 'Recycler', items: 76, pct: 18 },
-  { address: '0xMN34…OP56', role: 'Manufacturer', items: 54, pct: 13 },
-  { address: '0xQR78…ST90', role: 'Collector', items: 50, pct: 12 },
-]
-
-const ROLE_COLORS: Record<string, string> = {
-  Recycler: 'bg-blue-500',
-  Collector: 'bg-green-500',
-  Manufacturer: 'bg-purple-500',
-}
-
-// ── Top Materials Chart ───────────────────────────────────────────────────────
-
-function TopMaterialsChart() {
-  const max = Math.max(...TOP_MATERIALS.map((m) => m.value))
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Medal className="h-4 w-4" />
-          Top Materials by Volume
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {TOP_MATERIALS.map(({ label, value, color }, i) => (
-          <div key={label} className="space-y-1">
-            <div className="flex items-center justify-between text-sm">
-              <span className="flex items-center gap-1.5">
-                <span className="text-muted-foreground text-xs w-4">#{i + 1}</span>
-                {label}
-              </span>
-              <span className="font-medium text-xs">{value} t</span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className={`h-full ${color} transition-all duration-500`}
-                style={{ width: `${(value / max) * 100}%` }}
-              />
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  )
-}
-
-// ── Participant Contribution Chart ────────────────────────────────────────────
-
-function ParticipantContributionChart() {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Users className="h-4 w-4" />
-          Participant Contributions
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {PARTICIPANT_CONTRIBUTIONS.map(({ address, role, items, pct }) => (
-          <div key={address} className="space-y-1">
-            <div className="flex items-center justify-between text-sm">
-              <span className="font-mono text-xs">{address}</span>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">{role}</span>
-                <span className="font-medium text-xs">{items} items</span>
-              </div>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className={`h-full ${ROLE_COLORS[role] ?? 'bg-primary'} transition-all duration-500`}
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-          </div>
-        ))}
-        <div className="flex items-center gap-3 pt-2 flex-wrap">
-          {Object.entries(ROLE_COLORS).map(([role, color]) => (
-            <span key={role} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span className={`h-2 w-2 rounded-full ${color}`} />
-              {role}
-            </span>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-// ── Page ──────────────────────────────────────────────────────────────────────
 
 export function AnalyticsPage() {
   useAppTitle('Analytics')
@@ -199,36 +98,10 @@ export function AnalyticsPage() {
         <div className="lg:col-span-2">
           <RecyclingRateChart />
         </div>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Activity className="h-4 w-4" />
-              Quick Stats
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {[
-              { label: 'Plastic', value: 73, color: 'bg-blue-500' },
-              { label: 'Metal', value: 51, color: 'bg-green-500' },
-              { label: 'Glass', value: 42, color: 'bg-purple-500' },
-              { label: 'Paper', value: 38, color: 'bg-orange-500' },
-              { label: 'E-Waste', value: 22, color: 'bg-red-500' },
-            ].map(({ label, value, color }) => (
-              <div key={label} className="space-y-1">
-                <div className="flex justify-between text-sm">
-                  <span>{label}</span>
-                  <span className="font-medium">{value}%</span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                  <div className={`h-full ${color} transition-all duration-500`} style={{ width: `${value}%` }} />
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
+        <QuickStatsCard />
       </div>
 
-      {/* New charts row: top materials + participant contributions */}
+      {/* Top materials + participant contributions */}
       <div className="grid gap-6 lg:grid-cols-2">
         <TopMaterialsChart />
         <ParticipantContributionChart />


### PR DESCRIPTION
## Description
`frontend/src/pages/AnalyticsPage.tsx` mixed chart config, data shaping, and layout. This breaks the inline charts into standalone, reusable components and moves data transforms into `lib/analytics.ts`.

## Changes
- Extracted `TopMaterialsChart`, `ParticipantContributionChart`, and the inline Quick Stats card (now `QuickStatsCard`) into `components/analytics/`, joining the existing chart components there. Each accepts an optional data prop with the current dataset as the default, so they are reusable outside this page.
- Moved datasets and transforms into `lib/analytics.ts`: `TOP_MATERIALS`, `PARTICIPANT_CONTRIBUTIONS`, `ROLE_COLORS`, plus pure helpers `maxValue`, `percentOfMax`, and `roleColor` — testable in isolation and ready to be swapped for live data.
- `AnalyticsPage.tsx` now only composes charts and layout (250 → 122 lines). Rendering is unchanged.

## Acceptance Criteria
- [x] Charts are reusable components in `components/analytics/`
- [x] Data transforms live in `lib/analytics.ts`

Closes #869