### PR TITLE
docs: document smart contract storage key schema

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -7,6 +7,7 @@ Comprehensive documentation of Scavenger's on-chain storage schema, relationship
 - [Overview](#overview)
 - [Entity-Relationship Diagram](#entity-relationship-diagram)
 - [Storage Entities](#storage-entities)
+- [Storage Key Schema](#storage-key-schema)
 - [Data Dictionary](#data-dictionary)
 - [Indexing Strategy](#indexing-strategy)
 - [Query Optimization](#query-optimization)
@@ -379,6 +380,215 @@ pub struct GlobalMetrics {
 **Access Patterns:**
 - Get metrics: `O(1)`
 - Update metrics: `O(1)` per field
+
+---
+
+## Storage Key Schema
+
+This section is the reference for **how** contract state is keyed and **how long** it
+survives. It is the persistence contract that integrators and indexer authors depend
+on: if a key moves between storage tiers, or its TTL policy changes, downstream
+consumers must be told.
+
+Source of truth: `stellar-contract/src/lib.rs` (key constants),
+`stellar-contract/src/storage_utils.rs` (instance TTL bump),
+`stellar-contract/src/storage_optimizer.rs` (cache/index helpers), and
+`stellar-contract/src/participant.rs` (persistent participant records).
+
+### Storage Tiers
+
+Soroban exposes three storage tiers. Each has different cost, lifetime, and
+recovery semantics, and the contract uses all three deliberately.
+
+| Tier | Soroban accessor | Lifetime | Recoverable after expiry? | Used in Scavngr for |
+|------|------------------|----------|---------------------------|---------------------|
+| **Instance** | `env.storage().instance()` | Tied to the contract instance; extended on every call via `bump_instance` | Yes — restoring the instance restores all entries | Config scalars, counters, and the bulk of per-entity records |
+| **Persistent** | `env.storage().persistent()` | Per-entry TTL; archived (not deleted) when it lapses | Yes — entry must be explicitly restored before use | Participant records (`participant.rs`), compliance reports, performance snapshots, search index |
+| **Temporary** | `env.storage().temporary()` | Per-entry TTL; **permanently deleted** on expiry | **No** — data is unrecoverable | Read caches and hot-path derived data only |
+
+**Rule of thumb enforced in this codebase:** never put anything in temporary storage
+that cannot be recomputed from instance or persistent storage. Every temporary entry
+in the contract today is a cache of data that also lives in a durable tier.
+
+#### Instance storage and the TTL bump
+
+Every externally-invokable function calls `storage_utils::bump_instance(&env)` before
+touching state:
+
+```rust
+// stellar-contract/src/storage_utils.rs
+pub fn bump_instance(env: &Env) {
+    // Keep instance alive for ~30 days (at 5 s/ledger, 30d ≈ 518_400 ledgers).
+    const INSTANCE_LIFETIME_THRESHOLD: u32 = 518_400;
+    const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+```
+
+Consequences integrators should plan for:
+
+- A contract invoked at least once every ~30 days never expires; its instance TTL is
+  continuously refreshed.
+- Because instance storage is a **single ledger entry**, bumping it extends *all*
+  instance-keyed data at once. This is why the layout keeps large, rarely-read
+  collections out of instance storage where practical.
+- A contract that goes fully idle for more than ~30 days has its instance archived.
+  State is not lost — the instance must be restored (`RestoreFootprint`) before the
+  next invocation succeeds.
+
+### Key Naming Rules
+
+1. **Scalar/config keys** are `Symbol` constants declared at the top of `lib.rs`.
+   Soroban's `symbol_short!` caps symbols at **9 characters**, which is why names are
+   abbreviated (`REWARD_CFG` → `"RWD_CFG"`). The Rust constant name is the
+   human-readable name; the symbol is the on-chain key.
+2. **Per-entity keys** are tuples whose first element is a discriminator string and
+   whose remaining elements are the entity identifier — e.g. `("waste", waste_id)`.
+   Tuple keys avoid the string-concatenation and hashing overhead of composing keys
+   manually.
+3. **Participant records keyed by address alone** use the single-element tuple form
+   `(address,)`, which is distinct from the bare `Address` key.
+
+### Instance Storage Keys — Scalars and Config
+
+Declared in `stellar-contract/src/lib.rs`. All are read via
+`env.storage().instance()` and inherit the ~30-day instance TTL described above.
+
+| Rust constant | On-chain symbol | Value type | Purpose |
+|---------------|-----------------|------------|---------|
+| `ADMINS` | `ADMINS` | `Vec<Address>` | Contract administrators |
+| `CHARITY` | `CHARITY` | `Address` | Charity payout destination |
+| `TOKEN_ADDR` | `TKN_ADDR` | `Address` | Reward token contract address |
+| `REWARD_CFG` | `RWD_CFG` | `RewardConfig` | Collector/owner reward split |
+| `TOTAL_WEIGHT` | `TOT_WGT` | `u128` | Cumulative waste weight (grams) |
+| `TOTAL_TOKENS` | `TOT_TKN` | `u128` | Cumulative reward tokens issued |
+| `TOTAL_CARBON` | `TOT_CARB` | `u128` | Cumulative carbon credits |
+| `PART_INDEX` | `PART_IDX` | `Vec<Address>` | Enumerable participant index |
+| `PAUSED` | `PAUSED` | `bool` | Emergency pause flag |
+| `REENTRANCY_GUARD` | `RE_GUARD` | `bool` | Reentrancy lock (set/removed within one call) |
+| `MULTISIG_THRESHOLD` | `MS_THRESH` | `u32` | Approvals required for admin actions |
+| `PROPOSAL_COUNT` | `PROP_CNT` | `u64` | Multi-sig proposal ID counter |
+| `MIN_WEIGHT` | `MIN_WGT` | `u128` | Minimum accepted submission weight |
+| `SEASONAL_MUL` | `SEAS_MUL` | `u32` | Seasonal reward multiplier |
+| `MILESTONES_KEY` | `MLSTONES` | `Vec<..>` | Milestone definitions |
+| `CHALLENGE_COUNT` | `CHAL_CNT` | `u64` | Challenge ID counter |
+| `PENDING_XFR_CNT` | `PXFR_CNT` | `u64` | Pending-transfer ID counter |
+| `AUCTION_COUNT` | `AUC_CNT` | `u64` | Auction ID counter |
+| `DISPUTE_CNT` | `DISP_CNT` | `u64` | Dispute ID counter |
+| `ROUTE_CNT` | `ROUTE_CNT` | `u64` | Collection-route ID counter |
+| `BATCH_COUNT` | `BATCH_CNT` | `u64` | Batch ID counter |
+| `BATCH_INDEX` | `BATCH_IDX` | `Vec<u64>` | Batch enumeration index |
+| `CARB_LIST_CNT` | `CARB_CNT` | `u64` | Carbon-credit listing counter |
+| `CARB_LIST_IDX` | `CARB_IDX` | `Vec<u64>` | Active carbon-credit listing index |
+| `CONTAMINATED_LIST` | `CONT_LST` | `Vec<u128>` | Waste IDs flagged as contaminated |
+| `CERTIFICATIONS` | `CERT_IDX` | `Vec<..>` | Certification index |
+| `PERMISSIONS` | `PERMS` | RBAC map | Role-based permission grants (issue #704) |
+| `RECONCIL_LOG` | `REC_LOG` | `Vec<..>` | Reconciliation audit trail (issue #706) |
+| `QUALITY_SCORES` | `QUAL_SC` | scores | Quality scoring data (issue #654) |
+| `LOCATION_HISTORY` | `LOC_HIST` | `Vec<..>` | Location tracking history (issue #655) |
+| `REPORT_COUNT` | `REP_CNT` | `u64` | Compliance report ID counter |
+| `TRANSACTION_STATS` | `TX_STATS` | stats | Transaction benchmarking stats (issue #703) |
+
+### Instance Storage Keys — Per-Entity Records
+
+Composite tuple keys. The first tuple element is the discriminator shown below.
+
+| Key pattern | Value type | Purpose |
+|-------------|------------|---------|
+| `(address,)` | `Participant` | Participant record keyed by address |
+| `("stats", address)` | `RecyclingStats` | Per-participant recycling statistics |
+| `("participant_wastes", address)` | `Vec<u128>` | Waste IDs owned/submitted by a participant |
+| `("goals", address)` | goal record | Per-participant recycling goals |
+| `("waste", waste_id)` | `Waste` | Waste record (v1 layout) |
+| `("waste_v2", waste_id)` | `Waste` | Waste record (v2 layout, with expiry support) |
+| `("waste_count",)` | `u128` | Waste ID counter |
+| `("waste_ttl", waste_type)` | `u64` | **Business** expiry in seconds per waste type (see note below) |
+| `("transfers", waste_id)` | `Vec<TransferRecord>` | Transfer chain for a waste item |
+| `("transfer_history", waste_id)` | `Vec<..>` | Historical transfer detail |
+| `("pending_xfr", id)` | pending transfer | Transfer awaiting approval |
+| `("incentive", incentive_id)` | `Incentive` | Incentive record |
+| `("incentive_count",)` | `u64` | Incentive ID counter |
+| `("rewarder_incentives", address)` | `Vec<u64>` | Incentive IDs created by a rewarder/manufacturer |
+| `("general_incentives", waste_type)` | `Vec<u64>` | Incentive IDs applicable to a waste type |
+| `("auction", auction_id)` | auction record | Carbon-credit / material auction |
+| `("carb_list", listing_id)` | listing | Carbon-credit marketplace listing |
+| `("challenge", id)` | challenge | Community challenge definition |
+| `("chal_prog", id, address)` | progress | Per-participant challenge progress |
+| `("milestones", address)` | `Vec<..>` | Milestones reached by a participant |
+| `("dispute", dispute_id)` | dispute | Dispute record (issue #549) |
+| `("route", route_id)` | route | Collection route (issue #552) |
+| `("proposal", proposal_id)` | `AdminProposal` | Multi-sig admin proposal |
+| `("grade_history", waste_id)` | `Vec<..>` | Grading history for a waste item |
+| `("ai_grade_conf",)` | config | AI grading configuration |
+| `("contamination_reports", waste_id)` | `Vec<..>` | Contamination reports for a waste item |
+| `("index", name, key)` | `Address` | Generic secondary index (`StorageIndex` helper) |
+
+> **`waste_ttl` is not a storage TTL.** It is an application-level expiry measured in
+> **seconds against the ledger timestamp**, configured per waste type via
+> `set_waste_ttl` and read at registration to compute `expires_at`. A value of `0`
+> disables expiry. Soroban storage TTLs, by contrast, are measured in **ledgers** and
+> govern whether the ledger entry itself is archived. The two are independent — a
+> waste item can be business-expired while its ledger entry is still live, and vice
+> versa.
+
+### Persistent Storage Keys
+
+Entries with independent TTLs that are archived rather than deleted on expiry.
+
+| Key pattern | Value type | Defined in | Purpose |
+|-------------|------------|------------|---------|
+| `(Symbol("PART"), address)` | `Participant` | `participant.rs` | Participant record via `require_participant` / `save_participant` |
+| `(REPORTS, report_id)` — symbol `REPORTS` | report | `lib.rs` | Compliance report (issue #700) |
+| `PERF_SNAPSHOTS` — symbol `PERF_SNP` | `Vec<..>` | `lib.rs` | Performance benchmark snapshots (issue #703) |
+| `Symbol("idx")` | `Vec<(String, u64, String)>` | `search.rs` | On-chain search index |
+
+> **Known duplication.** Participant data is reachable through two paths: the
+> instance-keyed `(address,)` entries used throughout `lib.rs`, and the
+> persistent-keyed `("PART", address)` entries used by the `participant.rs` helpers.
+> New code should prefer the `participant.rs` helpers. Consolidating the two is
+> tracked as future migration work — see the [Migration Guide](#migration-guide)
+> before changing either path.
+
+### Temporary Storage Keys
+
+Ephemeral, unrecoverable on expiry. Every entry here is a cache of durable data.
+
+| Key pattern | TTL (ledgers) | Purpose |
+|-------------|---------------|---------|
+| `("cache", key)` | Caller-supplied; `1000` for prefetched participant and stats records | Generic read cache (`StorageCache`) |
+| `("waste_hot", waste_id)` | `5000` | Hot subset of a waste record (`is_active`, `current_owner`, `waste_type`) |
+
+At ~5 s/ledger these correspond to roughly 1.4 hours (1 000 ledgers) and 7 hours
+(5 000 ledgers). A cache miss is always safe: the caller falls back to the durable
+tier.
+
+### TTL Policy Summary
+
+| Concern | Policy |
+|---------|--------|
+| Instance TTL | Bumped to 518 400 ledgers (~30 days) on every invocation |
+| Persistent TTL | Per-entry; archived on expiry, restorable via `RestoreFootprint` |
+| Temporary TTL | 1 000–5 000 ledgers; **unrecoverable** on expiry, cache-only |
+| Business expiry (`waste_ttl`) | Seconds, per waste type, `0` = never; applies only to newly registered waste |
+| Transfer approval expiry | `TRANSFER_EXPIRY_SECS` = 24 hours |
+| Admin proposal expiry | `PROPOSAL_TTL_SECS` = 7 days |
+| Reputation decay window | `DECAY_WINDOW_SECS` = 30 days, then 1 point/day |
+
+### Persistence Guarantees for Integrators
+
+- **Durable:** everything in instance and persistent storage. Archival is not data
+  loss; entries are restorable.
+- **Not durable:** anything in temporary storage. Do not read `("cache", …)` or
+  `("waste_hot", …)` as an authoritative source.
+- **Idle contracts:** a contract with no invocations for ~30 days requires an instance
+  restore before the next call succeeds. Budget for this on low-traffic deployments.
+- **Symbol keys are part of the ABI surface.** Renaming a `symbol_short!` constant
+  orphans the existing ledger entry; the old key silently returns `None` rather than
+  erroring. Treat key renames as migrations — see `RWD_CFG`, which replaced the older
+  `COL_PCT`/`OWN_PCT` pair and required a one-time `set_percentages` call after
+  upgrade.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the smart contract storage key schema in `docs/DATABASE_SCHEMA.md`. Storage key enums and TTL policy previously lived only in code, leaving integrators without a stated persistence contract.

Closes #865

## What was added

A new **Storage Key Schema** section (linked from the table of contents) covering:

- **Storage tiers** — instance vs persistent vs temporary, with lifetime, cost, and recovery-on-expiry semantics for each, plus the rule the codebase enforces: nothing goes in temporary storage that cannot be recomputed from a durable tier.
- **Instance TTL bump** — `bump_instance` extends the instance to 518 400 ledgers (~30 days) on every invocation, why a single bump extends all instance-keyed data, and what happens to a contract idle for longer than that.
- **Key naming rules** — the 9-character `symbol_short!` limit that drives the abbreviated names, the tuple-key convention for per-entity records, and the single-element `(address,)` form.
- **Instance scalar/config keys** — every `Symbol` constant in `lib.rs` mapped to its on-chain symbol, value type, and purpose.
- **Instance per-entity keys** — every composite tuple key pattern.
- **Persistent keys** — participant records, compliance reports, performance snapshots, search index.
- **Temporary keys** — the two cache patterns and their TTLs in ledgers and wall-clock.
- **TTL policy summary** — one table covering storage TTLs and the separate business-level expiries (transfer approval, admin proposal, reputation decay).
- **Persistence guarantees for integrators** — what is durable, what is not, and why key renames are migrations.

## Notes for reviewers

Two things surfaced while reading the source that are documented rather than changed, since this issue is docs-only:

1. **`waste_ttl` is not a storage TTL.** It is an application-level expiry in seconds against the ledger timestamp (`set_waste_ttl` / `get_waste_ttl`), independent of Soroban's ledger-denominated storage TTLs. Called out explicitly as it is an easy misread.
2. **Participant records are reachable through two paths** — instance-keyed `(address,)` in `lib.rs`, and persistent-keyed `("PART", address)` in `participant.rs`. Documented as known duplication with a note to prefer the `participant.rs` helpers; consolidation would be a separate change.

## Acceptance criteria

- [x] All storage keys documented
- [x] TTL policy explained
- [x] Tested (n/a — documentation only)
- [ ] Code review passed
- [x] Related tests passing (no code changed)
