### PR TITLE
feat(perf): code-split routes with React.lazy + Suspense

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "bundle:analyze": "node scripts/bundle-analysis.mjs",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --max-warnings 0",
     "format": "prettier --write .",

--- a/frontend/scripts/bundle-analysis.mjs
+++ b/frontend/scripts/bundle-analysis.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * bundle-analysis.mjs
+ *
+ * Measures the production bundle output produced by `vite build`.
+ * Run after building: `node scripts/bundle-analysis.mjs`
+ *
+ * Outputs:
+ *   - Initial chunks (entry + eagerly-imported modules)
+ *   - Lazy chunks (route-level code-split chunks)
+ *   - Total bundle size
+ *   - Chunk count
+ *
+ * Exit code 1 if the initial JS bundle exceeds the configured threshold.
+ */
+
+import { readdirSync, statSync, existsSync } from 'node:fs'
+import { join, extname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const distDir = join(__dirname, '..', 'dist', 'assets')
+
+// ── Thresholds ────────────────────────────────────────────────────────────────
+// Adjust if the budget changes.  Values in KB (uncompressed).
+const INITIAL_BUNDLE_WARN_KB = 200  // warn if initial JS > 200 KB
+const INITIAL_BUNDLE_FAIL_KB = 350  // fail CI if initial JS > 350 KB
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function toKB(bytes) {
+  return (bytes / 1024).toFixed(1)
+}
+
+function padEnd(str, len) {
+  return String(str).padEnd(len, ' ')
+}
+
+function padStart(str, len) {
+  return String(str).padStart(len, ' ')
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+if (!existsSync(distDir)) {
+  console.error(`\n❌  dist/assets not found. Run \`npm run build\` first.\n`)
+  process.exit(1)
+}
+
+const files = readdirSync(distDir).filter((f) => extname(f) === '.js')
+
+if (files.length === 0) {
+  console.error('\n❌  No JS files found in dist/assets.\n')
+  process.exit(1)
+}
+
+const chunks = files.map((file) => {
+  const filePath = join(distDir, file)
+  const size = statSync(filePath).size
+
+  // Vite names the entry chunk "index-[hash].js"; other chunks get a content-
+  // addressable hash.  We identify the entry by the "index" prefix.
+  const isEntry = basename(file).startsWith('index')
+  return { file, size, isEntry }
+})
+
+chunks.sort((a, b) => b.size - a.size)
+
+const totalBytes = chunks.reduce((s, c) => s + c.size, 0)
+const initialBytes = chunks.filter((c) => c.isEntry).reduce((s, c) => s + c.size, 0)
+const lazyChunks = chunks.filter((c) => !c.isEntry)
+const initialChunks = chunks.filter((c) => c.isEntry)
+
+// ── Report ────────────────────────────────────────────────────────────────────
+const COL1 = 50
+const COL2 = 10
+
+console.log('\n📦  Bundle Analysis Report')
+console.log('='.repeat(COL1 + COL2 + 4))
+
+console.log('\n🔵  Initial chunks (loaded on every page visit)')
+console.log('-'.repeat(COL1 + COL2 + 4))
+for (const { file, size } of initialChunks) {
+  console.log(`  ${padEnd(file, COL1)} ${padStart(toKB(size) + ' KB', COL2)}`)
+}
+
+console.log('\n🟢  Lazy chunks (loaded only when the route is visited)')
+console.log('-'.repeat(COL1 + COL2 + 4))
+for (const { file, size } of lazyChunks) {
+  console.log(`  ${padEnd(file, COL1)} ${padStart(toKB(size) + ' KB', COL2)}`)
+}
+
+console.log('\n' + '='.repeat(COL1 + COL2 + 4))
+console.log(`  ${'Total JS'.padEnd(COL1)} ${padStart(toKB(totalBytes) + ' KB', COL2)}`)
+console.log(`  ${'Initial JS'.padEnd(COL1)} ${padStart(toKB(initialBytes) + ' KB', COL2)}`)
+console.log(`  ${'Lazy chunks'.padEnd(COL1)} ${padStart(lazyChunks.length, COL2)}`)
+console.log('='.repeat(COL1 + COL2 + 4))
+
+// ── Budget check ──────────────────────────────────────────────────────────────
+const initialKB = initialBytes / 1024
+
+if (initialKB > INITIAL_BUNDLE_FAIL_KB) {
+  console.error(
+    `\n❌  Initial bundle (${toKB(initialBytes)} KB) exceeds the failure threshold of ${INITIAL_BUNDLE_FAIL_KB} KB.\n`
+  )
+  process.exit(1)
+}
+
+if (initialKB > INITIAL_BUNDLE_WARN_KB) {
+  console.warn(
+    `\n⚠️   Initial bundle (${toKB(initialBytes)} KB) exceeds the warning threshold of ${INITIAL_BUNDLE_WARN_KB} KB.`
+  )
+  console.warn('    Consider splitting large dependencies further.\n')
+} else {
+  console.log(
+    `\n✅  Initial bundle (${toKB(initialBytes)} KB) is within budget (< ${INITIAL_BUNDLE_WARN_KB} KB).\n`
+  )
+}

--- a/frontend/src/components/PageErrorBoundary.tsx
+++ b/frontend/src/components/PageErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Button } from '@/components/ui/Button'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Error boundary specifically for lazy-loaded page chunks.
+ *
+ * When a dynamic `import()` fails (e.g. a network error while loading a route
+ * chunk) React throws during rendering. This boundary catches that, shows a
+ * user-friendly message, and offers a reload button so the user can retry
+ * without losing the whole app.
+ */
+export class PageErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Log to console so it's visible in CI / dev tools
+    console.error('[PageErrorBoundary] Failed to load page chunk:', error, info)
+  }
+
+  handleReload = () => {
+    // Clear the error state so the Suspense boundary retries the import
+    this.setState({ hasError: false, error: null })
+    // Also hard-reload the chunk by refreshing — clears stale cached chunk hashes
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center"
+        >
+          <p className="text-lg font-semibold">Failed to load this page.</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            The page could not be loaded, possibly due to a network error or a new deployment.
+            Reloading usually fixes it.
+          </p>
+          <Button onClick={this.handleReload}>Reload page</Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,13 +3,17 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
 import { useAuth } from '@/context/AuthContext'
 import { AppShell } from '@/components/layout/AppShell'
 import { PageSkeleton } from '@/components/ui/Skeletons'
+import { PageErrorBoundary } from '@/components/PageErrorBoundary'
 
-// Eagerly load tiny pages that are always needed
+// Eagerly load tiny pages that are always needed at startup
 import { LandingPage } from '@/pages/LandingPage'
 import { LoginPage } from '@/pages/LoginPage'
 import { NotFoundPage } from '@/pages/NotFoundPage'
 
-// Lazy-load all protected pages to reduce initial bundle size
+// ─── Lazy-loaded protected pages ──────────────────────────────────────────────
+// Each import() call becomes its own JS chunk — loaded only when the route is
+// visited, keeping the initial bundle as small as possible.
+
 const HomePage = lazy(() => import('@/pages/HomePage').then((m) => ({ default: m.HomePage })))
 const RecyclerDashboard = lazy(() =>
   import('@/pages/RecyclerDashboard').then((m) => ({ default: m.RecyclerDashboard }))
@@ -17,12 +21,15 @@ const RecyclerDashboard = lazy(() =>
 const IncentivesMarketplacePage = lazy(() =>
   import('@/pages/IncentivesMarketplacePage').then((m) => ({ default: m.IncentivesMarketplacePage }))
 )
+const IncentivesPage = lazy(() =>
+  import('@/pages/IncentivesPage').then((m) => ({ default: m.IncentivesPage }))
+)
 const WasteListPage = lazy(() =>
   import('@/pages/WasteListPage').then((m) => ({ default: m.WasteListPage }))
 )
 const ManufacturerDashboardPage = lazy(() =>
   import('@/pages/ManufacturerDashboardPage').then((m) => ({
-    default: m.ManufacturerDashboardPage
+    default: m.ManufacturerDashboardPage,
   }))
 )
 const CollectorDashboardPage = lazy(() =>
@@ -74,7 +81,9 @@ const RecyclingGuidePage = lazy(() =>
   import('@/pages/RecyclingGuidePage').then((m) => ({ default: m.RecyclingGuidePage }))
 )
 const PerformanceMonitoringPage = lazy(() =>
-  import('@/pages/PerformanceMonitoringPage').then((m) => ({ default: m.PerformanceMonitoringPage }))
+  import('@/pages/PerformanceMonitoringPage').then((m) => ({
+    default: m.PerformanceMonitoringPage,
+  }))
 )
 const GamificationPage = lazy(() =>
   import('@/pages/GamificationPage').then((m) => ({ default: m.GamificationPage }))
@@ -99,12 +108,12 @@ const MaterialTransferPage = lazy(() =>
 )
 const WasteVerificationDashboardPage = lazy(() =>
   import('@/pages/WasteVerificationDashboardPage').then((m) => ({
-    default: m.WasteVerificationDashboardPage
+    default: m.WasteVerificationDashboardPage,
   }))
 )
 const ParticipantRegistrationPage = lazy(() =>
   import('@/pages/ParticipantRegistrationPage').then((m) => ({
-    default: m.ParticipantRegistrationPage
+    default: m.ParticipantRegistrationPage,
   }))
 )
 const TestReportsPage = lazy(() =>
@@ -123,7 +132,9 @@ const FeatureFlagsPage = lazy(() =>
   import('@/pages/FeatureFlagsPage').then((m) => ({ default: m.FeatureFlagsPage }))
 )
 const PlatformHealthDashboardPage = lazy(() =>
-  import('@/pages/PlatformHealthDashboardPage').then((m) => ({ default: m.PlatformHealthDashboardPage }))
+  import('@/pages/PlatformHealthDashboardPage').then((m) => ({
+    default: m.PlatformHealthDashboardPage,
+  }))
 )
 const PerformanceSLAsPage = lazy(() =>
   import('@/pages/PerformanceSLAsPage').then((m) => ({ default: m.PerformanceSLAsPage }))
@@ -131,6 +142,40 @@ const PerformanceSLAsPage = lazy(() =>
 const GovernancePage = lazy(() =>
   import('@/pages/GovernancePage').then((m) => ({ default: m.GovernancePage }))
 )
+// Previously missing pages — now lazy-loaded
+const ProfilePage = lazy(() =>
+  import('@/pages/ProfilePage').then((m) => ({ default: m.ProfilePage }))
+)
+const CharityDonationsPage = lazy(() =>
+  import('@/pages/CharityDonationsPage').then((m) => ({ default: m.CharityDonationsPage }))
+)
+const EnvironmentalImpactDashboardPage = lazy(() =>
+  import('@/pages/EnvironmentalImpactDashboardPage').then((m) => ({
+    default: m.EnvironmentalImpactDashboardPage,
+  }))
+)
+const ImpactCalculatorPage = lazy(() =>
+  import('@/pages/ImpactCalculatorPage').then((m) => ({ default: m.ImpactCalculatorPage }))
+)
+const SearchResultsPage = lazy(() =>
+  import('@/pages/SearchResultsPage').then((m) => ({ default: m.SearchResultsPage }))
+)
+const SubscriptionsPage = lazy(() =>
+  import('@/pages/SubscriptionsPage').then((m) => ({ default: m.SubscriptionsPage }))
+)
+const QRCodePage = lazy(() =>
+  import('@/pages/QRCodePage').then((m) => ({ default: m.QRCodePage }))
+)
+const OfflineSettings = lazy(() =>
+  import('@/pages/OfflineSettings').then((m) => ({ default: m.OfflineSettings }))
+)
+const ThemeSettings = lazy(() =>
+  import('@/pages/ThemeSettings').then((m) => ({ default: m.ThemeSettings }))
+)
+
+// ─── Suspense wrapper ─────────────────────────────────────────────────────────
+// Wraps the route outlet in a Suspense boundary so every lazy page gets a
+// consistent PageSkeleton loading fallback while its chunk is being fetched.
 
 // eslint-disable-next-line react-refresh/only-export-components
 function PageFallback() {
@@ -141,13 +186,17 @@ function PageFallback() {
   )
 }
 
+// ─── Auth guard ───────────────────────────────────────────────────────────────
+
 // eslint-disable-next-line react-refresh/only-export-components
 function ProtectedLayout() {
   const { isAuthenticated, isLoading } = useAuth()
   if (isLoading) return null
   return isAuthenticated ? (
     <AppShell>
-      <PageFallback />
+      <PageErrorBoundary>
+        <PageFallback />
+      </PageErrorBoundary>
     </AppShell>
   ) : (
     <Navigate to="/login" replace />
@@ -164,12 +213,15 @@ export const router = createBrowserRouter([
       { path: 'submit', element: <div>Submit Waste</div> },
       { path: 'collect', element: <CollectorDashboardPage /> },
       { path: 'incentives', element: <IncentivesMarketplacePage /> },
+      { path: 'incentives/manage', element: <IncentivesPage /> },
       { path: 'transfer', element: <MaterialTransferPage /> },
       { path: 'history', element: <div>History</div> },
       { path: 'dashboard/recycler', element: <RecyclerDashboard /> },
       { path: 'wastes', element: <WasteListPage /> },
       { path: 'manufacturer', element: <ManufacturerDashboardPage /> },
       { path: 'settings', element: <SettingsPage /> },
+      { path: 'settings/offline', element: <OfflineSettings /> },
+      { path: 'settings/theme', element: <ThemeSettings /> },
       { path: 'rewards', element: <RewardsPage /> },
       { path: 'tracker', element: <SupplyChainTrackerPage /> },
       { path: 'community', element: <CommunityPage /> },
@@ -200,8 +252,16 @@ export const router = createBrowserRouter([
       { path: 'batch-upload', element: <BatchUploadPage /> },
       { path: 'feature-flags', element: <FeatureFlagsPage /> },
       { path: 'health', element: <PlatformHealthDashboardPage /> },
-      { path: 'slas', element: <PerformanceSLAsPage /> }
-    ]
+      { path: 'slas', element: <PerformanceSLAsPage /> },
+      // Previously unrouted pages — wired up with lazy loading
+      { path: 'profile', element: <ProfilePage /> },
+      { path: 'donations', element: <CharityDonationsPage /> },
+      { path: 'environmental-impact', element: <EnvironmentalImpactDashboardPage /> },
+      { path: 'impact-calculator', element: <ImpactCalculatorPage /> },
+      { path: 'search', element: <SearchResultsPage /> },
+      { path: 'subscriptions', element: <SubscriptionsPage /> },
+      { path: 'qr', element: <QRCodePage /> },
+    ],
   },
-  { path: '*', element: <NotFoundPage /> }
+  { path: '*', element: <NotFoundPage /> },
 ])


### PR DESCRIPTION
## Summary

Completes route-level code splitting so every protected page is loaded on demand, reducing the initial bundle. Adds 10 previously unrouted pages, a `PageErrorBoundary` for chunk-load failures, and a bundle analysis script.

## Changes

- **router.tsx**: all protected pages are `React.lazy` imports wrapped in `Suspense` with a `PageSkeleton` fallback; adds 10 previously missing routes (`ProfilePage`, `CharityDonationsPage`, `EnvironmentalImpactDashboardPage`, `ImpactCalculatorPage`, `SearchResultsPage`, `SubscriptionsPage`, `QRCodePage`, `OfflineSettings`, `ThemeSettings`, `IncentivesPage`) each as its own lazy chunk
- **PageErrorBoundary.tsx**: class-based error boundary that catches chunk-load failures (network errors, stale hashes after deployment) and shows a Reload button instead of a blank screen; wraps the Suspense outlet in `ProtectedLayout`
- **scripts/bundle-analysis.mjs**: Node script that reads `dist/assets` after `vite build`, reports initial vs lazy chunk sizes, and exits 1 if initial JS exceeds the 350 KB hard budget
- **package.json**: adds `bundle:analyze` npm script

## How to measure

```bash
npm run build
npm run bundle:analyze
```

## Loading fallback

Every lazy route shows `<PageSkeleton />` (animated pulse placeholder) while its chunk is being fetched.

Closes #877