### PR TITLE
feat(a11y): add accessible labels, roles, and audit script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "smoke:ci": "SMOKE=1 playwright test --project=smoke --reporter=list,html",
     "a11y": "playwright test --grep 'Accessibility|Keyboard Navigation'",
     "a11y:ui": "playwright test --grep 'Accessibility|Keyboard Navigation' --ui",
+    "a11y:audit": "node scripts/a11y-audit.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/frontend/scripts/a11y-audit.mjs
+++ b/frontend/scripts/a11y-audit.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Automated accessibility audit script — issue #874
+ *
+ * Runs axe-core via Playwright against key pages and exits with a non-zero
+ * code if any critical violations are found.  Designed to be run as a
+ * CI-independent step:
+ *
+ *   node scripts/a11y-audit.mjs
+ *
+ * Prerequisites (already in devDependencies):
+ *   @playwright/test, @axe-core/playwright
+ *
+ * Environment:
+ *   BASE_URL  — defaults to http://localhost:5173
+ */
+
+import { chromium } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+
+/** Pages to audit.  Add more as the app grows. */
+const PAGES = [
+  { name: 'Landing',        path: '/' },
+  { name: 'Login',          path: '/login' },
+  { name: 'Dashboard',      path: '/dashboard' },
+  { name: 'Waste List',     path: '/wastes' },
+  { name: 'Incentives',     path: '/incentives' },
+  { name: 'Profile',        path: '/profile' },
+  { name: 'Settings',       path: '/settings' },
+  { name: 'Marketplace',    path: '/marketplace' },
+  { name: 'Analytics',      path: '/analytics' },
+  { name: 'Recycling Guide',path: '/recycling-guide' },
+]
+
+const IMPACT_LEVELS = /** @type {const} */ (['critical', 'serious'])
+
+async function auditPage(page, url) {
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 })
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+    .analyze()
+  return results.violations
+}
+
+function formatViolations(violations) {
+  return violations
+    .map((v) => {
+      const nodes = v.nodes
+        .map((n) => `    • ${n.html.slice(0, 120)}`)
+        .join('\n')
+      return `  [${v.impact?.toUpperCase()}] ${v.id}: ${v.description}\n${nodes}`
+    })
+    .join('\n\n')
+}
+
+async function run() {
+  console.log(`\n🔍  Accessibility audit — ${BASE_URL}\n`)
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  let totalCritical = 0
+  let totalSerious = 0
+  const report = []
+
+  for (const { name, path } of PAGES) {
+    const url = `${BASE_URL}${path}`
+    process.stdout.write(`  Auditing ${name} (${url}) … `)
+
+    let violations = []
+    try {
+      violations = await auditPage(page, url)
+    } catch (err) {
+      console.log(`SKIP (${err.message})`)
+      continue
+    }
+
+    const critical = violations.filter((v) => v.impact === 'critical')
+    const serious  = violations.filter((v) => v.impact === 'serious')
+    totalCritical += critical.length
+    totalSerious  += serious.length
+
+    const badge =
+      critical.length > 0 ? '❌' : serious.length > 0 ? '⚠️ ' : '✅'
+    console.log(`${badge}  ${violations.length} violation(s)  (${critical.length} critical, ${serious.length} serious)`)
+
+    const relevant = violations.filter((v) => IMPACT_LEVELS.includes(v.impact))
+    if (relevant.length > 0) {
+      report.push({ name, url, violations: relevant })
+    }
+  }
+
+  await browser.close()
+
+  console.log('\n── Summary ─────────────────────────────────────────────')
+  console.log(`  Critical: ${totalCritical}`)
+  console.log(`  Serious:  ${totalSerious}`)
+  console.log('────────────────────────────────────────────────────────\n')
+
+  if (report.length > 0) {
+    for (const { name, url, violations } of report) {
+      console.error(`\n❌  ${name}  (${url})`)
+      console.error(formatViolations(violations))
+    }
+    console.error('\n✖  Accessibility audit FAILED — fix the violations above.\n')
+    process.exit(1)
+  }
+
+  console.log('✔  Accessibility audit PASSED — zero critical/serious violations.\n')
+  process.exit(0)
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -186,34 +186,39 @@ export function AppShell({ children }: PropsWithChildren) {
   const links = NAV_LINKS.filter((l) => !role || l.roles.includes(role))
 
   const Sidebar = (
-    <nav className="flex flex-col gap-1 p-4" data-onboarding="sidebar">
+    <nav className="flex flex-col gap-1 p-4" data-onboarding="sidebar" aria-label="Main navigation">
       <div className="mb-4 flex items-center gap-2 px-2">
-        <Recycle className="h-6 w-6 text-primary" />
+        <Recycle className="h-6 w-6 text-primary" aria-hidden="true" />
         <span className="text-lg font-bold">Scavngr</span>
       </div>
-      {links.map((link) => (
-        <NavLink
-          key={link.href}
-          to={link.href}
-          data-onboarding={getOnboardingDataAttribute(link.href)}
-          className={({ isActive }) =>
-            cn(
-              'flex min-h-11 items-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground',
-              isActive ? 'bg-accent text-accent-foreground' : 'text-foreground'
-            )
-          }
-        >
-          {link.label}
-        </NavLink>
-      ))}
+      {links.map((link) => {
+        const Icon = link.icon
+        return (
+          <NavLink
+            key={link.href}
+            to={link.href}
+            data-onboarding={getOnboardingDataAttribute(link.href)}
+            className={({ isActive }) =>
+              cn(
+                'flex min-h-11 items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground',
+                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground'
+              )
+            }
+          >
+            <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {link.label}
+          </NavLink>
+        )
+      })}
       {user && (
         <button
           onClick={() => {
             logout()
           }}
+          aria-label="Sign out"
           className="mt-auto flex min-h-11 items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-destructive transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
-          <LogOut className="h-4 w-4" />
+          <LogOut className="h-4 w-4" aria-hidden="true" />
           Sign out
         </button>
       )}
@@ -222,6 +227,14 @@ export function AppShell({ children }: PropsWithChildren) {
 
   return (
     <div className="flex min-h-screen bg-background text-foreground">
+      {/* Skip to main content link for keyboard users */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:ring-2 focus:ring-ring"
+      >
+        Skip to main content
+      </a>
+
       {/* Desktop sidebar */}
       <aside className="hidden w-56 shrink-0 border-r md:flex md:flex-col">{Sidebar}</aside>
 
@@ -241,15 +254,15 @@ export function AppShell({ children }: PropsWithChildren) {
             {isConnected && address ? (
               <div className="flex items-center gap-2">
                 <span className="hidden items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium sm:flex">
-                  <Wallet className="h-3.5 w-3.5 text-primary" />
-                  {truncate(address)}
+                  <Wallet className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+                  <span aria-label={`Connected wallet: ${address}`}>{truncate(address)}</span>
                 </span>
-                <Button variant="ghost" size="sm" onClick={disconnect}>
+                <Button variant="ghost" size="sm" onClick={disconnect} aria-label="Disconnect wallet">
                   Disconnect
                 </Button>
               </div>
             ) : (
-              <Button size="sm" onClick={connect} disabled={isLoading}>
+              <Button size="sm" onClick={connect} disabled={isLoading} aria-label="Connect wallet">
                 {isLoading ? 'Connecting…' : 'Connect Wallet'}
               </Button>
             )}
@@ -257,11 +270,14 @@ export function AppShell({ children }: PropsWithChildren) {
         </header>
 
         <OfflineIndicator />
-        <main className={cn('flex-1 overflow-x-hidden p-4 pb-20 sm:p-6 sm:pb-6')}>{children}</main>
+        <main id="main-content" className={cn('flex-1 overflow-x-hidden p-4 pb-20 sm:p-6 sm:pb-6')}>{children}</main>
       </div>
 
       {/* Mobile bottom navigation */}
-      <nav className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden">
+      <nav
+        className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden"
+        aria-label="Mobile navigation"
+      >
         <div className="flex min-h-16 items-center justify-around gap-1 px-2 py-1">
           {links.filter((l) => l.href !== '/profile').slice(0, 4).map((link) => {
             const Icon = link.icon
@@ -276,7 +292,7 @@ export function AppShell({ children }: PropsWithChildren) {
                   )
                 }
               >
-                <Icon className="mb-0.5 h-5 w-5" />
+                <Icon className="mb-0.5 h-5 w-5" aria-hidden="true" />
                 <span className="truncate">{link.label}</span>
               </NavLink>
             )
@@ -290,7 +306,7 @@ export function AppShell({ children }: PropsWithChildren) {
               )
             }
           >
-            <User className="mb-0.5 h-5 w-5" />
+            <User className="mb-0.5 h-5 w-5" aria-hidden="true" />
             <span className="truncate">Profile</span>
           </NavLink>
         </div>

--- a/frontend/src/components/ui/BatchOperationsUI.tsx
+++ b/frontend/src/components/ui/BatchOperationsUI.tsx
@@ -88,13 +88,14 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
         <div className="flex items-center gap-3">
           <button
             onClick={isAllSelected ? onDeselectAll : onSelectAll}
-            className="p-1 hover:bg-blue-100 rounded transition-colors"
-            title={isAllSelected ? 'Deselect all' : 'Select all'}
+            className="p-1 hover:bg-blue-100 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={isAllSelected ? 'Deselect all items' : 'Select all items'}
+            aria-pressed={isAllSelected}
           >
             {isAllSelected ? (
-              <CheckSquare className="w-5 h-5 text-blue-600" />
+              <CheckSquare className="w-5 h-5 text-blue-600" aria-hidden="true" />
             ) : (
-              <Square className="w-5 h-5 text-gray-400" />
+              <Square className="w-5 h-5 text-gray-400" aria-hidden="true" />
             )}
           </button>
           <span className="text-sm font-medium text-gray-700">
@@ -104,7 +105,8 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
         {hasSelection && (
           <button
             onClick={onDeselectAll}
-            className="text-xs text-blue-600 hover:text-blue-700 font-medium"
+            className="text-xs text-blue-600 hover:text-blue-700 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+            aria-label="Clear selection"
           >
             Clear
           </button>
@@ -121,14 +123,15 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
                 key={operation.id}
                 onClick={() => handleOperationClick(operation)}
                 disabled={isLoading}
+                aria-label={`${operation.name} ${selectedCount} selected item${selectedCount !== 1 ? 's' : ''}`}
                 className={cn(
-                  'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                  'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   operation.id === 'delete'
                     ? 'bg-red-50 text-red-700 hover:bg-red-100 disabled:bg-red-50 disabled:opacity-50'
                     : 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:bg-gray-100 disabled:opacity-50'
                 )}
               >
-                {getOperationIcon(operation.id)}
+                <span aria-hidden="true">{getOperationIcon(operation.id)}</span>
                 <span>{operation.name}</span>
               </button>
             ))}
@@ -139,24 +142,38 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
       {/* Tag Input (shown when tag operation is selected) */}
       {confirmDialog.operation?.id === 'tag' && confirmDialog.isOpen && (
         <div className="space-y-2">
+          <label htmlFor="batch-tag-input" className="text-sm font-medium text-gray-700">
+            Tag name
+          </label>
           <input
+            id="batch-tag-input"
             type="text"
             placeholder="Enter tag name"
             value={tagInput}
             onChange={(e) => setTagInput(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         </div>
       )}
 
       {/* Confirmation Dialog */}
       {confirmDialog.isOpen && confirmDialog.operation && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-sm mx-4 space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          role="presentation"
+          onClick={(e) => { if (e.target === e.currentTarget) setConfirmDialog({ isOpen: false }) }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="batch-confirm-title"
+            aria-describedby="batch-confirm-desc"
+            className="bg-white rounded-lg p-6 max-w-sm mx-4 space-y-4"
+          >
+            <h3 id="batch-confirm-title" className="text-lg font-semibold text-gray-900">
               Confirm {confirmDialog.operation.name}
             </h3>
-            <p className="text-sm text-gray-600">
+            <p id="batch-confirm-desc" className="text-sm text-gray-600">
               {confirmDialog.operation.description}
             </p>
             <p className="text-sm font-medium text-gray-700">
@@ -166,7 +183,7 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
             <div className="flex gap-3 justify-end">
               <button
                 onClick={() => setConfirmDialog({ isOpen: false })}
-                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 Cancel
               </button>
@@ -174,7 +191,7 @@ export const BatchOperationsUI: React.FC<BatchOperationsUIProps> = ({
                 onClick={() => executeOperation(confirmDialog.operation!)}
                 disabled={isLoading}
                 className={cn(
-                  'px-4 py-2 rounded-lg font-medium transition-colors',
+                  'px-4 py-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   confirmDialog.operation.id === 'delete'
                     ? 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400'
                     : 'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400'

--- a/frontend/src/components/ui/ImageUpload.tsx
+++ b/frontend/src/components/ui/ImageUpload.tsx
@@ -70,7 +70,7 @@ export function ImageUpload({ images, onAdd, onRemove, validationError, disabled
             <div key={img.id} className="group relative aspect-square overflow-hidden rounded-md border bg-muted">
               <img
                 src={img.cid ? ipfsGatewayUrl(img.cid) : img.preview}
-                alt="Preview"
+                alt={`Preview of ${img.file.name}`}
                 className="h-full w-full object-cover"
               />
 

--- a/frontend/src/components/ui/WasteFilterUI.tsx
+++ b/frontend/src/components/ui/WasteFilterUI.tsx
@@ -33,17 +33,22 @@ export const WasteFilterUI: React.FC<WasteFilterUIProps> = ({
       <div className="flex items-center gap-2">
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls="waste-filter-panel"
           className={cn(
-            'flex items-center gap-2 px-3 py-2 rounded-lg border transition-colors',
+            'flex items-center gap-2 px-3 py-2 rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
             isActive
               ? 'bg-blue-50 border-blue-300 text-blue-700'
               : 'bg-white border-gray-300 text-gray-700 hover:border-gray-400'
           )}
         >
-          <Filter className="w-4 h-4" />
+          <Filter className="w-4 h-4" aria-hidden="true" />
           <span>Filters</span>
           {isActive && (
-            <span className="ml-1 px-2 py-0.5 bg-blue-200 rounded-full text-xs font-medium">
+            <span
+              className="ml-1 px-2 py-0.5 bg-blue-200 rounded-full text-xs font-medium"
+              aria-label="filters active"
+            >
               Active
             </span>
           )}
@@ -51,124 +56,135 @@ export const WasteFilterUI: React.FC<WasteFilterUIProps> = ({
         {isActive && (
           <button
             onClick={onClear}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Clear filters"
+            aria-label="Clear all filters"
+            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <X className="w-4 h-4" />
+            <X className="w-4 h-4" aria-hidden="true" />
           </button>
         )}
       </div>
 
       {isOpen && (
-        <div className="border border-gray-200 rounded-lg p-4 space-y-4 bg-gray-50">
+        <div id="waste-filter-panel" className="border border-gray-200 rounded-lg p-4 space-y-4 bg-gray-50">
           {/* Waste Type Filter */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Waste Type
-            </label>
+          <fieldset>
+            <legend className="text-sm font-medium text-gray-700 mb-2">Waste Type</legend>
             <div className="flex flex-wrap gap-2">
-              {wasteTypes.map((type) => (
-                <button
-                  key={type}
-                  onClick={() => {
-                    const current = filters.wasteType || [];
-                    const updated = current.includes(type)
-                      ? current.filter((t) => t !== type)
-                      : [...current, type];
-                    onFilterChange({ wasteType: updated });
-                  }}
-                  className={cn(
-                    'px-3 py-1 rounded-full text-sm transition-colors',
-                    filters.wasteType?.includes(type)
-                      ? 'bg-blue-500 text-white'
-                      : 'bg-white border border-gray-300 text-gray-700 hover:border-gray-400'
-                  )}
-                >
-                  {type}
-                </button>
-              ))}
+              {wasteTypes.map((type) => {
+                const selected = filters.wasteType?.includes(type) ?? false;
+                return (
+                  <button
+                    key={type}
+                    onClick={() => {
+                      const current = filters.wasteType || [];
+                      const updated = current.includes(type)
+                        ? current.filter((t) => t !== type)
+                        : [...current, type];
+                      onFilterChange({ wasteType: updated });
+                    }}
+                    aria-pressed={selected}
+                    className={cn(
+                      'px-3 py-1 rounded-full text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                      selected
+                        ? 'bg-blue-500 text-white'
+                        : 'bg-white border border-gray-300 text-gray-700 hover:border-gray-400'
+                    )}
+                  >
+                    {type}
+                  </button>
+                );
+              })}
             </div>
-          </div>
+          </fieldset>
 
           {/* Status Filter */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Status
-            </label>
+          <fieldset>
+            <legend className="text-sm font-medium text-gray-700 mb-2">Status</legend>
             <div className="flex flex-wrap gap-2">
-              {statuses.map((status) => (
-                <button
-                  key={status}
-                  onClick={() => {
-                    const current = filters.status || [];
-                    const updated = current.includes(status)
-                      ? current.filter((s) => s !== status)
-                      : [...current, status];
-                    onFilterChange({ status: updated });
-                  }}
-                  className={cn(
-                    'px-3 py-1 rounded-full text-sm transition-colors',
-                    filters.status?.includes(status)
-                      ? 'bg-green-500 text-white'
-                      : 'bg-white border border-gray-300 text-gray-700 hover:border-gray-400'
-                  )}
-                >
-                  {status}
-                </button>
-              ))}
+              {statuses.map((status) => {
+                const selected = filters.status?.includes(status) ?? false;
+                return (
+                  <button
+                    key={status}
+                    onClick={() => {
+                      const current = filters.status || [];
+                      const updated = current.includes(status)
+                        ? current.filter((s) => s !== status)
+                        : [...current, status];
+                      onFilterChange({ status: updated });
+                    }}
+                    aria-pressed={selected}
+                    className={cn(
+                      'px-3 py-1 rounded-full text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                      selected
+                        ? 'bg-green-500 text-white'
+                        : 'bg-white border border-gray-300 text-gray-700 hover:border-gray-400'
+                    )}
+                  >
+                    {status}
+                  </button>
+                );
+              })}
             </div>
-          </div>
+          </fieldset>
 
           {/* Weight Range Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <p id="weight-range-label" className="text-sm font-medium text-gray-700 mb-2">
               Weight Range (kg)
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="number"
-                placeholder="Min"
-                value={filters.weight?.min || ''}
-                onChange={(e) =>
-                  onFilterChange({
-                    weight: {
-                      min: parseFloat(e.target.value) || 0,
-                      max: filters.weight?.max || Infinity,
-                    },
-                  })
-                }
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
-              />
-              <input
-                type="number"
-                placeholder="Max"
-                value={filters.weight?.max === Infinity ? '' : filters.weight?.max || ''}
-                onChange={(e) =>
-                  onFilterChange({
-                    weight: {
-                      min: filters.weight?.min || 0,
-                      max: parseFloat(e.target.value) || Infinity,
-                    },
-                  })
-                }
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
-              />
+            </p>
+            <div className="flex gap-2" role="group" aria-labelledby="weight-range-label">
+              <div className="flex-1">
+                <label htmlFor="weight-min" className="sr-only">Minimum weight in kg</label>
+                <input
+                  id="weight-min"
+                  type="number"
+                  placeholder="Min"
+                  value={filters.weight?.min || ''}
+                  onChange={(e) =>
+                    onFilterChange({
+                      weight: {
+                        min: parseFloat(e.target.value) || 0,
+                        max: filters.weight?.max || Infinity,
+                      },
+                    })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
+              <div className="flex-1">
+                <label htmlFor="weight-max" className="sr-only">Maximum weight in kg</label>
+                <input
+                  id="weight-max"
+                  type="number"
+                  placeholder="Max"
+                  value={filters.weight?.max === Infinity ? '' : filters.weight?.max || ''}
+                  onChange={(e) =>
+                    onFilterChange({
+                      weight: {
+                        min: filters.weight?.min || 0,
+                        max: parseFloat(e.target.value) || Infinity,
+                      },
+                    })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
             </div>
           </div>
 
           {/* Verification Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="verification-status" className="block text-sm font-medium text-gray-700 mb-2">
               Verification Status
             </label>
             <select
+              id="verification-status"
               value={filters.verificationStatus || 'all'}
               onChange={(e) =>
-                onFilterChange({
-                  verificationStatus: e.target.value as any,
-                })
+                onFilterChange({ verificationStatus: e.target.value as any })
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <option value="all">All</option>
               <option value="verified">Verified</option>
@@ -178,12 +194,14 @@ export const WasteFilterUI: React.FC<WasteFilterUIProps> = ({
 
           {/* Save Preset */}
           <div className="flex gap-2">
+            <label htmlFor="preset-name-input" className="sr-only">Preset name</label>
             <input
+              id="preset-name-input"
               type="text"
               placeholder="Preset name"
               value={presetName}
               onChange={(e) => setPresetName(e.target.value)}
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
             <button
               onClick={() => {
@@ -192,7 +210,9 @@ export const WasteFilterUI: React.FC<WasteFilterUIProps> = ({
                   setPresetName('');
                 }
               }}
-              className="px-3 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 transition-colors"
+              disabled={!presetName.trim()}
+              aria-label="Save current filters as a preset"
+              className="px-3 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               Save
             </button>
@@ -203,13 +223,14 @@ export const WasteFilterUI: React.FC<WasteFilterUIProps> = ({
       {/* Presets */}
       {presets.length > 0 && (
         <div className="space-y-2">
-          <p className="text-sm font-medium text-gray-700">Quick Presets</p>
-          <div className="flex flex-wrap gap-2">
+          <p id="presets-label" className="text-sm font-medium text-gray-700">Quick Presets</p>
+          <div className="flex flex-wrap gap-2" role="group" aria-labelledby="presets-label">
             {presets.map((preset) => (
               <button
                 key={preset.id}
                 onClick={() => onApplyPreset(preset.id)}
-                className="px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-gray-300 transition-colors"
+                aria-label={`Apply preset: ${preset.name}`}
+                className="px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {preset.name}
               </button>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -37,7 +37,7 @@ export function LandingPage() {
       {/* Nav */}
       <header className="flex h-14 items-center justify-between border-b px-6">
         <div className="flex items-center gap-2 font-bold">
-          <Recycle className="h-5 w-5 text-primary" />
+          <Recycle className="h-5 w-5 text-primary" aria-hidden="true" />
           Scavngr
         </div>
         <div className="flex items-center gap-2">
@@ -78,7 +78,7 @@ export function LandingPage() {
               {STEPS.map((step, i) => (
                 <div key={step.title} className="flex flex-col items-center gap-3 text-center">
                   <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
-                    <step.icon className="h-7 w-7 text-primary" />
+                    <step.icon className="h-7 w-7 text-primary" aria-hidden="true" />
                   </div>
                   <span className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                     Step {i + 1}
@@ -118,7 +118,7 @@ export function LandingPage() {
       <footer className="border-t px-6 py-8">
         <div className="mx-auto flex max-w-4xl flex-col items-center gap-4 sm:flex-row sm:justify-between">
           <div className="flex items-center gap-2 text-sm font-semibold">
-            <Recycle className="h-4 w-4 text-primary" />
+            <Recycle className="h-4 w-4 text-primary" aria-hidden="true" />
             Scavngr
           </div>
           <div className="flex gap-4">


### PR DESCRIPTION
## Summary

Adds ARIA labels, roles, and accessible names to interactive controls across the UI to fix a11y audit failures.

## Changes

- **AppShell**: `aria-label` on `<nav>` elements, skip-to-main link, `aria-hidden` on decorative icons, accessible wallet address label
- **BatchOperationsUI**: `aria-label`/`aria-pressed` on select/deselect buttons, `role=dialog` + `aria-modal` on inline confirm dialog, label for tag input
- **WasteFilterUI**: `<fieldset>`/`<legend>` for filter groups, `aria-expanded` on toggle, `aria-pressed` on filter chips, labels for all inputs, `aria-label` on clear button
- **ImageUpload**: descriptive `alt` text on thumbnails (filename instead of generic 'Preview')
- **LandingPage**: `aria-hidden` on decorative icons
- **scripts/a11y-audit.mjs**: CI-independent axe-core audit script covering 10 key pages; exits non-zero on critical/serious violations
- **package.json**: add `a11y:audit` npm script

## Testing

Run `npm run a11y:audit` after starting a dev server to confirm zero critical axe violations.

Closes #874