### PR TITLE
docs: consolidate developer setup into a single canonical guide

### DIFF
--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -1,6 +1,11 @@
 SCAVNGR - QUICK START GUIDE
 ===========================
 
+NOTE: This is a contract-only cheat sheet. The canonical setup guide covering
+      contracts, indexer, frontend, backend, and mobile is:
+
+        docs/DEVELOPER_ONBOARDING.md
+
 1. VERIFY SETUP
    Windows: .\scripts\verify-setup.ps1
    Linux/Mac: ./scripts/verify-setup.sh

--- a/README.md
+++ b/README.md
@@ -45,81 +45,26 @@ Scavenger/
 - **Role Validation**: Permission checks for different actions
 - **Soroban Storage**: Efficient on-chain data storage
 
-## Prerequisites
-
-- Rust 1.70+ with `wasm32-unknown-unknown` target
-- Soroban CLI
-- Stellar account with XLM (for deployment)
-
-## Installation
+## Getting Started
 
 ```bash
-# Install Rust
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Add WASM target
-rustup target add wasm32-unknown-unknown
-
-# Install Soroban CLI
-cargo install --locked soroban-cli --features opt
+git clone https://github.com/YOUR_USERNAME/Scavenger.git
+cd Scavenger
+cp frontend/.env.example .env
+docker compose up -d
 ```
 
-## Build
+That brings up Stellar standalone, Postgres, Redis, the backend, the indexer, and the
+frontend. You still need to deploy the contract and set `CONTRACT_ID` before contract
+calls work.
 
-```bash
-# Build the contract
-cargo build --release
+➡️ **[Developer Onboarding Guide](docs/DEVELOPER_ONBOARDING.md#development-environment-setup)** — the canonical setup path
 
-# Build WASM
-cd stellar-contract
-cargo build --target wasm32-unknown-unknown --release
+It covers prerequisites, both the Docker and run-it-directly paths, every environment
+variable, per-component run commands, a verification checklist, and troubleshooting
+for contracts, indexer, frontend, backend, and mobile.
 
-# Optimize WASM
-soroban contract optimize \
-  --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.wasm
-```
-
-## Testing
-
-```bash
-# Run all tests
-cargo test
-
-# Run tests with output
-cargo test -- --nocapture
-```
-
-## Deployment
-
-### Local (Standalone Network)
-
-```bash
-# Start Stellar standalone
-docker run --rm -it -p 8000:8000 \
-  stellar/quickstart:latest --standalone --enable-soroban-rpc
-
-# Deploy contract
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.optimized.wasm \
-  --source <YOUR_SECRET_KEY> \
-  --network standalone
-```
-
-### Testnet
-
-```bash
-# Generate keypair
-soroban keys generate testnet-deployer
-
-# Fund account
-curl "https://friendbot.stellar.org?addr=$(soroban keys address testnet-deployer)"
-
-# Deploy
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.optimized.wasm \
-  --source testnet-deployer \
-  --network testnet
-```
+Related: [Docker specifics](docs/DEV_ENVIRONMENT.md) · [Contributing](CONTRIBUTING.md) · [Architecture](docs/ARCHITECTURE.md) · [API Reference](docs/API_REFERENCE.md)
 
 ## Contract API
 
@@ -179,22 +124,10 @@ pub enum ParticipantRole {
 
 ## Environment Variables
 
-Copy `frontend/.env.example` to `frontend/.env` and fill in the values.
+There are separate env files for the root/compose stack, the frontend, the indexer,
+and the mobile app. All of them are documented in one place:
 
-| Variable | Required | Description |
-|---|---|---|
-| `VITE_CONTRACT_ID` | ✅ | Deployed Soroban contract ID |
-| `VITE_NETWORK` | ✅ | Stellar network: `TESTNET`, `MAINNET`, `FUTURENET`, or `STANDALONE` |
-| `VITE_RPC_URL` | ✅ | Soroban RPC endpoint URL |
-| `VITE_FIREBASE_API_KEY` | ✅ | Firebase project API key |
-| `VITE_FIREBASE_AUTH_DOMAIN` | ✅ | Firebase auth domain |
-| `VITE_FIREBASE_PROJECT_ID` | ✅ | Firebase project ID |
-| `VITE_FIREBASE_STORAGE_BUCKET` | ✅ | Firebase storage bucket |
-| `VITE_FIREBASE_MESSAGING_SENDER_ID` | ✅ | Firebase messaging sender ID |
-| `VITE_FIREBASE_APP_ID` | ✅ | Firebase app ID |
-| `VITE_FIREBASE_MEASUREMENT_ID` | ✅ | Firebase measurement ID |
-
-The app validates `VITE_CONTRACT_ID`, `VITE_NETWORK`, and `VITE_RPC_URL` at startup and will throw a clear error if any are missing or invalid.
+➡️ **[Developer Onboarding — Environment Variables](docs/DEVELOPER_ONBOARDING.md#environment-variables)**
 
 ## Development
 
@@ -208,6 +141,9 @@ cargo clippy
 # Watch for changes
 cargo watch -x test
 ```
+
+Per-component build, run, and test commands are in the
+[Local Run Commands](docs/DEVELOPER_ONBOARDING.md#local-run-commands) table.
 
 ## CI/CD
 

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -2,11 +2,24 @@
 
 Welcome to the Scavngr codebase. This guide gets you from zero to a running local environment and your first pull request.
 
+> **This is the canonical setup guide.** Setup steps for the contract, indexer,
+> frontend, backend, and mobile app all live here. Component READMEs cover what is
+> specific to that component and link back here for setup rather than repeating it.
+> If you find setup instructions duplicated elsewhere, that is a bug — please replace
+> them with a link to this guide.
+
 ---
 
 ## Table of Contents
 
 1. [Development Environment Setup](#development-environment-setup)
+   - [Prerequisites](#prerequisites)
+   - [Path A: Docker (recommended)](#path-a-docker-recommended)
+   - [Path B: Running components directly](#path-b-running-components-directly)
+   - [Environment Variables](#environment-variables)
+   - [Local Run Commands](#local-run-commands)
+   - [Verifying Setup](#verifying-setup)
+   - [Setup Troubleshooting](#setup-troubleshooting)
 2. [Project Structure Overview](#project-structure-overview)
 3. [Development Workflow](#development-workflow)
 4. [Coding Standards](#coding-standards)
@@ -20,16 +33,43 @@ Welcome to the Scavngr codebase. This guide gets you from zero to a running loca
 
 ## Development Environment Setup
 
-### Required Tools
+There are two ways to get running. **Path A (Docker)** brings up every service with
+one command and is what most contributors should use. **Path B** runs components
+directly on your machine, which you will want for the component you are actively
+working on.
+
+The two compose: a common setup is Docker for the dependencies (Stellar, Postgres,
+Redis) and Path B for whichever component you are editing.
+
+### Prerequisites
+
+**Everyone needs:**
 
 | Tool | Version | Install |
 |---|---|---|
-| Rust | stable (1.70+) | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
-| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
-| Soroban CLI | latest | `cargo install --locked soroban-cli` |
-| Node.js | 18+ | https://nodejs.org (LTS) |
-| Docker Desktop | 24+ | https://docker.com |
 | Git | 2.40+ | https://git-scm.com |
+| Docker Desktop | 24+ | https://docker.com — needs Compose v2 (`docker compose version`) |
+
+**Additionally, by component:**
+
+| Component | Tool | Version | Install |
+|---|---|---|---|
+| Contract | Rust | stable (1.70+) | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| Contract | wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| Contract | Soroban CLI | latest | `cargo install --locked soroban-cli --features opt` |
+| Indexer | Node.js | 18+ | https://nodejs.org (LTS) |
+| Indexer | PostgreSQL | 14+ | Provided by Docker; only needed natively for Path B |
+| Frontend | Node.js | 18+ | https://nodejs.org (LTS) |
+| Frontend | Freighter wallet | latest | https://freighter.app — browser extension, required for contract calls |
+| Backend | Rust | stable (1.70+) | as above |
+| Mobile | Node.js | 18+ | https://nodejs.org (LTS) |
+| Mobile | React Native CLI | latest | `npm install -g react-native-cli` |
+| Mobile | Xcode | latest | iOS builds only (macOS) |
+| Mobile | Android Studio | latest | Android builds only |
+| Perf tests | k6 | latest | https://k6.io — only for `performance/` |
+
+The repo pins its Rust toolchain in `rust-toolchain.toml`, so `rustup` will select the
+right version automatically the first time you build.
 
 ### Recommended VS Code Extensions
 
@@ -46,56 +86,279 @@ Welcome to the Scavngr codebase. This guide gets you from zero to a running loca
 }
 ```
 
-### First-Time Setup
+### Clone and fork
+
+Do this once, whichever path you take:
 
 ```bash
 # 1. Fork the repo on GitHub, then clone your fork
 git clone https://github.com/YOUR_USERNAME/Scavenger.git
 cd Scavenger
 
-# 2. Add upstream remote
+# 2. Add the upstream remote so you can sync later
 git remote add upstream https://github.com/Xoulomon/Scavenger.git
+```
 
-# 3. Copy environment template
+### Path A: Docker (recommended)
+
+Brings up Stellar standalone, Postgres, Redis, the backend, the indexer, and the
+frontend together.
+
+```bash
+# 1. Create the root .env used by docker compose
 cp frontend/.env.example .env
+# Only the Firebase vars need real values for local dev; the compose file
+# substitutes dev stubs for anything you leave unset, and overrides the
+# Stellar vars to point at the local standalone network.
 
-# 4. Start all services (Stellar standalone + backend + frontend + DB)
+# 2. Start everything
 docker compose up -d
 
-# 5. Wait ~30 seconds for Stellar to initialise, then check health
+# 3. Stellar needs ~30 s to initialise. Watch until all services are healthy:
 docker compose ps
-curl http://localhost:8000/health  # Stellar standalone
-curl http://localhost:8080/health  # Backend API
-curl http://localhost:5173         # Frontend
+```
 
-# 6. Deploy the contract locally (see DEV_ENVIRONMENT.md for full details)
+Once up:
+
+| Service | URL | Notes |
+|---|---|---|
+| Stellar standalone | http://localhost:8000 | Horizon API + Soroban RPC + friendbot |
+| Frontend | http://localhost:5173 | Vite dev server with HMR |
+| Backend | http://localhost:8080 | Rust / Actix-web API |
+| Indexer | http://localhost:3001 | Event indexer + REST API |
+| PostgreSQL | localhost:5432 | user `scavngr`, password `scavngr_dev`, db `scavngr` |
+| Redis | localhost:6379 | Cache / job queue |
+
+**Then deploy the contract**, which nothing else can do for you:
+
+```bash
+# Generate a keypair and fund it from the local friendbot
 soroban keys generate local-deployer --network standalone
 curl "http://localhost:8000/friendbot?addr=$(soroban keys address local-deployer)"
 
-cd stellar-contract
+# Build and deploy
 cargo build --target wasm32-unknown-unknown --release
 soroban contract deploy \
   --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.optimized.wasm \
   --source local-deployer \
   --network standalone
+
+# Record the returned contract ID and restart the services that consume it
+echo "CONTRACT_ID=<returned-id>" >> .env
+docker compose up -d --force-recreate indexer frontend
 ```
+
+Until `CONTRACT_ID` is set, the frontend and indexer start but every contract call
+fails. This is the single most common "my setup is broken" cause.
+
+For Docker-specific details — hot reload, seed data, port overrides, per-container
+shells — see [DEV_ENVIRONMENT.md](./DEV_ENVIRONMENT.md).
+
+### Path B: Running components directly
+
+Each block below assumes you have cloned the repo and are at its root. If you are not
+running the full Docker stack, start at least its dependencies first:
+
+```bash
+docker compose up -d stellar postgres redis
+```
+
+#### Contract (`stellar-contract/`)
+
+```bash
+# Build (native, for tests)
+cargo build --release
+
+# Build WASM
+cargo build --target wasm32-unknown-unknown --release
+
+# Optimise the WASM artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.wasm
+
+# Test
+cargo test
+```
+
+Deploying to testnet instead of standalone:
+
+```bash
+soroban keys generate testnet-deployer
+curl "https://friendbot.stellar.org?addr=$(soroban keys address testnet-deployer)"
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/stellar_scavngr_contract.optimized.wasm \
+  --source testnet-deployer \
+  --network testnet
+```
+
+#### Indexer (`indexer/`)
+
+```bash
+cd indexer
+npm install
+cp .env.example .env
+# Set CONTRACT_ID to the ID you deployed above. DATABASE_URL must point at a
+# reachable Postgres; the Docker one is
+#   postgresql://scavngr:scavngr_dev@localhost:5432/scavngr
+
+npm run migrate   # apply SQL migrations (also runs automatically on start)
+npm run dev       # ts-node, watches src/
+```
+
+The indexer refuses to start without `STELLAR_RPC_URL` and `CONTRACT_ID`.
+
+#### Frontend (`frontend/`)
+
+```bash
+cd frontend
+npm install
+cp .env.example .env
+# Set VITE_CONTRACT_ID, VITE_NETWORK, VITE_RPC_URL
+
+npm run dev       # http://localhost:5173
+```
+
+The app validates `VITE_CONTRACT_ID`, `VITE_NETWORK`, and `VITE_RPC_URL` at startup and
+fails loudly if any is missing or malformed. Install the
+[Freighter](https://freighter.app) extension before trying any action that signs a
+transaction.
+
+#### Backend (`backend/`)
+
+```bash
+cd backend
+cargo run
+# Reads the root .env; see the Environment Variables section below.
+```
+
+#### Mobile (`mobile/`)
+
+```bash
+cd mobile
+npm install
+cp .env.example .env 2>/dev/null || cat > .env <<'ENVEOF'
+REACT_APP_API_URL=http://localhost:8080
+REACT_APP_CONTRACT_ID=your_contract_id
+REACT_APP_NETWORK=testnet
+ENVEOF
+
+npm start                 # Metro bundler
+npm run ios               # iOS simulator (macOS only)
+npm run android           # Android emulator
+```
+
+### Environment Variables
+
+There are **three** env files, and they are not interchangeable. Copy each from its
+own template.
+
+| File | Template | Consumed by |
+|---|---|---|
+| `.env` (repo root) | `frontend/.env.example` | `docker compose`, backend |
+| `frontend/.env` | `frontend/.env.example` | Vite dev server (Path B only) |
+| `indexer/.env` | `indexer/.env.example` | Indexer process (Path B only) |
+| `mobile/.env` | — (see the mobile block above) | React Native app |
+
+> The root `.env` is seeded from `frontend/.env.example` because compose passes the
+> `VITE_*` values through to the frontend container. That is why the same template
+> serves two files.
+
+**Frontend — `VITE_*`** (`frontend/.env.example`):
+
+| Variable | Required | Description |
+|---|---|---|
+| `VITE_CONTRACT_ID` | ✅ | Deployed Soroban contract ID |
+| `VITE_NETWORK` | ✅ | `TESTNET`, `MAINNET`, `FUTURENET`, or `STANDALONE` |
+| `VITE_RPC_URL` | ✅ | Soroban RPC endpoint |
+| `VITE_FIREBASE_API_KEY` | ✅ | Firebase project API key |
+| `VITE_FIREBASE_AUTH_DOMAIN` | ✅ | Firebase auth domain |
+| `VITE_FIREBASE_PROJECT_ID` | ✅ | Firebase project ID |
+| `VITE_FIREBASE_STORAGE_BUCKET` | ✅ | Firebase storage bucket |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | ✅ | Firebase messaging sender ID |
+| `VITE_FIREBASE_APP_ID` | ✅ | Firebase app ID |
+| `VITE_FIREBASE_MEASUREMENT_ID` | ✅ | Firebase measurement ID |
+| `VITE_PINATA_JWT` | — | Pinata IPFS token; omit to use the dev stub |
+
+Under Docker, every `VITE_FIREBASE_*` value falls back to `dev-stub`, so you can bring
+the stack up before you have a Firebase project.
+
+**Indexer** (`indexer/.env.example`):
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DATABASE_URL` | ✅ | `postgresql://localhost/scavenger` | Postgres connection string |
+| `STELLAR_RPC_URL` | ✅ | — | Soroban RPC endpoint; startup fails without it |
+| `CONTRACT_ID` | ✅ | — | Contract to index; startup fails without it |
+| `NETWORK_PASSPHRASE` | ✅ | — | Must match the network |
+| `START_LEDGER` | — | `0` | Ledger to begin indexing from |
+| `POLL_INTERVAL_MS` | — | `5000` | RPC poll interval |
+| `API_HOST` | — | `0.0.0.0` | REST API bind address |
+| `API_PORT` | — | `3001` | REST API port |
+| `DB_MAX_CONNECTIONS` | — | `20` | Connection pool size |
+| `LOG_LEVEL` / `LOG_FORMAT` | — | `info` / `json` | Logging |
+
+**Backend** (root `.env.example`) — server, security, email, storage, search,
+rate limiting, and archival settings. `CSRF_SECRET` and `ALLOWED_ORIGINS` must be set
+for anything beyond local development. See `.env.example` for the annotated list.
+
+**Never commit a populated `.env`.** All four paths are gitignored; keep it that way.
+
+### Local Run Commands
+
+| Component | Install | Run | Test | Lint / Format |
+|---|---|---|---|---|
+| Contract | — | `soroban contract deploy …` | `cargo test` | `cargo fmt`, `cargo clippy` |
+| Indexer | `cd indexer && npm install` | `npm run dev` | `npm test` | — |
+| Frontend | `cd frontend && npm install` | `npm run dev` | `npm test` | `npm run lint`, `npm run format` |
+| Backend | — | `cd backend && cargo run` | `cargo test` | `cargo fmt`, `cargo clippy` |
+| Mobile | `cd mobile && npm install` | `npm start` | `npm test` | `npm run lint` |
+| Full stack | — | `docker compose up -d` | — | — |
+
+Component-specific test suites (integration, security, performance, E2E) have their
+own READMEs — they assume this environment is already up:
+
+- [`integration-tests/README.md`](../integration-tests/README.md)
+- [`security-tests/README.md`](../security-tests/README.md)
+- [`performance/README.md`](../performance/README.md)
+- [`docs/E2E_TESTING.md`](./E2E_TESTING.md)
 
 ### Verifying Setup
 
-```bash
-# Contract compiles
-cargo build --target wasm32-unknown-unknown --release
+Run these in order. Each should succeed before you move to the next.
 
-# All tests pass
+```bash
+# 1. Contract compiles and its tests pass
+cargo build --target wasm32-unknown-unknown --release
 cargo test
 
-# Frontend starts
-cd frontend && npm install && npm run dev
-# Open http://localhost:5173
+# 2. Docker stack is healthy (Path A)
+docker compose ps          # every service "healthy" or "running"
+curl -sf http://localhost:8000/friendbot?addr=test | head -c 1   # Stellar up
+curl -sf http://localhost:8080/health                            # Backend
+curl -sf http://localhost:3001/health                            # Indexer
 
-# Indexer runs
-cd indexer && npm install && npm run dev
+# 3. Frontend serves
+curl -sf http://localhost:5173 >/dev/null && echo "frontend ok"
+
+# 4. Contract is deployed and reachable
+soroban contract invoke --id "$CONTRACT_ID" --network standalone -- get_metrics
 ```
+
+You have a working environment when step 4 returns metrics rather than an error.
+
+### Setup Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Contract calls fail; UI loads fine | `CONTRACT_ID` unset or stale | Deploy the contract, put the ID in `.env`, `docker compose up -d --force-recreate indexer frontend` |
+| Indexer exits immediately on start | `STELLAR_RPC_URL` or `CONTRACT_ID` missing | Both are required; the process throws at startup by design |
+| Stellar container unhealthy for ~30 s | Normal — it initialises slowly | Wait. Other services gate on it via `depends_on` health checks |
+| Port already in use | Something else owns 5173/8000/8080/3001/5432/6379 | Override the port in a `docker-compose.override.yml` (example in [DEV_ENVIRONMENT.md](./DEV_ENVIRONMENT.md)) |
+| `wasm32-unknown-unknown` target not found | Target not installed | `rustup target add wasm32-unknown-unknown` |
+| Frontend throws on startup about env vars | A required `VITE_*` is missing or malformed | Validation is deliberate; fill in `frontend/.env` |
+| "Freighter is not installed" | Extension missing | Install from https://freighter.app and reload |
+| Postgres connection refused from a native indexer | Using the Docker-internal hostname | Use `localhost:5432` from the host, `postgres:5432` from inside a container |
+| Stale state after schema changes | Old volumes | `docker compose down -v` then `docker compose up -d` (destroys all local data) |
 
 ---
 

--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -1,5 +1,10 @@
 # Development Environment — #484
 
+> **Start with the [Developer Onboarding Guide](./DEVELOPER_ONBOARDING.md#development-environment-setup)**,
+> which is the canonical setup path for all components. This document is the
+> Docker-specific reference: service URLs, hot reload, seed data, container shells,
+> and port overrides.
+
 ## Prerequisites
 
 - Docker Desktop ≥ 24 (or Docker Engine + Compose plugin v2)

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -52,22 +52,19 @@ This test suite includes 15+ integration tests covering:
 
 ## Setup
 
-### Prerequisites
+These tests run against a live environment. Set one up using the canonical guide
+first — Node.js, Docker, the Stellar network, Postgres, and the deployed contract are
+all covered there:
 
-- Node.js 18+
-- Running Scavenger API
-- Running Stellar testnet or standalone network
-- PostgreSQL database (for backend)
+➡️ **[Developer Onboarding Guide](../docs/DEVELOPER_ONBOARDING.md#development-environment-setup)**
 
-### Installation
+Then install and configure this suite:
 
 ```bash
 npm install
 ```
 
-### Configuration
-
-Create `.env` file:
+Create a `.env` in this directory pointing at your running environment:
 
 ```env
 API_URL=http://localhost:3000/api
@@ -75,6 +72,10 @@ CONTRACT_ID=your-contract-id
 DATABASE_URL=postgresql://user:password@localhost:5432/scavenger
 STELLAR_NETWORK=testnet
 ```
+
+Set `CONTRACT_ID` to the contract you deployed during setup. If you brought the stack
+up with `docker compose`, `DATABASE_URL` is
+`postgresql://scavngr:scavngr_dev@localhost:5432/scavngr`.
 
 ## Running Tests
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -10,19 +10,15 @@ React Native mobile application for iOS and Android platforms.
 - **Profile Management**: Manage participant profile and settings
 - **Real-time Updates**: Receive notifications for waste transfers and rewards
 
-## Prerequisites
+## Setup
 
-- Node.js 16+
-- React Native CLI
-- Xcode (for iOS development)
-- Android Studio (for Android development)
+Prerequisites, environment variables, and first-time setup for the mobile app are in
+the canonical guide:
 
-## Installation
+➡️ **[Developer Onboarding Guide — Mobile](../docs/DEVELOPER_ONBOARDING.md#mobile-mobile)**
 
-```bash
-cd mobile
-npm install
-```
+The mobile app talks to the backend and the deployed contract, so bring the rest of
+the stack up first — that is covered in the same guide.
 
 ## Development
 
@@ -73,13 +69,7 @@ src/
 
 ## Environment Variables
 
-Create a `.env` file in the mobile directory:
-
-```
-REACT_APP_API_URL=http://localhost:8080
-REACT_APP_CONTRACT_ID=your_contract_id
-REACT_APP_NETWORK=testnet
-```
+See [Developer Onboarding — Environment Variables](../docs/DEVELOPER_ONBOARDING.md#environment-variables).
 
 ## Testing
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -18,6 +18,10 @@ We use [k6](https://k6.io/) for load, stress, and endurance testing.
 
 ## Running Tests
 
+Requires a running environment (see the
+[Developer Onboarding Guide](../docs/DEVELOPER_ONBOARDING.md#development-environment-setup))
+plus [k6](https://k6.io) installed locally.
+
 To run the full suite:
 ```bash
 ./performance/run-perf-tests.sh

--- a/security-tests/README.md
+++ b/security-tests/README.md
@@ -15,13 +15,14 @@ This directory contains security tests covering:
 
 ## Setup
 
-### Prerequisites
+Base environment setup (Node.js, Docker, running services) is in the canonical guide:
 
-- Node.js 18+
-- OWASP ZAP (optional, for automated scanning)
-- curl or Postman for API testing
+➡️ **[Developer Onboarding Guide](../docs/DEVELOPER_ONBOARDING.md#development-environment-setup)**
 
-### Installation
+Additional tools for this suite only:
+
+- OWASP ZAP — optional, for automated scanning
+- curl or Postman — for manual API probing
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary

Makes `docs/DEVELOPER_ONBOARDING.md` the single canonical setup path for contracts, frontend, indexer, backend, and mobile, and removes the duplicated instructions that were spread across the root README, `DEV_ENVIRONMENT.md`, `QUICKSTART.txt`, and four component READMEs.

Closes #863

## The problem

Setup instructions existed in seven places, each covering a different subset and disagreeing on the details. The root README told you to install Rust and deploy a contract but never mentioned the indexer or Docker. `DEV_ENVIRONMENT.md` gave you the Docker stack but not the contract toolchain. `mobile/README.md` said Node 16+ where everything else said 18+. The frontend env table lived in the root README, the indexer's variables were only in `indexer/.env.example`, and nothing explained that the root `.env` and `frontend/.env` are different files seeded from the same template.

A new contributor had no way to know which page was current, and no page got them all the way to a working environment.

## What the canonical guide now covers

- **Prerequisites** split into what everyone needs versus what each component needs. This surfaced several that were previously undocumented anywhere: the **Freighter extension** (without it no action that signs a transaction works), React Native CLI, k6 for the performance suite, and Postgres for running the indexer natively. Node version is now consistent at 18+.
- **Two paths.** Path A brings up the full Docker stack; Path B runs a component directly. The guide states that they compose — Docker for dependencies, native for whatever you are editing — which is what people actually do but nothing said.
- **Environment variables**, all of them, with a table making clear that root `.env`, `frontend/.env`, and `indexer/.env` are three distinct files, and explaining why the root one is seeded from `frontend/.env.example` (compose passes `VITE_*` through). Required-vs-optional and defaults are marked, including that the indexer hard-fails without `STELLAR_RPC_URL` and `CONTRACT_ID`.
- **A per-component run/test/lint command table** for contract, indexer, frontend, backend, mobile, and the full stack.
- **An ordered verification checklist** that ends at `soroban contract invoke ... get_metrics` — a real contract call, so "setup works" means something checkable rather than "the containers started".
- **A setup troubleshooting table** covering the failure modes the existing docs hinted at separately, led by the most common one: everything looks healthy but contract calls fail because `CONTRACT_ID` was never set after deploying.

## Duplication removed

| File | What changed |
|---|---|
| `README.md` | Installation / Build / Testing / Deployment sections and the `VITE_*` env table replaced with a four-line quickstart plus links. Contract API listing and CI/CD sections kept — they are not setup. |
| `mobile/README.md` | Prerequisites, Installation, and Environment Variables → pointers. iOS/Android/Metro/build commands kept. |
| `integration-tests/README.md` | Prerequisites and Installation → pointer; the suite-specific `.env` kept, with a note on where its values come from. |
| `security-tests/README.md` | Prerequisites and Installation → pointer; ZAP and curl kept, since those are specific to this suite. |
| `performance/README.md` | Notes the k6 and running-environment requirement, which was previously implicit. |
| `docs/DEV_ENVIRONMENT.md` | Banner marking it the Docker-specific reference (hot reload, seed data, container shells, port overrides) rather than a competing setup path. Content otherwise untouched. |
| `QUICKSTART.txt` | Banner marking it a contract-only cheat sheet. |

`website/README.md` and `indexer/src/README.md` were checked and left alone — the first documents an independent Docusaurus site, the second has no setup instructions to dedupe.

## Verification

- All relative links and heading anchors added across the eight modified files were resolved against the filesystem and against the actual headings in their targets — no broken files, no broken anchors.
- Command accuracy was checked against the source rather than copied forward: `frontend/package.json` and `indexer/package.json` scripts, `docker-compose.yml` service names, ports and env substitution, `indexer/src/config/index.ts` defaults, `indexer/src/index.ts` required variables, and `.env.example` / `frontend/.env.example` / `indexer/.env.example`.
- **Not verified on a clean machine.** The acceptance criteria ask for this and I could not do it in this environment — no fresh host, and a real run-through needs Docker, the Rust toolchain, and a Freighter install. Everything above was verified against the source, so the commands and variables are correct as written, but the end-to-end timing claims (the ~30 s Stellar init in particular) are carried over from the existing docs rather than re-measured. Worth one reviewer doing the walkthrough before merge.

## Acceptance criteria

- [x] Single canonical setup guide
- [ ] Verified on a clean machine — see above; needs a reviewer with a fresh host
- [x] Tested (manual run-through of the documented commands against the source; full clean-machine run outstanding)
- [ ] Code review passed
- [x] Related tests passing (no code changed)
