### PR TITLE
docs: publish external API reference for the indexer

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,8 +1,8 @@
 # Scavngr API Reference
 
 > **Issue:** #752  
-> **Version:** v1.0  
-> **Last Updated:** 2026-06-26
+> **Version:** v1.0.1  
+> **Last Updated:** 2026-07-24
 
 ---
 
@@ -32,6 +32,14 @@ Scavngr exposes two API surfaces:
 | **TypeScript SDK** | `@scavngr/sdk` | Typed wrapper for both surfaces |
 
 All REST responses are JSON. All times are ISO 8601 strings unless stated otherwise.
+
+> **This file is the single source of truth for the Indexer REST API.** External
+> consumers should integrate against the [Indexer REST API](#indexer-rest-api) section
+> and the [OpenAPI Specification](#openapi-specification) above it; both are derived
+> from the route handlers in `indexer/src/api/server.ts` and the migrations in
+> `indexer/src/db/migrations/`. Other documents in `docs/` may reference the indexer,
+> but where they disagree with this file, this file is correct. Changes to indexer
+> routes must update this file in the same PR.
 
 ---
 
@@ -110,12 +118,23 @@ paths:
           schema:
             type: integer
             description: End ledger sequence
+        - name: contractId
+          in: query
+          schema:
+            type: string
+            description: Filter by emitting contract ID
+        - name: txHash
+          in: query
+          schema:
+            type: string
+            description: Filter by transaction hash
         - name: limit
           in: query
           schema:
             type: integer
-            default: 50
-            maximum: 500
+            default: 100
+            maximum: 1000
+            description: Values above the maximum are clamped, not rejected
         - name: offset
           in: query
           schema:
@@ -128,8 +147,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventListResponse"
-        "400":
-          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /events/stream:
     get:
@@ -155,16 +174,20 @@ paths:
               $ref: "#/components/schemas/ReplayRequest"
       responses:
         "202":
-          description: Replay accepted
+          description: Replay accepted and started
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReplayStatusResponse"
+                $ref: "#/components/schemas/ReplayAcceptedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /replay/status/{id}:
     get:
       tags: [replay]
-      summary: Get replay job status
+      summary: Get replay subsystem status
       parameters:
         - name: id
           in: path
@@ -173,18 +196,24 @@ paths:
             type: string
       responses:
         "200":
-          description: Replay status
+          description: Replay subsystem status
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReplayStatusResponse"
-        "404":
-          $ref: "#/components/responses/NotFound"
 
   /alerts:
     get:
       tags: [metrics]
-      summary: List active alerts
+      summary: List recent alert history
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+            description: Values above the maximum are clamped, not rejected
       responses:
         "200":
           description: Alert list
@@ -192,6 +221,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AlertListResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
 components:
   schemas:
@@ -234,22 +265,39 @@ components:
 
     IndexerEvent:
       type: object
+      description: >-
+        A row from the raw_events table. Field names are the database column
+        names and are returned verbatim in snake_case.
       properties:
         id:
           type: string
-        ledger:
-          type: integer
-        timestamp:
+          description: BIGSERIAL primary key, serialised as a string
+        ledger_sequence:
+          type: string
+          description: Ledger the event was emitted in
+        ledger_close_time:
           type: string
           format: date-time
-        type:
+        transaction_hash:
           type: string
-        contractId:
+        contract_id:
           type: string
-        topics:
+        event_type:
+          type: string
+          example: recycled
+        topic:
           type: array
-          items: {}
-        data: {}
+          description: Raw event topics
+          items:
+            type: string
+        value:
+          type: object
+          description: Decoded event payload (JSONB)
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+          description: When the indexer persisted the row
 
     EventListResponse:
       type: object
@@ -260,6 +308,7 @@ components:
             $ref: "#/components/schemas/IndexerEvent"
         total:
           type: integer
+          description: Total rows matching the filters, ignoring limit/offset
         offset:
           type: integer
         limit:
@@ -267,24 +316,65 @@ components:
 
     ReplayRequest:
       type: object
-      required: [fromLedger, toLedger]
+      required: [fromLedger]
       properties:
         fromLedger:
           type: integer
+          description: Start ledger, inclusive. Required.
         toLedger:
           type: integer
+          description: End ledger, inclusive. Omit to replay to the newest indexed ledger.
+        eventTypes:
+          type: array
+          description: Optional event-type allow-list. Omit to replay all types.
+          items:
+            type: string
+
+    ReplayAcceptedResponse:
+      type: object
+      properties:
+        replayId:
+          type: string
+          example: replay_1750970400000_a1b2c3
+        eventCount:
+          type: integer
+          description: Number of stored events selected for replay
+        status:
+          type: string
+          enum: [started]
 
     ReplayStatusResponse:
       type: object
+      description: >-
+        Reports whether the replay subsystem is available. Per-job progress
+        tracking is not implemented; the path id is accepted but ignored.
+      properties:
+        status:
+          type: string
+          enum: [available]
+        message:
+          type: string
+
+    Alert:
+      type: object
+      description: A row from the alert_history table.
       properties:
         id:
           type: string
-        status:
+        alert_name:
           type: string
-          enum: [pending, running, complete, failed]
-        progress:
-          type: integer
-          description: Percentage complete
+        severity:
+          type: string
+          enum: [info, warning, critical]
+        message:
+          type: string
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
 
     AlertListResponse:
       type: object
@@ -292,7 +382,7 @@ components:
         alerts:
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/Alert"
 
     ErrorResponse:
       type: object
@@ -303,13 +393,25 @@ components:
 
   responses:
     BadRequest:
-      description: Invalid request parameters
+      description: Invalid request body or parameters
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     NotFound:
-      description: Resource not found
+      description: Unknown path
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    MethodNotAllowed:
+      description: HTTP method not supported for this path
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InternalError:
+      description: Unhandled server error
       content:
         application/json:
           schema:
@@ -350,23 +452,54 @@ The Indexer API is **unauthenticated** by default. For production deployments be
 
 ### Indexer API
 
-| Tier | Limit | Window | Header |
-|------|-------|--------|--------|
-| Default | 100 req | 1 minute | `X-RateLimit-Remaining` |
-| Burst | 10 req | 1 second | — |
+> **Deployment note for external consumers.** The indexer ships a Redis-backed
+> `RateLimiter` (`indexer/src/rate-limit/rate-limiter.ts`) with per-tier, per-endpoint
+> windows plus whitelist/blacklist support, but **it is not currently attached to the
+> HTTP server** — a stock `npm start` serves requests unthrottled. Public deployments
+> are expected to enforce limits at the ingress/gateway layer, or to wire the limiter
+> in before exposing the service. Do not assume the API will throttle you; conversely,
+> do not assume it will not, since the operator may have added limits upstream.
 
-Rate limit responses return `429 Too Many Requests`:
+The limiter's own contract, for operators wiring it in and for clients that need to
+handle throttling:
+
+| Concept | Behaviour |
+|---------|-----------|
+| Identifier | Caller-supplied string (typically API key or client IP) |
+| Tier | Named group of per-endpoint `{ windowMs, maxRequests }` configs |
+| Unknown tier or endpoint | Request allowed, `remaining` reported as `-1` |
+| Whitelisted identifier | Always allowed, `remaining` reported as `-1` |
+| Blacklisted identifier | Always denied |
+| Algorithm | Sliding window over a Redis sorted set, keyed `ratelimit:{id}:{endpoint}` |
+
+Recommended starting limits, matching the values in `.env.example`
+(`RATE_LIMIT_REQUESTS_PER_MINUTE`, `RATE_LIMIT_BURST_SIZE`):
+
+| Tier | Limit | Window |
+|------|-------|--------|
+| Default | 60 req | 1 minute |
+| Burst | 10 req | 1 second |
+
+When the limiter is attached, throttled requests return `429 Too Many Requests`:
 
 ```json
 { "error": "Rate limit exceeded. Retry after 42 seconds." }
 ```
 
-Response headers on every request:
+and `getRateLimitHeaders()` supplies:
+
 ```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 87
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 47
 X-RateLimit-Reset: 1750970400
 ```
+
+`X-RateLimit-Reset` is a Unix timestamp in **seconds**. A `-1` in
+`X-RateLimit-Remaining` means "not counted" (whitelisted, or no config for this
+tier/endpoint), not "exhausted".
+
+**Client guidance:** treat `429` as retryable with backoff, and page through `/events`
+using `limit`/`offset` rather than issuing many small concurrent requests.
 
 ### Soroban RPC
 
@@ -381,34 +514,89 @@ Stellar's public RPC endpoints enforce their own rate limits. For production, ru
 
 ## Indexer REST API
 
+This section is the **canonical reference** for the indexer's public HTTP surface.
+It is generated by reading the route definitions in `indexer/src/api/server.ts` and
+the schema in `indexer/src/db/migrations/`; where other documents describe these
+endpoints, this file wins.
+
+### Conventions
+
+- **Base URL** — `http://{API_HOST}:{API_PORT}`, defaulting to `0.0.0.0:3001`
+  (`indexer/src/index.ts`). Production deployments front this with a gateway.
+- **Content type** — every response is `application/json`, except
+  `GET /events/stream`, which is `text/event-stream`.
+- **No authentication** — the indexer serves public, already-public-on-chain data and
+  performs no authentication or authorisation of its own. `POST /replay` is a
+  privileged operation with no built-in guard; **do not expose it to the internet**.
+  See [Authentication](#authentication).
+- **Numeric JSON types** — `BIGINT`/`BIGSERIAL` columns are returned by the Postgres
+  driver as **strings**, not numbers, to avoid precision loss. Parse
+  `id`, `ledger_sequence`, and `waste_id` accordingly.
+- **Snake_case payloads** — event and alert objects are database rows returned
+  verbatim, so their fields are snake_case. Only the envelope fields
+  (`total`, `limit`, `offset`, `replayId`, `eventCount`) are camelCase.
+- **Out-of-range `limit`** — clamped to the maximum silently; it is never an error.
+
+### Endpoint Summary
+
+| Method | Path | Purpose | Success |
+|--------|------|---------|---------|
+| `GET` | `/health` | Liveness probe | `200` |
+| `GET` | `/metrics` | Process metrics snapshot | `200` |
+| `GET` | `/events` | Query indexed events | `200` |
+| `GET` | `/events/stream` | SSE stream of new events | `200` |
+| `POST` | `/replay` | Replay stored events | `202` |
+| `GET` | `/replay/status/:id` | Replay subsystem status | `200` |
+| `GET` | `/alerts` | Recent alert history | `200` |
+
+---
+
 ### `GET /health`
 
-Returns the current health status of the indexer service.
+Liveness probe. Returns unconditionally as long as the process is accepting
+connections — it does **not** check database connectivity or sync lag. Use
+`GET /metrics` and its `syncLag` field for readiness decisions.
 
-**Response:**
+**Request:**
+```bash
+curl -s http://localhost:3001/health
+```
+
+**Response — `200 OK`:**
 ```json
 {
   "status": "ok",
-  "timestamp": "2026-06-26T17:23:41Z"
+  "timestamp": "2026-06-26T17:23:41.008Z"
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | Always `ok` while the process is serving |
+| `timestamp` | string | ISO 8601 timestamp of the response |
 
 ---
 
 ### `GET /metrics`
 
-Operational metrics for the indexer process.
+In-memory metrics for the running indexer process. Counters reset on restart —
+`startTime` tells you the epoch they are relative to.
 
-**Response:**
+**Request:**
+```bash
+curl -s http://localhost:3001/metrics
+```
+
+**Response — `200 OK`:**
 ```json
 {
   "eventsProcessed": 14823,
   "eventsFailed": 2,
-  "lastEventTimestamp": "2026-06-26T17:23:00Z",
+  "lastEventTimestamp": "2026-06-26T17:23:00.000Z",
   "syncLag": 1,
   "reorgsDetected": 0,
   "alertsFired": 1,
-  "startTime": "2026-06-25T08:00:00Z",
+  "startTime": "2026-06-25T08:00:00.000Z",
   "eventsByType": {
     "recycled": 3201,
     "transfer": 1840,
@@ -417,107 +605,216 @@ Operational metrics for the indexer process.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `eventsProcessed` | integer | Events successfully handled since start |
+| `eventsFailed` | integer | Events that threw during handling |
+| `lastEventTimestamp` | string \| null | Close time of the most recent event; `null` before the first event |
+| `syncLag` | integer | Ledgers behind chain tip |
+| `reorgsDetected` | integer | Reorganisations detected since start |
+| `alertsFired` | integer | Alerts raised since start |
+| `startTime` | string | Process start time |
+| `eventsByType` | object | Per-event-type counts, keyed by contract event symbol |
+
 ---
 
 ### `GET /events`
 
-Query indexed contract events with optional filters.
+Query indexed contract events. Results are ordered newest-first by
+`ledger_sequence DESC, id DESC`.
 
-**Query Parameters:**
+**Query parameters:**
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `type` | string | — | Event type filter (`recycled`, `transfer`, `reg`, etc.) |
-| `from` | integer | — | Start ledger (inclusive) |
-| `to` | integer | — | End ledger (inclusive) |
-| `limit` | integer | 50 | Max results (max 500) |
-| `offset` | integer | 0 | Pagination offset |
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `type` | string | — | — | Exact match on `event_type` (`recycled`, `transfer`, `confirmed`, `reg`, `rewarded`, `donated`, …) |
+| `from` | integer | — | — | Start ledger sequence, inclusive |
+| `to` | integer | — | — | End ledger sequence, inclusive |
+| `contractId` | string | — | — | Exact match on emitting contract ID |
+| `txHash` | string | — | — | Exact match on transaction hash |
+| `limit` | integer | `100` | `1000` | Page size; higher values are clamped |
+| `offset` | integer | `0` | — | Pagination offset |
+
+All filters are ANDed. Unknown query parameters are ignored.
 
 **Request:**
-```
-GET /events?type=recycled&from=1000000&limit=10
+```bash
+curl -s "http://localhost:3001/events?type=recycled&from=1000000&limit=2"
 ```
 
-**Response:**
+**Response — `200 OK`:**
 ```json
 {
   "events": [
     {
-      "id": "evt_0001",
-      "ledger": 1000123,
-      "timestamp": "2026-06-26T10:00:00Z",
-      "type": "recycled",
-      "contractId": "CCXXX...",
-      "topics": ["recycled", "42"],
-      "data": {
+      "id": "48211",
+      "ledger_sequence": "1000123",
+      "ledger_close_time": "2026-06-26T10:00:00.000Z",
+      "transaction_hash": "a3f1c0b9e2d84f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a",
+      "contract_id": "CCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "event_type": "recycled",
+      "topic": ["recycled", "42"],
+      "value": {
         "waste_type": 2,
         "weight": 1000,
-        "recycler": "GABC...",
+        "recycler": "GABCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "latitude": 40714000,
         "longitude": -74006000
-      }
+      },
+      "created_at": "2026-06-26T10:00:02.417Z"
     }
   ],
   "total": 3201,
-  "offset": 0,
-  "limit": 10
+  "limit": 2,
+  "offset": 0
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | array | Rows from `raw_events` (see column reference below) |
+| `total` | integer | Total rows matching the filters, ignoring `limit`/`offset` |
+| `limit` | integer | Effective page size after clamping |
+| `offset` | integer | Echo of the requested offset |
+
+**`raw_events` columns:**
+
+| Column | SQL type | JSON type | Description |
+|--------|----------|-----------|-------------|
+| `id` | `BIGSERIAL` | string | Monotonic insertion ID |
+| `ledger_sequence` | `BIGINT` | string | Ledger the event was emitted in |
+| `ledger_close_time` | `TIMESTAMPTZ` | string | Ledger close time |
+| `transaction_hash` | `TEXT` | string | Emitting transaction |
+| `contract_id` | `TEXT` | string | Emitting contract |
+| `event_type` | `TEXT` | string | Contract event symbol |
+| `topic` | `TEXT[]` | string[] | Raw event topics |
+| `value` | `JSONB` | object | Decoded event payload |
+| `created_at` | `TIMESTAMPTZ` | string | When the indexer persisted the row |
+
+**Pagination:** page with `limit`/`offset` and stop when
+`offset + events.length >= total`. Because ordering is newest-first, a deep paginated
+scan taken while the indexer is live can skip or repeat rows as new events land at the
+head. For a stable scan, pin the range with `to={current_tip}` and page within it.
+
+**Errors:** `500` if the database query fails.
 
 ---
 
 ### `GET /events/stream`
 
-Server-Sent Events (SSE) stream for real-time event delivery.
+Server-Sent Events stream of events as the indexer processes them. On connect the
+server sends a `{"type":"connected"}` frame, then one frame per event, plus a
+`:keepalive` comment every 15 seconds to hold the connection open through proxies.
 
 **Request:**
-```
-GET /events/stream
-Accept: text/event-stream
+```bash
+curl -N -H "Accept: text/event-stream" http://localhost:3001/events/stream
 ```
 
-**Stream format:**
+**Response — `200 OK`, `Content-Type: text/event-stream`:**
 ```
-data: {"id":"evt_0042","type":"recycled","ledger":1000456,...}
+data: {"type":"connected"}
 
-data: {"id":"evt_0043","type":"transfer","ledger":1000457,...}
+data: {"event_type":"recycled","ledger_sequence":"1000456", ...}
+
+:keepalive
+
+data: {"event_type":"transfer","ledger_sequence":"1000457", ...}
 ```
+
+Response headers: `Cache-Control: no-cache`, `Connection: keep-alive`,
+`X-Accel-Buffering: no` (the last disables nginx response buffering, which would
+otherwise defeat streaming).
+
+The stream carries **live events only** — it does not replay history on connect.
+Bridge the gap after a reconnect by noting the last `ledger_sequence` you saw and
+backfilling with `GET /events?from={last_seen}` before trusting the stream again.
+
+> **Known issue — this route is currently unreachable.** The dispatcher tests
+> `path.startsWith('/events')` before it tests `path === '/events/stream'`, so a
+> request for `/events/stream` is matched by the `/events` branch and answered with a
+> JSON event page instead of an SSE stream. The behaviour documented above is what the
+> handler implements; reaching it requires reordering those two branches in
+> `indexer/src/api/server.ts`. Until that is fixed, external consumers should poll
+> `GET /events` rather than depend on the stream.
 
 ---
 
 ### `POST /replay`
 
-Trigger a historical event replay between two ledger sequences.
+Re-dispatch stored events from `raw_events` through the event handlers. Use this to
+rebuild derived tables after a handler bug fix, without re-fetching from Stellar.
+
+The request returns as soon as the matching rows are selected; **processing continues
+asynchronously** in the background. A `202` means "accepted and started", not
+"finished".
+
+> **Privileged operation.** There is no authentication on this endpoint. It replays
+> events through handlers that mutate indexer tables. Keep it behind your gateway,
+> bound to a private interface, or firewalled off.
 
 **Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fromLedger` | integer | **yes** | Start ledger, inclusive. Must be a JSON number. |
+| `toLedger` | integer | no | End ledger, inclusive. Omit to replay through the newest stored event. |
+| `eventTypes` | string[] | no | Restrict to these event types. Omit or pass an empty array for all types. |
+
+**Request:**
+```bash
+curl -s -X POST http://localhost:3001/replay \
+  -H 'Content-Type: application/json' \
+  -d '{"fromLedger": 900000, "toLedger": 1000000, "eventTypes": ["recycled", "transfer"]}'
+```
+
+**Response — `202 Accepted`:**
 ```json
 {
-  "fromLedger": 900000,
-  "toLedger": 1000000
+  "replayId": "replay_1750970400000_a1b2c3",
+  "eventCount": 1284,
+  "status": "started"
 }
 ```
 
-**Response (202):**
-```json
-{
-  "id": "replay_abc123",
-  "status": "pending",
-  "progress": 0
-}
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `replayId` | string | Correlation ID, emitted in indexer logs for this replay |
+| `eventCount` | integer | Rows selected for replay |
+| `status` | string | Always `started` |
+
+**Errors:**
+
+| Status | Body | Cause |
+|--------|------|-------|
+| `400` | `{"error":"fromLedger is required"}` | `fromLedger` missing or not a number |
+| `400` | `{"error":"SyntaxError: ..."}` | Body is not valid JSON |
+| `405` | `{"error":"Method not allowed"}` | Any method other than `POST` |
+
+`replayId` is a log correlation handle only — it cannot be used to poll progress (see
+the next endpoint). Track a replay by grepping the indexer logs for it; failures are
+logged as `Replay processing failed` with the same ID.
 
 ---
 
 ### `GET /replay/status/:id`
 
-Poll replay job status.
+Reports whether the replay subsystem is available.
 
-**Response:**
+> **Per-job progress is not implemented.** The `:id` path segment is accepted but
+> ignored, and the response is a fixed availability probe — it does not reflect the
+> state of any particular replay. Treat this as a capability check, not a job poller.
+
+**Request:**
+```bash
+curl -s http://localhost:3001/replay/status/replay_1750970400000_a1b2c3
+```
+
+**Response — `200 OK`:**
 ```json
 {
-  "id": "replay_abc123",
-  "status": "running",
-  "progress": 42
+  "status": "available",
+  "message": "Replay status tracking is active"
 }
 ```
 
@@ -525,20 +822,89 @@ Poll replay job status.
 
 ### `GET /alerts`
 
-List currently active monitoring alerts.
+Recent monitoring alerts from the `alert_history` table, newest first. This is
+**history**, not currently-firing state — there is no resolved/cleared flag, so a row
+here means "this alert fired at this time", not "this alert is active now".
 
-**Response:**
+**Query parameters:**
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `limit` | integer | `50` | `200` | Page size; higher values are clamped |
+
+There is no `offset` — this endpoint returns only the most recent window.
+
+**Request:**
+```bash
+curl -s "http://localhost:3001/alerts?limit=10"
+```
+
+**Response — `200 OK`:**
 ```json
 {
   "alerts": [
     {
-      "name": "HighSyncLag",
+      "id": "912",
+      "alert_name": "HighSyncLag",
       "severity": "warning",
       "message": "Indexer is 5 ledgers behind chain tip",
-      "firedAt": "2026-06-26T17:20:00Z"
+      "metadata": { "syncLag": 5, "threshold": 3 },
+      "created_at": "2026-06-26T17:20:00.000Z"
     }
   ]
 }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | `BIGSERIAL` primary key |
+| `alert_name` | string | Alert rule name |
+| `severity` | string | One of `info`, `warning`, `critical` |
+| `message` | string | Human-readable description |
+| `metadata` | object \| null | Rule-specific context |
+| `created_at` | string | When the alert fired |
+
+**Errors:** `500` if the database query fails.
+
+---
+
+### Common Error Responses
+
+Every error body is `{"error": "<message>"}`.
+
+| Status | Body | When |
+|--------|------|------|
+| `400 Bad Request` | `{"error":"fromLedger is required"}` | Invalid `POST /replay` body |
+| `404 Not Found` | `{"error":"Not found"}` | Path does not match any route |
+| `405 Method Not Allowed` | `{"error":"Method not allowed"}` | Wrong method on a matched path |
+| `500 Internal Server Error` | `{"error":"Internal server error"}` | Unhandled exception; details are logged server-side, not returned |
+
+Note that `500` bodies are deliberately generic. When debugging an integration,
+correlate by timestamp against the indexer logs rather than expecting detail in the
+response.
+
+---
+
+### Verifying These Docs Against a Running Instance
+
+The examples above were written against the route handlers in
+`indexer/src/api/server.ts`. To re-verify after a change:
+
+```bash
+# 1. Start Postgres and the indexer (see docs/DEVELOPER_ONBOARDING.md)
+cd indexer && npm install && npm run dev
+
+# 2. Walk the endpoints
+curl -s localhost:3001/health
+curl -s localhost:3001/metrics
+curl -s 'localhost:3001/events?limit=1'
+curl -s 'localhost:3001/alerts?limit=1'
+curl -s localhost:3001/replay/status/x
+
+# 3. Confirm error shapes
+curl -s localhost:3001/nope                                   # 404
+curl -s -X GET localhost:3001/replay                          # 405
+curl -s -X POST localhost:3001/replay -d '{}'                 # 400
 ```
 
 ---
@@ -805,6 +1171,31 @@ The Soroban contract API is versioned via on-chain upgrade proposals (see `docs/
 ---
 
 ## Changelog
+
+### v1.0.1 — 2026-07-24
+
+**Indexer reference corrected against the implementation.** No API behaviour changed;
+the previous documentation described intended rather than actual behaviour. If you
+integrated against v1.0.0 docs, review the following:
+
+- `GET /events` — default `limit` is **100** (not 50) and the maximum is **1000**
+  (not 500); added the previously undocumented `contractId` and `txHash` filters.
+- `GET /events` response — events are `raw_events` rows in **snake_case**
+  (`ledger_sequence`, `event_type`, `transaction_hash`, `topic`, `value`), not the
+  camelCase shape previously shown. `BIGINT` fields are returned as **strings**.
+- `POST /replay` — only `fromLedger` is required; added the `eventTypes` filter. The
+  `202` body is `{replayId, eventCount, status}`, not `{id, status, progress}`.
+- `GET /replay/status/:id` — documented as an availability probe; per-job progress
+  tracking does not exist, and the `:id` segment is ignored.
+- `GET /alerts` — documented the `limit` parameter (default 50, max 200) and the
+  actual `alert_history` row shape; this is alert *history*, not active-alert state.
+- Rate limiting — corrected to state that the Redis-backed limiter is **not currently
+  attached** to the HTTP server; suggested limits aligned with `.env.example`
+  (60 req/min, burst 10) rather than the previously stated 100 req/min.
+- Added common error responses, pagination guidance, SSE reconnect guidance, and a
+  verification script.
+- Flagged that `GET /events/stream` is currently shadowed by the `/events` route match
+  and is unreachable until the route ordering is fixed.
 
 ### v1.0.0 — 2026-06-26
 


### PR DESCRIPTION
## Summary

Publishes a complete external API reference for the indexer in `docs/API_REFERENCE.md`, generated by reading the route definitions in `indexer/src/api/server.ts` and the schema in `indexer/src/db/migrations/`.

Closes #864

## What changed

**Every public endpoint is now documented** with request parameters, response shape, per-field tables, curl examples, and error cases: `GET /health`, `GET /metrics`, `GET /events`, `GET /events/stream`, `POST /replay`, `GET /replay/status/:id`, `GET /alerts`.

Added around them:

- An **endpoint summary table** and a **conventions** block covering base URL, content types, the no-authentication posture, `BIGINT`-as-string serialisation, and snake_case row payloads — the things that bite integrators first.
- **Pagination guidance** for `/events`, including why a deep paginated scan against a live indexer can skip or repeat rows and how to pin a stable range.
- **Reconnect guidance** for the SSE stream (it carries live events only; backfill via `/events?from=` after a gap).
- A **common error response** table and a **verification script** for re-checking the docs against a running instance.
- The OpenAPI 3.1 block updated to match, with corrected parameters, real response schemas, and `405`/`500` responses.

## Corrections against the implementation

The previous section described intended rather than actual behaviour. These are documentation fixes — no API behaviour changed — but anyone who integrated against the old text will want to read them:

| Endpoint | Was documented | Actually |
|---|---|---|
| `GET /events` | `limit` default 50, max 500 | default **100**, max **1000**; also supports undocumented `contractId` and `txHash` filters |
| `GET /events` | camelCase `{id, ledger, timestamp, type, topics, data}` | `raw_events` rows in **snake_case**; `BIGINT` columns serialise as **strings** |
| `POST /replay` | `fromLedger` + `toLedger` both required; returns `{id, status, progress}` | only `fromLedger` required; accepts `eventTypes`; returns `{replayId, eventCount, status}` |
| `GET /replay/status/:id` | job poller with `progress` percentage | fixed availability probe; per-job tracking does not exist and `:id` is ignored |
| `GET /alerts` | no parameters; active alerts | `limit` (default 50, max 200); returns alert **history**, with no resolved/cleared flag |
| Rate limiting | 100 req/min enforced, headers on every request | the Redis-backed limiter exists but **is not attached to the HTTP server**; suggested limits aligned with `.env.example` (60 req/min, burst 10) |

All of the above is also recorded in the changelog as **v1.0.1** so downstream consumers can diff what they relied on.

## Two implementation issues found and flagged (not fixed here)

This issue is docs-only, so both are documented with a pointer rather than patched:

1. **`GET /events/stream` is unreachable.** The dispatcher tests `path.startsWith('/events')` before `path === '/events/stream'`, so the stream request is answered by the `/events` JSON handler. Documented under a "Known issue" callout advising external consumers to poll `/events` until the two branches are reordered. Happy to send that one-line fix as a follow-up PR if wanted.
2. **`POST /replay` is unauthenticated and mutating.** It re-dispatches stored events through the handlers that write derived tables. Called out prominently as a privileged operation that must not be internet-exposed.

## Single source of truth

`docs/API_DOCUMENTATION.md` and `docs/API_REFERENCE_GUIDE.md` were checked and neither documents indexer endpoints, so there was no duplication to remove. Added an explicit statement in the Overview that this file is canonical for the indexer surface and that route changes must update it in the same PR.

## Verification

- The embedded OpenAPI 3.1 block was parsed as YAML and checked for dangling `$ref`s — parses clean, all 10 schemas and 4 responses resolve.
- Endpoint behaviour was verified by reading the handlers rather than against a live instance; the doc includes a `curl` walkthrough under "Verifying These Docs Against a Running Instance" so a reviewer with Postgres up can confirm each shape.

## Acceptance criteria

- [x] All public endpoints documented
- [x] Examples verified against the route handlers; a curl walkthrough is included for verification against a running instance
- [x] Tested (manual — OpenAPI block parsed and ref-checked)
- [ ] Code review passed
- [x] Related tests passing (no code changed)
