### PR TITLE
docs: add Architecture Decision Records index and backfill core ADRs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -564,58 +564,38 @@ Primary Failure
 
 ## Architecture Decision Records (ADRs)
 
-### ADR-001: Use Soroban for Smart Contracts
+This document describes **how** the system is built. The decision log records **why**,
+including the alternatives that were rejected and the costs each choice carries.
 
-**Decision**: Use Soroban (Rust) instead of JavaScript/TypeScript
+➡️ **[Architecture Decision Records](./adr/README.md)**
 
-**Rationale**:
-- Type safety
-- Performance
-- Stellar native
-- Mature ecosystem
+| # | Decision | Area |
+|---|----------|------|
+| [0001](./adr/0001-use-soroban-for-smart-contracts.md) | Use Soroban and Rust for the on-chain contract | Contract |
+| [0002](./adr/0002-off-chain-event-driven-indexing.md) | Serve queries from an off-chain event-driven indexer | Indexer |
+| [0003](./adr/0003-percentage-based-reward-distribution.md) | Distribute rewards by configurable percentage | Contract |
+| [0004](./adr/0004-contract-storage-key-layout.md) | Tier contract storage by access pattern, with typed tuple keys | Contract |
+| [0005](./adr/0005-indexer-relational-schema.md) | Project events into a normalised Postgres schema, keeping raw events | Indexer |
+| [0006](./adr/0006-wallet-based-authentication-flow.md) | Authenticate with wallet signatures; treat frontend session state as UI only | Frontend / Auth |
 
-**Consequences**:
-- Steeper learning curve
-- Better security
-- Faster execution
+ADRs 0001–0003 were previously recorded inline in this document and now live in the
+log, keeping their original numbering. Changes that contradict an Accepted ADR should
+be raised in review; changes that supersede one should ship with a new ADR.
 
-### ADR-002: Event-Driven Indexing
-
-**Decision**: Use off-chain indexer for queries
-
-**Rationale**:
-- Reduce contract complexity
-- Faster queries
-- Better analytics
-
-**Consequences**:
-- Additional infrastructure
-- Eventual consistency
-- More operational overhead
-
-### ADR-003: Percentage-Based Rewards
-
-**Decision**: Use configurable percentages for reward distribution
-
-**Rationale**:
-- Flexible incentive structure
-- Admin control
-- Fair distribution
-
-**Consequences**:
-- Requires admin management
-- Potential for disputes
-- Audit trail needed
+New decisions start from [`docs/adr/template.md`](./adr/template.md).
 
 ---
 
 ## Related Documentation
 
+- [Architecture Decision Records](./adr/README.md)
+- [API Reference](./API_REFERENCE.md)
 - [API Documentation](./API_DOCUMENTATION.md)
+- [Database Schema](./DATABASE_SCHEMA.md)
 - [User Guide](./USER_GUIDE.md)
 - [Security Audit Report](./SECURITY_AUDIT.md)
 - [Deployment Guide](./KUBERNETES_DEPLOYMENT.md)
 
 ---
 
-Last updated: April 27, 2026
+Last updated: July 24, 2026

--- a/docs/adr/0001-use-soroban-for-smart-contracts.md
+++ b/docs/adr/0001-use-soroban-for-smart-contracts.md
@@ -1,0 +1,63 @@
+# ADR-0001: Use Soroban and Rust for the on-chain contract
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** [ADR-0002](./0002-off-chain-event-driven-indexing.md), [ADR-0004](./0004-contract-storage-key-layout.md)
+
+> Migrated from the inline ADR section of [ARCHITECTURE.md](../ARCHITECTURE.md), which
+> is where this decision was originally recorded.
+
+## Context
+
+Scavngr tracks recyclable material through a supply chain and pays rewards for
+verified handoffs. The chain of custody and the reward arithmetic have to be
+tamper-evident, which puts them on-chain.
+
+Stellar was the target network. Within Stellar, contract logic can be written for the
+Soroban runtime, which compiles Rust to WASM. Off-chain alternatives were also on the
+table, since not every part of the system strictly needs consensus.
+
+## Decision
+
+We will implement the supply-chain and reward logic as a Soroban smart contract
+written in Rust, in `stellar-contract/`.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| A JavaScript/TypeScript backend holding the authoritative state | No tamper-evidence. The custody chain and reward payouts are exactly the things participants need to be able to verify without trusting us. |
+| A different chain with a more familiar contract language | Stellar was already the target network for payments and asset issuance. Bridging to a second chain would add a trust boundary and operational surface for no gain. |
+| Thin on-chain contract with most logic off-chain | Rejected for the custody and reward paths, but *accepted* for queries and analytics — see [ADR-0002](./0002-off-chain-event-driven-indexing.md). |
+
+## Consequences
+
+### Positive
+
+- Custody transfers and reward distribution are verifiable by anyone, without trusting
+  the project's infrastructure.
+- Rust's type system catches a large class of errors before deployment, which matters
+  disproportionately for code that cannot be hot-patched.
+- Native to Stellar: no bridge, no second chain, no wrapped assets.
+
+### Negative
+
+- Steeper contributor ramp. Contributors comfortable with the TypeScript frontend
+  cannot necessarily work on the contract.
+- Deployed contract logic is expensive to change. Fixes require an upgrade flow rather
+  than a redeploy — see `docs/CONTRACT_UPGRADE_RUNBOOK.md`.
+- Storage is metered and rent-bearing, which constrains the schema in ways a
+  relational database does not — see [ADR-0004](./0004-contract-storage-key-layout.md).
+
+### Neutral
+
+- The contract owns state mutation; every read-heavy path is served off-chain
+  ([ADR-0002](./0002-off-chain-event-driven-indexing.md)).
+- Authorisation is delegated to Soroban's `require_auth`, which shapes the
+  authentication design ([ADR-0006](./0006-wallet-based-authentication-flow.md)).
+
+## Compliance
+
+Contract source lives in `stellar-contract/src/`. Any proposal to move custody or
+reward logic off-chain contradicts this ADR and needs a superseding one.

--- a/docs/adr/0002-off-chain-event-driven-indexing.md
+++ b/docs/adr/0002-off-chain-event-driven-indexing.md
@@ -1,0 +1,70 @@
+# ADR-0002: Serve queries from an off-chain event-driven indexer
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** [ADR-0001](./0001-use-soroban-for-smart-contracts.md), [ADR-0005](./0005-indexer-relational-schema.md)
+
+> Migrated from the inline ADR section of [ARCHITECTURE.md](../ARCHITECTURE.md), which
+> is where this decision was originally recorded.
+
+## Context
+
+With state on-chain ([ADR-0001](./0001-use-soroban-for-smart-contracts.md)), the
+product still needs to answer questions the ledger is bad at: "show this participant's
+history", "aggregate weight by material type this month", "full-text search
+participants".
+
+Soroban storage is a key-value store with metered reads. There is no query planner, no
+secondary index, and no aggregation. Answering those questions on-chain would mean
+maintaining hand-rolled indexes in contract storage and paying to walk them on every
+read.
+
+## Decision
+
+We will emit events from the contract for every state change, and run an off-chain
+indexer (`indexer/`) that consumes them into Postgres. All read-heavy and analytical
+queries are served from the indexer, not from the contract.
+
+The contract remains the authority. The indexer is a derived, rebuildable projection.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| Query the contract directly from the frontend | Every non-trivial query becomes an on-chain iteration with metered reads. Aggregations and search are impractical. |
+| Maintain query-optimised indexes in contract storage | Shifts the cost to write time and inflates rent for data that does not need consensus. Some minimal indexes exist regardless (`PART_IDX`, `("participant_wastes", …)`), but they are enumeration aids, not a query engine. |
+| Read directly from Horizon / RPC without an indexer | No aggregation, no joins, no search, and no stable schema for external consumers. |
+
+## Consequences
+
+### Positive
+
+- Contract stays smaller and cheaper; query complexity lives where it is cheap.
+- Full SQL: joins, aggregates, and Postgres full-text search (`search_vector` columns).
+- Analytics and dashboards do not add on-chain cost.
+- Because the indexer is derived, it can be rebuilt from `raw_events` after a handler
+  bug fix — this is what `POST /replay` exists for.
+
+### Negative
+
+- **Eventual consistency.** A write confirmed on-chain is not immediately visible via
+  the indexer. Clients that write and then read must account for the lag; `syncLag` on
+  `GET /metrics` exposes it.
+- Additional infrastructure to run and monitor: Postgres, the indexer process, alerting.
+- Reorgs must be detected and handled rather than ignored.
+- Two places can disagree. When they do, the chain wins and the indexer is rebuilt.
+
+### Neutral
+
+- Requires storing raw events durably so replay is possible — see
+  [ADR-0005](./0005-indexer-relational-schema.md).
+- The indexer's HTTP surface becomes a public API with its own compatibility
+  obligations — see [`docs/API_REFERENCE.md`](../API_REFERENCE.md).
+
+## Compliance
+
+Any feature that adds an on-chain iteration purely to answer a read query contradicts
+this ADR. The corresponding data should be projected into the indexer instead.
+Derived indexer state must always be reconstructible from `raw_events`; a handler that
+depends on data not present in the event stream breaks replay.

--- a/docs/adr/0003-percentage-based-reward-distribution.md
+++ b/docs/adr/0003-percentage-based-reward-distribution.md
@@ -1,0 +1,63 @@
+# ADR-0003: Distribute rewards by configurable percentage
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** [ADR-0004](./0004-contract-storage-key-layout.md)
+
+> Migrated from the inline ADR section of [ARCHITECTURE.md](../ARCHITECTURE.md), which
+> is where this decision was originally recorded.
+
+## Context
+
+A single recycled item passes through several hands: the recycler who submits it, one
+or more collectors who move it, and the manufacturer who consumes it. When the reward
+is paid, it has to be split among them.
+
+The split needs to be adjustable — the right incentive balance is an economic question
+that will not be answered correctly on the first try, and it may need to differ by
+market or by season.
+
+## Decision
+
+We will split rewards by configurable percentages held in contract storage, rather
+than by fixed amounts baked into the contract.
+
+The collector and owner shares are stored together in a single `RewardConfig` struct
+under the `RWD_CFG` instance key, and are set by admins via `set_percentages`.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| Fixed reward amounts per material type | Cannot respond to token price movements or changed incentive needs without a contract upgrade. |
+| Percentages hard-coded as constants | Same problem: tuning the economics would require redeploying. |
+| Two separate storage keys (`COL_PCT`, `OWN_PCT`) | This was the original layout. Consolidated into `RWD_CFG` so one storage read fetches both values, halving instance-storage lookups on every reward path. The old keys are unused and expire with the instance TTL; deployments upgraded from that layout must call `set_percentages` once. |
+
+## Consequences
+
+### Positive
+
+- The incentive structure can be tuned without a contract upgrade.
+- One storage read per reward calculation instead of two.
+- Splits are transparent on-chain and auditable after the fact.
+
+### Negative
+
+- **Admins can change payout economics.** This is real centralisation and it needs
+  governance: multi-sig approval (`MS_THRESH`, `AdminAction::SetPercentages`) exists
+  precisely because this decision creates the power to change what people get paid.
+- Participants may dispute a payout made under a percentage set after they submitted
+  material. An audit trail is required, not optional.
+- Percentage arithmetic needs care about rounding and about the sum of shares.
+
+### Neutral
+
+- Creates an ongoing admin responsibility rather than a set-and-forget parameter.
+- Percentage changes should be announced ahead of taking effect.
+
+## Compliance
+
+Reward splits are read from `RWD_CFG` in the reward path. A change that reintroduces
+hard-coded amounts, or that lets percentages be set outside the multi-sig admin flow,
+contradicts this ADR.

--- a/docs/adr/0004-contract-storage-key-layout.md
+++ b/docs/adr/0004-contract-storage-key-layout.md
@@ -1,0 +1,107 @@
+# ADR-0004: Tier contract storage by access pattern, with typed tuple keys
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** issue #758; [ADR-0001](./0001-use-soroban-for-smart-contracts.md); [`docs/DATABASE_SCHEMA.md`](../DATABASE_SCHEMA.md)
+
+## Context
+
+Soroban charges for storage in two ways that pull in opposite directions:
+
+1. **Read cost.** Instance storage is a single ledger entry. Every invocation loads it
+   in full, so anything placed there is paid for on *every* call, whether or not it is
+   read.
+2. **Rent and expiry.** Every entry has a TTL. Instance storage expires as a unit;
+   persistent entries expire individually and are archived; temporary entries expire
+   individually and are **deleted outright**.
+
+The contract has grown to well over a hundred distinct storage keys spanning config
+scalars, per-entity records, counters, indexes, and caches. Without a stated policy,
+each new feature picks a tier by local convenience, and the result is either an
+inflated per-call read cost or data placed somewhere it can be permanently lost.
+
+Soroban also caps `symbol_short!` keys at 9 characters, which forces abbreviation and
+makes keys easy to collide or mistype without a convention.
+
+## Decision
+
+We will assign storage to tiers by access pattern, and key entries with typed tuples.
+
+**Tier policy:**
+
+- **Instance** — small scalars and config read on most invocations (`ADMINS`,
+  `RWD_CFG`, `PAUSED`, `RE_GUARD`, counters), plus the bulk of per-entity records.
+  Kept deliberately small to hold down the base read fee.
+- **Persistent** — per-entity records that must survive independently of the instance
+  and that are acceptable to restore on demand (participant records via
+  `participant.rs`, compliance reports, performance snapshots, the search index).
+- **Temporary** — **caches only**. Nothing may live in temporary storage that cannot
+  be recomputed from a durable tier, because temporary expiry is unrecoverable.
+
+**Key policy:**
+
+- Config scalars use `Symbol` constants declared together at the top of `lib.rs`, each
+  with a comment naming the feature or issue that introduced it.
+- Per-entity records use tuple keys — `("waste", waste_id)`, `("stats", address)` —
+  rather than concatenated strings, avoiding string hashing on every access.
+- Every externally-invokable function calls `storage_utils::bump_instance` first,
+  extending the instance TTL by 518 400 ledgers (~30 days at 5 s/ledger).
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| A single `DataKey` enum for all keys, as in many Soroban examples | Clean in principle, but every variant addition changes the enum's XDR encoding, which is a migration risk across upgrades for a contract this broad. Independent `Symbol` constants and tuple keys let features be added without touching a shared type. |
+| Put everything in persistent storage | Loses the single-entry read efficiency of instance storage for the hot config path, and multiplies the number of entries paying rent individually. |
+| Put everything in instance storage | Every invocation would load the entire contract state. Read cost grows without bound as features are added. |
+| String-concatenated keys (`"waste_" + id`) | Pays string construction and hashing on every access, and makes key collisions a runtime surprise rather than a type error. |
+
+## Consequences
+
+### Positive
+
+- Per-invocation read cost stays bounded by keeping the hot set small.
+- Tuple keys are cheap and type-checked at the call site.
+- Because instance storage bumps as a unit, one `bump_instance` call keeps all
+  instance-keyed data alive — no per-key TTL bookkeeping in normal operation.
+- The "temporary is cache-only" rule makes temporary expiry a non-event: a miss always
+  falls back to a durable tier.
+
+### Negative
+
+- **The 9-character symbol limit forces cryptic names** (`RWD_CFG`, `MS_THRESH`,
+  `PXFR_CNT`). The mapping from constant name to on-chain symbol has to be documented
+  or the keys are unreadable.
+- **Renaming a key silently orphans data.** A read against a renamed key returns
+  `None` rather than erroring, so a rename that looks like a refactor is actually a
+  migration. This already happened once: `COL_PCT`/`OWN_PCT` → `RWD_CFG` required a
+  one-time `set_percentages` call after upgrade.
+- **A contract idle for more than ~30 days has its instance archived** and needs a
+  `RestoreFootprint` before the next call succeeds. Low-traffic deployments must plan
+  for this.
+- Tier assignment is a judgement call made per feature, so it can drift without review
+  discipline.
+
+### Neutral
+
+- Participant data is currently reachable through **two** paths: instance-keyed
+  `(address,)` in `lib.rs`, and persistent-keyed `("PART", address)` via
+  `participant.rs`. New code should prefer the `participant.rs` helpers. Consolidating
+  the two is outstanding work.
+- Application-level expiries (`waste_ttl`, transfer approval, proposal TTL) are
+  measured in **seconds against the ledger timestamp** and are independent of Soroban
+  storage TTLs, which are measured in **ledgers**. The two are easy to confuse.
+
+## Compliance
+
+The full key inventory, tier assignment, and TTL policy live in the
+[Storage Key Schema section of `docs/DATABASE_SCHEMA.md`](../DATABASE_SCHEMA.md#storage-key-schema).
+
+Reviewers should check that a PR adding storage:
+
+- declares its key as a documented constant or a tuple with a discriminator;
+- picks a tier consistent with the policy above — in particular, that nothing
+  irreplaceable is written to temporary storage;
+- updates `docs/DATABASE_SCHEMA.md` in the same PR;
+- treats any key rename as a migration with an explicit upgrade step.

--- a/docs/adr/0005-indexer-relational-schema.md
+++ b/docs/adr/0005-indexer-relational-schema.md
@@ -1,0 +1,100 @@
+# ADR-0005: Project events into a normalised Postgres schema, keeping raw events
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** [ADR-0002](./0002-off-chain-event-driven-indexing.md); `indexer/src/db/migrations/`; [`docs/API_REFERENCE.md`](../API_REFERENCE.md)
+
+## Context
+
+[ADR-0002](./0002-off-chain-event-driven-indexing.md) commits to serving queries from
+an off-chain projection of the contract's event stream. That leaves the shape of the
+projection open.
+
+The constraints:
+
+- Handlers will have bugs. When one is fixed, historical data must be reprocessable
+  without re-fetching the whole chain from Stellar.
+- Reorgs mean the same event can arrive more than once. Ingestion has to be idempotent.
+- The product needs relational queries (a participant's transfers, aggregates by
+  material type) and text search over participants and materials.
+- On-chain values are `u128` weights and `i128` microdegree coordinates, which do not
+  fit a 64-bit integer.
+
+## Decision
+
+We will use Postgres with a two-layer schema:
+
+1. **`raw_events`** — an append-only log of every event as received:
+   `ledger_sequence`, `ledger_close_time`, `transaction_hash`, `contract_id`,
+   `event_type`, `topic TEXT[]`, `value JSONB`. This is the replay source of truth
+   off-chain.
+2. **Projected tables** — `participants`, `wastes`, `waste_transfers`,
+   `token_rewards`, `auctions`, `carbon_credits`, plus operational tables
+   (`sync_status`, `alert_history`, `migrations`). These are derived and rebuildable.
+
+Supporting decisions:
+
+- **Idempotency** comes from a unique index on
+  `(transaction_hash, event_type, topic[1])`, so a replayed or reorg-duplicated event
+  cannot be double-inserted.
+- **Domain constraints are expressed as `CHECK`s** on `role`, `waste_type`, and
+  `severity`, mirroring the contract's enums.
+- **Search uses generated `TSVECTOR` columns** with GIN indexes on `participants` and
+  `wastes`, rather than a separate search service.
+- **Weights use `NUMERIC`**, not `BIGINT`, since on-chain values are `u128`.
+- **Migrations are plain sequential SQL** in `indexer/src/db/migrations/`, tracked in a
+  `migrations` table and applied by `migrate.ts`.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| Projected tables only, no `raw_events` | A handler bug would be unrecoverable without re-fetching history from Stellar. `raw_events` makes `POST /replay` a local operation. |
+| `raw_events` only, query the JSONB directly | No referential integrity, no cheap aggregation, and every consumer would have to know the event encoding. |
+| A document store (MongoDB, etc.) | The queries are relational — transfers join participants join wastes. Losing joins and constraints to gain schema flexibility is the wrong trade for a projection whose shape is dictated by the contract. |
+| Elasticsearch as the primary store | Kept as an optional add-on for advanced search (`docker-compose.elasticsearch.yml`), but Postgres full-text search covers the product's needs without a second stateful system in the critical path. |
+| An ORM with generated migrations | Plain SQL keeps the applied DDL reviewable and makes index and constraint intent explicit. |
+| `BIGINT` for weights | Overflows `u128` on-chain values. |
+
+## Consequences
+
+### Positive
+
+- Replay is a local operation: fix a handler, `POST /replay`, done.
+- Reorg-safe ingestion via the unique index, with no application-level dedup logic.
+- Real joins, aggregates, and full-text search with one stateful dependency.
+- Sequential SQL migrations are easy to review and to reason about in deploys.
+
+### Negative
+
+- **`raw_events` grows without bound** and is never pruned by the current schema. It is
+  the largest table and needs a retention or partitioning strategy as volume grows.
+- **Storage duplication:** every event is stored twice, once raw and once projected.
+- The `CHECK` constraints on `role` and `waste_type` **duplicate the contract's enums**.
+  Adding a variant on-chain requires a migration here, and forgetting it causes
+  ingestion to fail on the new value rather than degrade gracefully.
+- Generated `TSVECTOR` columns are recomputed on every write to those rows.
+- `BIGINT` and `NUMERIC` columns are returned as **strings** by the `pg` driver, which
+  surfaces in the public API and surprises consumers who expect JSON numbers.
+
+### Neutral
+
+- `wastes.recycler_address` has a foreign key to `participants(address)`, so
+  participant registration must be indexed before any waste referencing it. Out-of-order
+  ingestion has to be handled.
+- Projected tables can be dropped and rebuilt; `raw_events` cannot.
+
+## Compliance
+
+Schema changes go in a new numbered file in `indexer/src/db/migrations/` — never by
+editing an applied migration.
+
+Reviewers should check that a PR touching the indexer:
+
+- keeps every projected table reconstructible from `raw_events` alone. A handler that
+  depends on data not present in the event stream breaks replay and violates this ADR;
+- preserves the idempotency index when changing ingestion;
+- adds a matching migration when a contract enum gains a variant;
+- updates [`docs/API_REFERENCE.md`](../API_REFERENCE.md) when a column reaches the
+  public API surface.

--- a/docs/adr/0006-wallet-based-authentication-flow.md
+++ b/docs/adr/0006-wallet-based-authentication-flow.md
@@ -1,0 +1,105 @@
+# ADR-0006: Authenticate with wallet signatures; treat frontend session state as UI only
+
+- **Status:** Accepted
+- **Date:** Backfilled 2026-07-24; decision predates the ADR log
+- **Deciders:** Core contributors
+- **Related:** [ADR-0001](./0001-use-soroban-for-smart-contracts.md), [ADR-0002](./0002-off-chain-event-driven-indexing.md); `frontend/src/context/WalletContext.tsx`, `frontend/src/context/AuthContext.tsx`
+
+## Context
+
+Participants are identified by their Stellar address. Every state-changing action —
+registering, submitting material, transferring custody, confirming receipt — is a
+contract call made by that address.
+
+That means the question "is this user who they claim to be?" already has an answer at
+the contract boundary: Soroban's `require_auth` will reject the invocation unless the
+transaction carries a valid signature from the address in question. There are 62
+`require_auth` call sites in `stellar-contract/src/lib.rs`.
+
+The open question was whether to *also* build a conventional account system —
+credentials, server-issued sessions, a user table — on top of that.
+
+## Decision
+
+We will use **wallet signatures as the sole authentication mechanism**, and treat the
+frontend's notion of a logged-in user as **presentation state, not a security
+boundary**.
+
+Concretely:
+
+- **Wallet connection** is via the Freighter browser extension
+  (`@stellar/freighter-api`), managed by `WalletContext`. The connected address is
+  cached in `localStorage` under `wallet_address` so a page reload does not force a
+  reconnect.
+- **Authorisation is enforced on-chain.** Each contract function calls
+  `caller.require_auth()`. Privileged functions additionally check membership in the
+  `ADMINS` list via `only_admin`, which does `require_auth` *and* a membership test —
+  holding a key is not the same as being an admin.
+- **`AuthContext` holds display state only** — address, role, name, cached in
+  `localStorage` under `scavngr_user`. It gates what the UI renders. It is not
+  consulted by anything that enforces a security property.
+- **The indexer REST API is unauthenticated**, because it serves data that is already
+  public on-chain. Operators are expected to place any access control at the gateway.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| Email/password accounts with server sessions | Introduces credential storage, reset flows, and breach liability for an identity the chain already establishes cryptographically. It would also create a second identity to reconcile with the on-chain address. |
+| Sign-In-With-Stellar: sign a nonce, exchange for a JWT | The standard pattern, and worth revisiting **if** a server endpoint ever needs to authorise a caller. Today no such endpoint exists: writes go to the contract and reads are public. A token system with nothing to protect is attack surface without benefit. |
+| Custodial key management | Removes the wallet-install friction, but makes the project a custodian of user funds and identity. Wrong trade for a supply-chain tracking application. |
+| Authenticating the indexer API | The data is public on-chain; authenticating it protects nothing. **`POST /replay` is the exception** and is a genuine gap — see below. |
+
+## Consequences
+
+### Positive
+
+- No credential storage, no password reset flow, no session-fixation surface.
+- Authorisation cannot be bypassed by manipulating the client, because it is enforced
+  by the network, not by our code.
+- One identity end to end: the Stellar address is the user ID in the contract, the
+  indexer, and the UI.
+- Admin privilege is a membership test against on-chain state, so it survives a
+  compromised frontend.
+
+### Negative
+
+- **`localStorage` is readable by any script on the origin.** Only a public address is
+  stored, so there is no secret to steal — but an XSS that rewrites `wallet_address`
+  can mislead the UI about which account is active. The user is still protected at
+  signing time, because Freighter shows what is being signed and holds the key.
+- **`AuthContext` is trivially forgeable.** Writing a `scavngr_user` object into
+  `localStorage` makes the UI render as that user. This is acceptable *only* because
+  nothing security-relevant depends on it, and it stops being acceptable the moment a
+  server endpoint trusts it. That constraint is easy to violate accidentally.
+- **Freighter is a hard dependency** for any state-changing action. Users without the
+  extension can browse but cannot participate; mobile support is constrained by wallet
+  availability.
+- **`POST /replay` on the indexer is unauthenticated and mutating.** It re-dispatches
+  stored events through handlers that write derived tables. It must not be exposed to
+  the internet. This is a real gap in the current posture, documented in
+  [`docs/API_REFERENCE.md`](../API_REFERENCE.md) rather than fixed in code.
+- No server-side notion of a session means no server-side revocation, rate limiting per
+  user, or audit of "who was logged in" beyond what the chain records.
+
+### Neutral
+
+- `AuthContext` contains a placeholder comment about checking for a stored token. If a
+  token flow is ever added, it should arrive as a superseding ADR, not as an
+  incremental edit — the "frontend state is not a security boundary" invariant is the
+  thing most likely to be lost by accident.
+- The backend service carries `CSRF_SECRET` and `ALLOWED_ORIGINS` configuration for
+  its own endpoints; those are separate from this decision.
+
+## Compliance
+
+The invariant to protect: **no server-side or contract-side decision may depend on
+`AuthContext`, `scavngr_user`, or `wallet_address`.** Those are UI hints.
+
+Reviewers should check that a PR:
+
+- enforces new privileged contract functions with `require_auth`, and `only_admin`
+  where admin rights are required;
+- does not introduce a server endpoint that trusts a client-supplied address without a
+  signature check — that requires a superseding ADR;
+- does not place a mutating endpoint on the indexer without a plan for guarding it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,79 @@
+# Architecture Decision Records
+
+This is Scavngr's decision log. It records the architectural choices the project has
+made, why they were made, and what they cost — so that a change which quietly
+contradicts one is visible as such in review.
+
+An ADR is not documentation of how the system works; that lives in
+[`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) and its siblings. An ADR captures the
+*reasoning* that produced a design, including the alternatives that lost. That
+reasoning is the part that is otherwise lost when contributors move on.
+
+## Index
+
+| # | Title | Status | Area |
+|---|-------|--------|------|
+| [0001](./0001-use-soroban-for-smart-contracts.md) | Use Soroban and Rust for the on-chain contract | Accepted | Contract |
+| [0002](./0002-off-chain-event-driven-indexing.md) | Serve queries from an off-chain event-driven indexer | Accepted | Indexer |
+| [0003](./0003-percentage-based-reward-distribution.md) | Distribute rewards by configurable percentage | Accepted | Contract |
+| [0004](./0004-contract-storage-key-layout.md) | Tier contract storage by access pattern, with typed tuple keys | Accepted | Contract |
+| [0005](./0005-indexer-relational-schema.md) | Project events into a normalised Postgres schema, keeping raw events | Accepted | Indexer |
+| [0006](./0006-wallet-based-authentication-flow.md) | Authenticate with wallet signatures; treat frontend session state as UI only | Accepted | Frontend / Auth |
+
+Template: [`template.md`](./template.md)
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion; not yet binding |
+| **Accepted** | Binding. Code that contradicts it should be challenged in review |
+| **Deprecated** | No longer applies, and nothing replaced it |
+| **Superseded** | Replaced by a later ADR, which is linked from the header |
+
+## Writing a new ADR
+
+1. Copy [`template.md`](./template.md) to `NNNN-short-slug.md`, using the next unused
+   number.
+2. Fill it in. The **Alternatives Considered** and the negative half of
+   **Consequences** are the sections that earn the ADR its keep — an ADR with an empty
+   alternatives table has not recorded a decision, only an outcome.
+3. Add a row to the index above.
+4. Open the PR with the change the ADR justifies, or on its own if the decision comes
+   first.
+
+## Amending an ADR
+
+Accepted ADRs are immutable in substance. If a decision changes, write a new ADR and
+set the old one's status to `Superseded by [ADR-NNNN]`. Do not rewrite history — the
+value of the log is that it records what was believed at the time, including what
+turned out to be wrong.
+
+Correcting a typo, a broken link, or a statement that was factually wrong about the
+code is an edit, not a supersession.
+
+## When to write one
+
+Write an ADR for decisions that are expensive to reverse, or that a future contributor
+could plausibly undo without realising it was a decision at all:
+
+- on-chain storage layout and tiering
+- database schema shape and migration strategy
+- trust boundaries and authentication
+- protocol, network, or major dependency commitments
+- anything where the obvious-looking change is the wrong one
+
+Do not write one for routine implementation choices, library version bumps, or
+decisions that are cheap to revisit.
+
+## A note on numbering
+
+ADRs 0001–0003 were originally recorded inline in `docs/ARCHITECTURE.md` and were
+migrated here when this log was created, keeping their original numbering. ADRs
+0004–0006 were backfilled at the same time for decisions that had never been written
+down: contract storage keys, the indexer schema, and the authentication flow.
+
+Backfilled ADRs carry a "Backfilled" note in their date field. Their Context sections
+reconstruct the reasoning from the code and from the constraints in force at the time;
+where the original discussion is not recoverable, they say what the code implies
+rather than inventing a debate that may not have happened.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,71 @@
+# ADR-NNNN: Short present-tense title
+
+- **Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNNN (link it)
+- **Date:** YYYY-MM-DD
+- **Deciders:** Names or roles
+- **Related:** Issues, PRs, or other ADRs
+
+## Context
+
+What is the situation that forces a decision? State the constraints, the pressures,
+and what was true at the time. This section should be readable by someone who joins
+the project a year from now and has no memory of the discussion.
+
+Avoid describing the solution here. If a reader cannot tell from this section *why*
+a decision was needed, the ADR has not done its job.
+
+## Decision
+
+State the decision in the active voice: "We will …".
+
+Be specific enough that someone can tell whether a future change contradicts it. A
+decision that cannot be violated is not a decision worth recording.
+
+## Alternatives Considered
+
+| Alternative | Why it was rejected |
+|-------------|---------------------|
+| … | … |
+
+Record the options that were genuinely on the table, and why each lost. This is the
+part that saves the most time later, because it stops the project from relitigating
+settled ground.
+
+## Consequences
+
+### Positive
+
+- What this buys us.
+
+### Negative
+
+- What it costs us. Be honest — an ADR with no negative consequences is either
+  trivial or dishonest.
+
+### Neutral
+
+- Follow-on work, changed constraints, or things that are now true and simply need to
+  be known.
+
+## Compliance
+
+How would someone reviewing a PR know whether it honours or violates this decision?
+Point at the code, the tests, or the docs that encode it.
+
+---
+
+## Notes on using this template
+
+- **Numbering** is sequential and permanent. Copy this file to `NNNN-slug.md` using
+  the next unused number and never renumber.
+- **ADRs are immutable once accepted.** If a decision changes, write a new ADR that
+  supersedes the old one and update the old one's status to
+  `Superseded by [ADR-NNNN]`. Do not edit the original's Decision section — the value
+  of the log is that it records what was believed at the time.
+- **Correcting the record** is fine: fixing a typo, a broken link, or a factually wrong
+  statement about the code is an edit, not a supersession.
+- **Scope.** Write an ADR for decisions that are expensive to reverse or that a future
+  contributor could plausibly undo by accident: storage layout, schema shape, trust
+  boundaries, protocol choices, dependency commitments. Do not write one for routine
+  implementation choices.
+- Delete this "Notes" section from real ADRs.


### PR DESCRIPTION
## Summary

Establishes an ADR log at `docs/adr/` with a template and index, backfills ADRs for the three undocumented decisions named in the issue, and links the log from `docs/ARCHITECTURE.md`.

Closes #862

## What was added

**`docs/adr/README.md`** — the index, plus the operating rules: status vocabulary (Proposed / Accepted / Deprecated / Superseded), how to write and number a new ADR, how to supersede one without rewriting history, and when a decision is worth an ADR at all versus a routine implementation choice.

**`docs/adr/template.md`** — the template. It leans on **Alternatives Considered** and the negative half of **Consequences**, on the view that an ADR with an empty alternatives table has recorded an outcome rather than a decision.

**The three backfilled ADRs the issue asks for:**

| # | Decision | What it captures |
|---|---|---|
| [0004](docs/adr/0004-contract-storage-key-layout.md) | Contract storage key layout | Tiering by access pattern (instance / persistent / temporary), the "temporary is cache-only" rule, typed tuple keys, the 9-character `symbol_short!` limit, the ~30-day instance TTL bump, and why a key rename is a migration rather than a refactor |
| [0005](docs/adr/0005-indexer-relational-schema.md) | Indexer relational schema | `raw_events` as the off-chain replay source, projected rebuildable tables, the `(transaction_hash, event_type, topic[1])` idempotency index for reorg safety, `NUMERIC` for `u128` weights, generated `TSVECTOR` search columns |
| [0006](docs/adr/0006-wallet-based-authentication-flow.md) | Wallet-based authentication | Freighter signatures with `require_auth` at the contract boundary, and the invariant that `AuthContext` / `localStorage` state is presentation only and never a security boundary |

## One judgment call worth flagging

`docs/ARCHITECTURE.md` already carried three ADRs inline, numbered **ADR-001 to ADR-003**. Numbering the new backfills 0001–0003 would have left the repo with two conflicting schemes; numbering them 0004–0006 while leaving the originals inline would have left the log incomplete and the numbering unexplained either way.

So the three inline ADRs are **migrated into the log as 0001–0003, keeping their original numbers**, and `ARCHITECTURE.md`'s ADR section becomes a summary table linking out. Their content is expanded from the original bullet lists with the alternatives and consequences those lists omitted — for example, ADR-0003 now states plainly that configurable percentages mean admins can change payout economics, which is why the multi-sig `AdminAction::SetPercentages` flow exists.

That is slightly more than the issue's three files. It seemed the better of the available options, but it is the one part of this PR that is a call rather than a requirement — happy to split the migration into its own PR and land the backfills alone if reviewers prefer.

## Notes

- Backfilled ADRs are marked as such in their date field. Their Context sections reconstruct the reasoning from the code and the constraints in force at the time; where the original discussion isn't recoverable, they say what the code implies rather than inventing a debate that may not have happened.
- Several ADRs record known gaps rather than papering over them: the duplicate participant storage paths (`lib.rs` instance-keyed vs `participant.rs` persistent-keyed) in 0004, unbounded `raw_events` growth in 0005, and unauthenticated `POST /replay` in 0006.
- ADR-0004 links to `DATABASE_SCHEMA.md#storage-key-schema`, a section added by the PR for #865. Both target `main`; the anchor resolves once either lands, and the link is to the file regardless.

## Verification

All relative links across `docs/adr/*.md` and the modified `ARCHITECTURE.md` section were resolved against the filesystem — no broken targets.

## Acceptance criteria

- [x] ADR template + index created
- [x] 3 backfilled ADRs (0004 storage keys, 0005 indexer schema, 0006 auth flow) — plus 0001–0003 migrated from `ARCHITECTURE.md`
- [x] ADRs linked from `docs/ARCHITECTURE.md`
- [x] Tested (n/a — docs review)
- [ ] Code review passed
- [x] Related tests passing (no code changed)
