### PR TITLE
[Frontend] Introduce a typed API client layer

### DIFF
--- a/frontend/src/components/ApiPlayground/index.tsx
+++ b/frontend/src/components/ApiPlayground/index.tsx
@@ -5,6 +5,7 @@ import { RequestBuilder } from './RequestBuilder';
 import { ResponseViewer } from './ResponseViewer';
 import { RequestHistory } from './RequestHistory';
 import { ExampleRequests } from './ExampleRequests';
+import { createApiClient, ApiError } from '@/lib/apiClient';
 
 const DEFAULT_REQUEST: ApiRequest = {
   id: uuidv4(),
@@ -20,29 +21,6 @@ const DEFAULT_REQUEST: ApiRequest = {
   auth: { type: 'none' },
 };
 
-function buildUrl(baseUrl: string, req: ApiRequest): string {
-  const enabledParams = req.queryParams.filter((p) => p.enabled && p.key);
-  if (enabledParams.length === 0) return baseUrl + req.url;
-  const qs = new URLSearchParams(enabledParams.map((p) => [p.key, p.value])).toString();
-  return `${baseUrl}${req.url}?${qs}`;
-}
-
-function buildHeaders(req: ApiRequest): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const h of req.headers) {
-    if (h.enabled && h.key) headers[h.key] = h.value;
-  }
-  if (req.auth.type === 'bearer' && req.auth.token) {
-    headers['Authorization'] = `Bearer ${req.auth.token}`;
-  }
-  if (req.auth.type === 'api_key' && req.auth.apiKey) {
-    headers['X-API-Key'] = req.auth.apiKey;
-  }
-  if (req.auth.type === 'stellar' && req.auth.stellarPublicKey) {
-    headers['X-Stellar-Public-Key'] = req.auth.stellarPublicKey;
-  }
-  return headers;
-}
 
 type PanelView = 'examples' | 'history';
 
@@ -61,37 +39,72 @@ export const ApiPlayground: React.FC<{ baseUrl?: string }> = ({
     setError(null);
     setResponse(null);
 
-    const startMs = performance.now();
     let res: ApiResponse | null = null;
     let err: string | null = null;
 
     try {
-      const url = buildUrl(baseUrl, request);
-      const headers = buildHeaders(request);
+      const client = createApiClient({ baseUrl });
+
+      // Build query params map
+      const enabledParams = request.queryParams.filter((p) => p.enabled && p.key);
+      const params = Object.fromEntries(enabledParams.map((p) => [p.key, p.value]));
+
+      // Build extra headers
+      const extraHeaders: Record<string, string> = {};
+      for (const h of request.headers) {
+        if (h.enabled && h.key) extraHeaders[h.key] = h.value;
+      }
+
+      // Auth headers
+      if (request.auth.type === 'api_key' && request.auth.apiKey) {
+        extraHeaders['X-API-Key'] = request.auth.apiKey;
+      }
+      if (request.auth.type === 'stellar' && request.auth.stellarPublicKey) {
+        extraHeaders['X-Stellar-Public-Key'] = request.auth.stellarPublicKey;
+      }
+
+      const bearerToken =
+        request.auth.type === 'bearer' ? request.auth.token : undefined;
+
       const hasBody = !['GET', 'DELETE'].includes(request.method) && request.body.trim();
+      const body = hasBody ? (() => { try { return JSON.parse(request.body); } catch { return request.body; } })() : undefined;
 
-      const fetchRes = await fetch(url, {
-        method: request.method,
-        headers,
-        body: hasBody ? request.body : undefined,
-      });
+      const method = request.method as 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-      const durationMs = Math.round(performance.now() - startMs);
-      const body = await fetchRes.text();
-      const responseHeaders: Record<string, string> = {};
-      fetchRes.headers.forEach((v, k) => { responseHeaders[k] = v; });
+      const result = await client[method.toLowerCase() as 'get' | 'post' | 'put' | 'patch' | 'delete'](
+        request.url,
+        // For methods with body, pass body as second arg; otherwise pass options directly
+        ...(method !== 'GET' && method !== 'DELETE'
+          ? [body, { headers: extraHeaders, params, bearerToken }]
+          : [{ headers: extraHeaders, params, bearerToken }]
+        ) as [unknown, ...unknown[]]
+      );
 
       res = {
-        status: fetchRes.status,
-        statusText: fetchRes.statusText,
-        headers: responseHeaders,
-        body,
-        durationMs,
+        status: result.status,
+        statusText: 'OK',
+        headers: result.headers,
+        body: typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2),
+        durationMs: result.durationMs,
         timestamp: new Date().toISOString(),
       };
       setResponse(res);
     } catch (e) {
-      err = e instanceof Error ? e.message : String(e);
+      if (e instanceof ApiError) {
+        const bodyStr = typeof e.body === 'string' ? e.body : JSON.stringify(e.body, null, 2);
+        err = `${e.status} ${e.statusText}${bodyStr ? `\n${bodyStr}` : ''}`;
+        res = {
+          status: e.status,
+          statusText: e.statusText,
+          headers: {},
+          body: bodyStr ?? '',
+          durationMs: 0,
+          timestamp: new Date().toISOString(),
+        };
+        setResponse(res);
+      } else {
+        err = e instanceof Error ? e.message : String(e);
+      }
       setError(err);
     } finally {
       setLoading(false);

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ApiClient, ApiError, createApiClient } from '../apiClient'
+
+/* ────────────────────────────────────────────────────────────────
+   Helpers
+   ──────────────────────────────────────────────────────────────── */
+
+function mockFetch(
+  response: Partial<Response> & { body?: unknown } = {}
+): ReturnType<typeof vi.fn> {
+  const { status = 200, statusText = 'OK', body = {}, headers: rawHeaders = {} } = response
+  const headersObj = new Headers(rawHeaders as Record<string, string>)
+  if (!headersObj.has('content-type')) headersObj.set('content-type', 'application/json')
+
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: headersObj,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } satisfies Partial<Response>)
+
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+/* ────────────────────────────────────────────────────────────────
+   Tests
+   ──────────────────────────────────────────────────────────────── */
+
+describe('ApiClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('get()', () => {
+    it('calls fetch with the correct URL and method', async () => {
+      const fetchMock = mockFetch({ body: { items: [] } })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.get('/wastes')
+
+      expect(fetchMock).toHaveBeenCalledOnce()
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://api.example.com/wastes')
+      expect(init.method).toBe('GET')
+    })
+
+    it('appends query params to the URL', async () => {
+      const fetchMock = mockFetch()
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.get('/wastes', { params: { page: 2, limit: 10 } })
+
+      const [url] = fetchMock.mock.calls[0] as [string]
+      expect(url).toContain('page=2')
+      expect(url).toContain('limit=10')
+    })
+
+    it('returns typed data with status and durationMs', async () => {
+      mockFetch({ body: { id: 1, type: 'Plastic' } })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      const result = await client.get<{ id: number; type: string }>('/waste/1')
+
+      expect(result.data).toEqual({ id: 1, type: 'Plastic' })
+      expect(result.status).toBe(200)
+      expect(typeof result.durationMs).toBe('number')
+    })
+
+    it('sets Authorization header when bearerToken is configured', async () => {
+      const fetchMock = mockFetch()
+      const client = createApiClient({
+        baseUrl: 'https://api.example.com',
+        bearerToken: 'my-token',
+      })
+
+      await client.get('/wastes')
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer my-token')
+    })
+
+    it('merges per-request headers', async () => {
+      const fetchMock = mockFetch()
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.get('/wastes', { headers: { 'X-Custom': 'yes' } })
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect((init.headers as Record<string, string>)['X-Custom']).toBe('yes')
+    })
+  })
+
+  describe('post()', () => {
+    it('calls fetch with POST and serialised JSON body', async () => {
+      const fetchMock = mockFetch({ status: 201, body: { id: 42 } })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.post('/wastes', { type: 'Plastic', weight: 1.5 })
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(init.method).toBe('POST')
+      expect(init.body).toBe(JSON.stringify({ type: 'Plastic', weight: 1.5 }))
+    })
+  })
+
+  describe('put()', () => {
+    it('calls fetch with PUT method', async () => {
+      const fetchMock = mockFetch()
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.put('/waste/1', { status: 'verified' })
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(init.method).toBe('PUT')
+    })
+  })
+
+  describe('patch()', () => {
+    it('calls fetch with PATCH method', async () => {
+      const fetchMock = mockFetch()
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.patch('/waste/1', { weight: 2.0 })
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(init.method).toBe('PATCH')
+    })
+  })
+
+  describe('delete()', () => {
+    it('calls fetch with DELETE method and no body', async () => {
+      const fetchMock = mockFetch({ status: 204 })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await client.delete('/waste/1')
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(init.method).toBe('DELETE')
+      expect(init.body).toBeUndefined()
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws ApiError with status and body for 4xx responses', async () => {
+      mockFetch({ status: 404, statusText: 'Not Found', body: { error: 'waste not found' } })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await expect(client.get('/waste/999')).rejects.toThrow(ApiError)
+
+      try {
+        await client.get('/waste/999')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError)
+        const apiErr = err as ApiError
+        expect(apiErr.status).toBe(404)
+        expect(apiErr.statusText).toBe('Not Found')
+      }
+    })
+
+    it('throws ApiError for 5xx responses', async () => {
+      mockFetch({ status: 500, statusText: 'Internal Server Error', body: {} })
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await expect(client.get('/wastes')).rejects.toBeInstanceOf(ApiError)
+    })
+
+    it('throws ApiError with status 0 on network failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')))
+      const client = createApiClient({ baseUrl: 'https://api.example.com' })
+
+      await expect(client.get('/wastes')).rejects.toThrow(ApiError)
+    })
+
+    it('throws ApiError with timeout message when AbortError is raised', async () => {
+      const abortError = new Error('Aborted')
+      abortError.name = 'AbortError'
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError))
+
+      const client = createApiClient({
+        baseUrl: 'https://api.example.com',
+        timeoutMs: 100,
+      })
+
+      await expect(client.get('/wastes')).rejects.toThrow(/timed out/)
+    })
+  })
+
+  describe('setToken()', () => {
+    it('updates the bearer token used for subsequent requests', async () => {
+      const fetchMock = mockFetch()
+      const client = new ApiClient({ baseUrl: 'https://api.example.com' })
+
+      client.setToken('new-token')
+      await client.get('/wastes')
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer new-token')
+    })
+
+    it('removes Authorization header when token is set to undefined', async () => {
+      const fetchMock = mockFetch()
+      const client = new ApiClient({
+        baseUrl: 'https://api.example.com',
+        bearerToken: 'old-token',
+      })
+
+      client.setToken(undefined)
+      await client.get('/wastes')
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined()
+    })
+  })
+})

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,212 @@
+/**
+ * lib/apiClient.ts
+ *
+ * Typed HTTP API client for Scavngr REST endpoints.
+ * Centralises all fetch calls, auth headers, and error handling so
+ * components never need to call fetch() directly.
+ *
+ * Usage:
+ *   const client = createApiClient({ baseUrl: 'https://api.example.com' })
+ *   const wastes = await client.get<Waste[]>('/contracts/wastes')
+ */
+
+/* ────────────────────────────────────────────────────────────────
+   Types
+   ──────────────────────────────────────────────────────────────── */
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+export interface ApiClientOptions {
+  /** Base URL prepended to every request path. */
+  baseUrl?: string
+  /** Default headers merged into every request. */
+  defaultHeaders?: Record<string, string>
+  /** Request timeout in milliseconds (default: 30 000). */
+  timeoutMs?: number
+  /** Optional bearer token for Authorization header. */
+  bearerToken?: string
+}
+
+export interface RequestOptions {
+  /** Additional headers merged with the client defaults for this request. */
+  headers?: Record<string, string>
+  /** URL query params appended to the path. */
+  params?: Record<string, string | number | boolean>
+  /** Request body (serialised to JSON automatically). */
+  body?: unknown
+  /** Per-request timeout override. */
+  timeoutMs?: number
+  /** Override the bearer token for this request only. */
+  bearerToken?: string
+}
+
+/** Typed API error carrying the HTTP status and parsed response body. */
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: unknown,
+    message?: string
+  ) {
+    super(message ?? `HTTP ${status} ${statusText}`)
+    this.name = 'ApiError'
+  }
+}
+
+/** Successful response envelope returned by every client method. */
+export interface ApiResult<T> {
+  data: T
+  status: number
+  headers: Record<string, string>
+  durationMs: number
+}
+
+/* ────────────────────────────────────────────────────────────────
+   Core client
+   ──────────────────────────────────────────────────────────────── */
+
+export class ApiClient {
+  private readonly baseUrl: string
+  private readonly defaultHeaders: Record<string, string>
+  private readonly timeoutMs: number
+  private bearerToken: string | undefined
+
+  constructor(options: ApiClientOptions = {}) {
+    this.baseUrl = options.baseUrl?.replace(/\/$/, '') ?? ''
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...options.defaultHeaders,
+    }
+    this.timeoutMs = options.timeoutMs ?? 30_000
+    this.bearerToken = options.bearerToken
+  }
+
+  /** Update the bearer token (e.g. after wallet connect). */
+  setToken(token: string | undefined): void {
+    this.bearerToken = token
+  }
+
+  private buildUrl(path: string, params?: Record<string, string | number | boolean>): string {
+    const base = `${this.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+    if (!params || Object.keys(params).length === 0) return base
+    const qs = new URLSearchParams(
+      Object.entries(params).map(([k, v]) => [k, String(v)])
+    ).toString()
+    return `${base}?${qs}`
+  }
+
+  private buildHeaders(options: RequestOptions): Record<string, string> {
+    const token = options.bearerToken ?? this.bearerToken
+    return {
+      ...this.defaultHeaders,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...options.headers,
+    }
+  }
+
+  private async request<T>(
+    method: HttpMethod,
+    path: string,
+    options: RequestOptions = {}
+  ): Promise<ApiResult<T>> {
+    const url = this.buildUrl(path, options.params)
+    const headers = this.buildHeaders(options)
+    const timeout = options.timeoutMs ?? this.timeoutMs
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeout)
+
+    const startMs = performance.now()
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method,
+        headers,
+        signal: controller.signal,
+        body:
+          options.body !== undefined && method !== 'GET' && method !== 'DELETE'
+            ? JSON.stringify(options.body)
+            : undefined,
+      })
+    } catch (err) {
+      clearTimeout(timer)
+      if ((err as Error).name === 'AbortError') {
+        throw new ApiError(0, 'Timeout', null, `Request timed out after ${timeout}ms`)
+      }
+      throw new ApiError(0, 'NetworkError', null, (err as Error).message)
+    } finally {
+      clearTimeout(timer)
+    }
+
+    const durationMs = Math.round(performance.now() - startMs)
+
+    const responseHeaders: Record<string, string> = {}
+    response.headers.forEach((v, k) => {
+      responseHeaders[k] = v
+    })
+
+    // Parse body as JSON if possible, otherwise as text
+    let body: unknown
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      body = await response.json()
+    } else {
+      body = await response.text()
+    }
+
+    if (!response.ok) {
+      throw new ApiError(response.status, response.statusText, body)
+    }
+
+    return { data: body as T, status: response.status, headers: responseHeaders, durationMs }
+  }
+
+  /* ── Convenience methods ─────────────────────────────────────── */
+
+  get<T>(path: string, options?: Omit<RequestOptions, 'body'>): Promise<ApiResult<T>> {
+    return this.request<T>('GET', path, options)
+  }
+
+  post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<ApiResult<T>> {
+    return this.request<T>('POST', path, { ...options, body })
+  }
+
+  put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<ApiResult<T>> {
+    return this.request<T>('PUT', path, { ...options, body })
+  }
+
+  patch<T>(path: string, body?: unknown, options?: RequestOptions): Promise<ApiResult<T>> {
+    return this.request<T>('PATCH', path, { ...options, body })
+  }
+
+  delete<T>(path: string, options?: Omit<RequestOptions, 'body'>): Promise<ApiResult<T>> {
+    return this.request<T>('DELETE', path, options)
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────
+   Factory
+   ──────────────────────────────────────────────────────────────── */
+
+/**
+ * Create a pre-configured ApiClient instance.
+ *
+ * @example
+ * const api = createApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL })
+ * const result = await api.get<Waste[]>('/contracts/wastes')
+ */
+export function createApiClient(options?: ApiClientOptions): ApiClient {
+  return new ApiClient(options)
+}
+
+/* ────────────────────────────────────────────────────────────────
+   Shared singleton (uses VITE_API_BASE_URL if set)
+   ──────────────────────────────────────────────────────────────── */
+
+export const apiClient = createApiClient({
+  baseUrl: typeof window !== 'undefined'
+    ? (import.meta as unknown as { env: Record<string, string> }).env?.VITE_API_BASE_URL ?? window.location.origin
+    : '',
+})


### PR DESCRIPTION
## Summary

Adds `lib/apiClient.ts` — a typed HTTP client that centralises all REST fetch calls and error handling. Replaces the ad-hoc `fetch()` calls in `ApiPlayground`.

## Changes

### `src/lib/apiClient.ts` (new)
- `ApiClient` class with typed `get / post / put / patch / delete` methods
- Generic return type `ApiResult<T>` carrying `data`, `status`, `headers`, `durationMs`
- `ApiError` class with `status`, `statusText`, `body` — thrown on any non-2xx response
- `AbortController`-based timeout (configurable, default 30 s)
- `setToken()` for dynamic bearer token updates after wallet connect
- `createApiClient(options)` factory + shared `apiClient` singleton
- Auto-serialises request body to JSON; auto-parses JSON responses

### `src/components/ApiPlayground/index.tsx`
- Replaced raw `fetch()` call with typed `ApiClient`
- Removed ad-hoc `buildUrl` / `buildHeaders` helper functions
- `ApiError` responses surface HTTP status + body in the response viewer

### `src/lib/__tests__/apiClient.test.ts` (new)
- Unit tests with mocked `fetch` covering all HTTP methods, error paths (4xx, 5xx, network failure, timeout), auth headers, and `setToken`

Closes #872