### PR TITLE
test: add factory helpers and adopt in 20+ tests

### DIFF
--- a/docs/FACTORY_HELPERS_GUIDE.md
+++ b/docs/FACTORY_HELPERS_GUIDE.md
@@ -1,0 +1,108 @@
+# Factory Helpers Guide
+
+Closes #946.
+
+## Why Factories?
+
+Before this PR every test hand-built participants, waste items, incentives and
+transfers inline, leading to:
+
+- Inconsistent field values across tests (different coordinate defaults, different weights)
+- Boilerplate duplication that made tests hard to read
+- Brittle setup that broke whenever a function signature changed
+
+The factories in `stellar-contract/tests/factories.rs` solve all three problems.
+
+---
+
+## Quick-start
+
+```rust
+// At the top of your test file:
+mod factories;
+use factories::*;
+
+#[test]
+fn my_test() {
+    let env = Env::default();
+    let (client, admin, recycler, collector, manufacturer) = setup_full_env(&env);
+
+    let waste_id  = WasteFactory::plastic(&env, &client, &recycler);
+    let incentive = IncentiveFactory::plastic(&env, &client, &manufacturer);
+    TransferFactory::transfer(&client, waste_id, &recycler, &collector);
+}
+```
+
+---
+
+## Reference
+
+### Environment helpers
+
+| Function | Description |
+|---|---|
+| `make_client(env)` | Register contract, enable `mock_all_auths`, return client |
+| `make_client_no_auth(env)` | Register contract without calling `mock_all_auths` |
+| `setup_full_env(env)` | Full setup: client + admin + recycler + collector + manufacturer |
+
+### `ParticipantFactory`
+
+| Method | Description |
+|---|---|
+| `recycler(env, client)` | Register and return a Recycler address |
+| `collector(env, client)` | Register and return a Collector address |
+| `manufacturer(env, client)` | Register and return a Manufacturer address |
+| `with_role(env, client, role)` | Register with any role |
+| `with_location(env, client, role, lat, lon)` | Register with a specific location |
+
+All methods generate a unique `Address` via `Address::generate(env)`.
+
+### `WasteFactory`
+
+| Method | Description |
+|---|---|
+| `plastic(env, client, owner)` | Submit 1 000 g of Plastic, return waste ID |
+| `metal(env, client, owner)` | Submit 1 000 g of Metal, return waste ID |
+| `glass(env, client, owner)` | Submit 1 000 g of Glass, return waste ID |
+| `paper(env, client, owner)` | Submit 1 000 g of Paper, return waste ID |
+| `electronics(env, client, owner)` | Submit 1 000 g of Electronics, return waste ID |
+| `with_type(env, client, owner, waste_type, weight)` | Custom type and weight |
+| `with_location(env, client, owner, type, weight, lat, lon)` | Custom location |
+
+All methods return `u128` waste IDs (matching the contract's internal type).
+
+### `IncentiveFactory`
+
+| Method | Description |
+|---|---|
+| `plastic(env, client, manufacturer)` | Plastic incentive, 100 reward, 1 000 budget |
+| `metal(env, client, manufacturer)` | Metal incentive, 200 reward, 2 000 budget |
+| `with_params(env, client, mfr, type, reward, budget)` | Fully custom |
+
+All methods return `u64` incentive IDs.
+
+### `TransferFactory`
+
+| Method | Description |
+|---|---|
+| `transfer(client, waste_id, from, to)` | Transfer at (0, 0) |
+| `transfer_at(client, waste_id, from, to, lat, lon)` | Transfer at a specific location |
+
+---
+
+## Adoption checklist
+
+When writing a new test:
+
+1. Call `setup_full_env(&env)` instead of copy-pasting the setup block.
+2. Create waste via `WasteFactory::<type>()` instead of calling `recycle_waste` directly.
+3. Create incentives via `IncentiveFactory::with_params()`.
+4. Transfer waste via `TransferFactory::transfer()`.
+
+---
+
+## Running the factory tests
+
+```bash
+cargo test -p stellar-scavngr-contract factory
+```

--- a/stellar-contract/tests/factories.rs
+++ b/stellar-contract/tests/factories.rs
@@ -1,0 +1,262 @@
+//! Test factory helpers for the Scavngr contract — closes #946.
+//!
+//! Tests were hand-building Participants, Wastes, Incentives and Transfers
+//! inconsistently. This module provides typed factory functions so every test
+//! can create objects in one line with sensible defaults.
+//!
+//! # Quick-start
+//!
+//! ```rust,ignore
+//! mod factories;
+//! use factories::*;
+//!
+//! #[test]
+//! fn my_test() {
+//!     let env = Env::default();
+//!     env.mock_all_auths();
+//!     let client = make_client(&env);
+//!     let recycler  = ParticipantFactory::recycler(&env, &client);
+//!     let waste_id  = WasteFactory::plastic(&env, &client, &recycler);
+//!     let collector = ParticipantFactory::collector(&env, &client);
+//!     TransferFactory::transfer(&client, waste_id, &recycler, &collector);
+//! }
+//! ```
+//!
+//! See `docs/FACTORY_HELPERS_GUIDE.md` for the full pattern catalogue.
+
+#![cfg(test)]
+#![allow(dead_code)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use stellar_scavngr_contract::{
+    ParticipantRole, ScavengerContract, ScavengerContractClient, WasteType,
+};
+
+// ── Environment / client helpers ─────────────────────────────────────────────
+
+/// Create a fresh contract client. Caller must already have called `env.mock_all_auths()`.
+pub fn make_client_no_auth(env: &Env) -> ScavengerContractClient<'_> {
+    let contract_id = env.register_contract(None, ScavengerContract);
+    ScavengerContractClient::new(env, &contract_id)
+}
+
+/// Create a fresh contract client with `mock_all_auths` already enabled.
+pub fn make_client(env: &Env) -> ScavengerContractClient<'_> {
+    env.mock_all_auths();
+    make_client_no_auth(env)
+}
+
+/// Full environment setup: client + admin + one participant of each role.
+///
+/// Returns `(client, admin, recycler, collector, manufacturer)`.
+pub fn setup_full_env(
+    env: &Env,
+) -> (
+    ScavengerContractClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    env.mock_all_auths();
+    let client = make_client_no_auth(env);
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+    let recycler = ParticipantFactory::recycler(env, &client);
+    let collector = ParticipantFactory::collector(env, &client);
+    let manufacturer = ParticipantFactory::manufacturer(env, &client);
+    (client, admin, recycler, collector, manufacturer)
+}
+
+// ── ParticipantFactory ────────────────────────────────────────────────────────
+
+/// Factory for registered participants.
+pub struct ParticipantFactory;
+
+impl ParticipantFactory {
+    /// Register and return a new Recycler address.
+    pub fn recycler(env: &Env, client: &ScavengerContractClient<'_>) -> Address {
+        Self::with_role(env, client, ParticipantRole::Recycler)
+    }
+
+    /// Register and return a new Collector address.
+    pub fn collector(env: &Env, client: &ScavengerContractClient<'_>) -> Address {
+        Self::with_role(env, client, ParticipantRole::Collector)
+    }
+
+    /// Register and return a new Manufacturer address.
+    pub fn manufacturer(env: &Env, client: &ScavengerContractClient<'_>) -> Address {
+        Self::with_role(env, client, ParticipantRole::Manufacturer)
+    }
+
+    /// Register a participant with the given role at (0, 0).
+    pub fn with_role(
+        env: &Env,
+        client: &ScavengerContractClient<'_>,
+        role: ParticipantRole,
+    ) -> Address {
+        let addr = Address::generate(env);
+        let name = soroban_sdk::symbol_short!("test");
+        client.register_participant(&addr, &role, &name, &0, &0);
+        addr
+    }
+
+    /// Register a participant with a specific location.
+    pub fn with_location(
+        env: &Env,
+        client: &ScavengerContractClient<'_>,
+        role: ParticipantRole,
+        lat: i32,
+        lon: i32,
+    ) -> Address {
+        let addr = Address::generate(env);
+        let name = soroban_sdk::symbol_short!("test");
+        client.register_participant(&addr, &role, &name, &lat, &lon);
+        addr
+    }
+}
+
+// ── WasteFactory ─────────────────────────────────────────────────────────────
+
+/// Factory for submitted waste items.
+pub struct WasteFactory;
+
+impl WasteFactory {
+    /// Submit 1 000 g of Plastic waste and return the waste ID.
+    pub fn plastic(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+    ) -> u128 {
+        Self::with_type(_env, client, owner, WasteType::Plastic, 1_000)
+    }
+
+    /// Submit 1 000 g of Metal waste and return the waste ID.
+    pub fn metal(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+    ) -> u128 {
+        Self::with_type(_env, client, owner, WasteType::Metal, 1_000)
+    }
+
+    /// Submit 1 000 g of Glass waste and return the waste ID.
+    pub fn glass(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+    ) -> u128 {
+        Self::with_type(_env, client, owner, WasteType::Glass, 1_000)
+    }
+
+    /// Submit 1 000 g of Paper waste and return the waste ID.
+    pub fn paper(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+    ) -> u128 {
+        Self::with_type(_env, client, owner, WasteType::Paper, 1_000)
+    }
+
+    /// Submit 1 000 g of Electronics waste and return the waste ID.
+    pub fn electronics(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+    ) -> u128 {
+        Self::with_type(_env, client, owner, WasteType::Electronics, 1_000)
+    }
+
+    /// Submit waste with an explicit type and weight; returns the waste ID.
+    pub fn with_type(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+        waste_type: WasteType,
+        weight: u128,
+    ) -> u128 {
+        client.recycle_waste(&waste_type, &weight, owner, &0i128, &0i128)
+    }
+
+    /// Submit waste at a specific geographic location.
+    pub fn with_location(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        owner: &Address,
+        waste_type: WasteType,
+        weight: u128,
+        lat: i128,
+        lon: i128,
+    ) -> u128 {
+        client.recycle_waste(&waste_type, &weight, owner, &lat, &lon)
+    }
+}
+
+// ── IncentiveFactory ──────────────────────────────────────────────────────────
+
+/// Factory for incentives.
+pub struct IncentiveFactory;
+
+impl IncentiveFactory {
+    /// Create a Plastic incentive (100 reward, 1 000 budget) and return the incentive ID.
+    pub fn plastic(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        manufacturer: &Address,
+    ) -> u64 {
+        Self::with_params(_env, client, manufacturer, WasteType::Plastic, 100, 1_000)
+    }
+
+    /// Create a Metal incentive (200 reward, 2 000 budget) and return the incentive ID.
+    pub fn metal(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        manufacturer: &Address,
+    ) -> u64 {
+        Self::with_params(_env, client, manufacturer, WasteType::Metal, 200, 2_000)
+    }
+
+    /// Create an incentive with fully custom parameters; returns the incentive ID.
+    pub fn with_params(
+        _env: &Env,
+        client: &ScavengerContractClient<'_>,
+        manufacturer: &Address,
+        waste_type: WasteType,
+        reward: u64,
+        budget: u64,
+    ) -> u64 {
+        client
+            .create_incentive(manufacturer, &waste_type, &reward, &budget)
+            .id
+    }
+}
+
+// ── TransferFactory ───────────────────────────────────────────────────────────
+
+/// Factory for waste transfers.
+pub struct TransferFactory;
+
+impl TransferFactory {
+    /// Transfer `waste_id` from `from` → `to` at (0, 0).
+    /// The soroban test client panics on contract errors automatically.
+    pub fn transfer(
+        client: &ScavengerContractClient<'_>,
+        waste_id: u128,
+        from: &Address,
+        to: &Address,
+    ) {
+        client.transfer_waste_v2(&waste_id, from, to, &0i128, &0i128);
+    }
+
+    /// Transfer with an explicit location.
+    pub fn transfer_at(
+        client: &ScavengerContractClient<'_>,
+        waste_id: u128,
+        from: &Address,
+        to: &Address,
+        lat: i128,
+        lon: i128,
+    ) {
+        client.transfer_waste_v2(&waste_id, from, to, &lat, &lon);
+    }
+}

--- a/stellar-contract/tests/factory_tests.rs
+++ b/stellar-contract/tests/factory_tests.rs
@@ -1,0 +1,294 @@
+//! Tests that exercise the factory helpers from `factories.rs` — closes #946.
+//!
+//! Every test uses ONLY factory helpers (no hand-built objects) to demonstrate
+//! the pattern and validate that the factories themselves work correctly.
+
+#![cfg(test)]
+
+mod factories;
+use factories::*;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use stellar_scavngr_contract::{ParticipantRole, WasteType};
+
+// ── ParticipantFactory tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_factory_creates_recycler() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client_no_auth(&env);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+
+    let recycler = ParticipantFactory::recycler(&env, &client);
+
+    assert!(
+        client.is_participant_registered(&recycler),
+        "Recycler should be registered"
+    );
+}
+
+#[test]
+fn test_factory_creates_collector() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client_no_auth(&env);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+
+    let collector = ParticipantFactory::collector(&env, &client);
+
+    assert!(
+        client.is_participant_registered(&collector),
+        "Collector should be registered"
+    );
+}
+
+#[test]
+fn test_factory_creates_manufacturer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client_no_auth(&env);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+
+    let manufacturer = ParticipantFactory::manufacturer(&env, &client);
+
+    assert!(
+        client.is_participant_registered(&manufacturer),
+        "Manufacturer should be registered"
+    );
+}
+
+#[test]
+fn test_factory_with_role_creates_independent_addresses() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client_no_auth(&env);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+
+    let r1 = ParticipantFactory::recycler(&env, &client);
+    let r2 = ParticipantFactory::recycler(&env, &client);
+
+    assert_ne!(r1, r2, "Each factory call should produce a unique address");
+}
+
+#[test]
+fn test_factory_with_location() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client_no_auth(&env);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+
+    let addr =
+        ParticipantFactory::with_location(&env, &client, ParticipantRole::Recycler, 40, 74);
+
+    assert!(
+        client.is_participant_registered(&addr),
+        "Located participant should be registered"
+    );
+}
+
+// ── WasteFactory tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_factory_creates_plastic_waste() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::plastic(&env, &client, &recycler);
+
+    assert!(waste_id > 0, "Waste ID must be non-zero");
+}
+
+#[test]
+fn test_factory_creates_metal_waste() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::metal(&env, &client, &recycler);
+
+    assert!(waste_id > 0);
+}
+
+#[test]
+fn test_factory_creates_glass_waste() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::glass(&env, &client, &recycler);
+
+    assert!(waste_id > 0);
+}
+
+#[test]
+fn test_factory_creates_paper_waste() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::paper(&env, &client, &recycler);
+
+    assert!(waste_id > 0);
+}
+
+#[test]
+fn test_factory_creates_electronics_waste() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::electronics(&env, &client, &recycler);
+
+    assert!(waste_id > 0);
+}
+
+#[test]
+fn test_factory_waste_ids_are_unique() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let id1 = WasteFactory::plastic(&env, &client, &recycler);
+    let id2 = WasteFactory::plastic(&env, &client, &recycler);
+    let id3 = WasteFactory::metal(&env, &client, &recycler);
+
+    assert_ne!(id1, id2);
+    assert_ne!(id2, id3);
+}
+
+#[test]
+fn test_factory_waste_with_custom_weight() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id =
+        WasteFactory::with_type(&env, &client, &recycler, WasteType::Metal, 5_000);
+
+    assert!(waste_id > 0);
+}
+
+#[test]
+fn test_factory_waste_with_location() {
+    let env = Env::default();
+    let (client, _, recycler, _, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::with_location(
+        &env,
+        &client,
+        &recycler,
+        WasteType::Glass,
+        500,
+        40_000_000,
+        -74_000_000,
+    );
+
+    assert!(waste_id > 0);
+}
+
+// ── IncentiveFactory tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_factory_creates_plastic_incentive() {
+    let env = Env::default();
+    let (client, _, _, _, manufacturer) = setup_full_env(&env);
+
+    let incentive_id = IncentiveFactory::plastic(&env, &client, &manufacturer);
+
+    assert!(incentive_id > 0 || incentive_id == 0, "ID should be valid");
+    let incentive = client.get_incentive_by_id(&incentive_id).expect("Incentive must exist");
+    assert_eq!(incentive.waste_type, WasteType::Plastic);
+}
+
+#[test]
+fn test_factory_creates_metal_incentive() {
+    let env = Env::default();
+    let (client, _, _, _, manufacturer) = setup_full_env(&env);
+
+    let incentive_id = IncentiveFactory::metal(&env, &client, &manufacturer);
+
+    let incentive = client.get_incentive_by_id(&incentive_id).expect("Incentive must exist");
+    assert_eq!(incentive.waste_type, WasteType::Metal);
+}
+
+#[test]
+fn test_factory_creates_incentive_with_custom_params() {
+    let env = Env::default();
+    let (client, _, _, _, manufacturer) = setup_full_env(&env);
+
+    let incentive_id =
+        IncentiveFactory::with_params(&env, &client, &manufacturer, WasteType::Glass, 500, 10_000);
+
+    let incentive = client.get_incentive_by_id(&incentive_id).expect("Incentive must exist");
+    assert_eq!(incentive.reward_points, 500);
+    assert_eq!(incentive.total_budget, 10_000);
+}
+
+// ── TransferFactory tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_factory_transfer_changes_ownership() {
+    let env = Env::default();
+    let (client, _, recycler, collector, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::plastic(&env, &client, &recycler);
+    TransferFactory::transfer(&client, waste_id, &recycler, &collector);
+
+    // After transfer the collector should appear in transfer history
+    let history = client.get_waste_transfer_history_v2(&waste_id);
+    assert!(!history.is_empty(), "Transfer history should not be empty");
+    let last = history.last().unwrap();
+    assert_eq!(last.to, collector);
+}
+
+#[test]
+fn test_factory_multi_hop_transfer() {
+    let env = Env::default();
+    let (client, _, recycler, collector, manufacturer) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::metal(&env, &client, &recycler);
+    TransferFactory::transfer(&client, waste_id, &recycler, &collector);
+    TransferFactory::transfer(&client, waste_id, &collector, &manufacturer);
+
+    let history = client.get_waste_transfer_history_v2(&waste_id);
+    assert_eq!(history.len(), 2, "Should have exactly two transfer records");
+}
+
+#[test]
+fn test_factory_transfer_at_location() {
+    let env = Env::default();
+    let (client, _, recycler, collector, _) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::glass(&env, &client, &recycler);
+    TransferFactory::transfer_at(&client, waste_id, &recycler, &collector, 40_000_000, -74_000_000);
+
+    let history = client.get_waste_transfer_history_v2(&waste_id);
+    assert!(!history.is_empty());
+}
+
+// ── setup_full_env tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_setup_full_env_registers_all_participants() {
+    let env = Env::default();
+    let (client, _, recycler, collector, manufacturer) = setup_full_env(&env);
+
+    assert!(client.is_participant_registered(&recycler));
+    assert!(client.is_participant_registered(&collector));
+    assert!(client.is_participant_registered(&manufacturer));
+}
+
+#[test]
+fn test_full_supply_chain_via_factories() {
+    let env = Env::default();
+    let (client, _, recycler, collector, manufacturer) = setup_full_env(&env);
+
+    let waste_id = WasteFactory::plastic(&env, &client, &recycler);
+    TransferFactory::transfer(&client, waste_id, &recycler, &collector);
+    TransferFactory::transfer(&client, waste_id, &collector, &manufacturer);
+
+    let _ = IncentiveFactory::plastic(&env, &client, &manufacturer);
+
+    let history = client.get_waste_transfer_history_v2(&waste_id);
+    assert_eq!(history.len(), 2);
+}


### PR DESCRIPTION
- Add factories.rs with ParticipantFactory, WasteFactory, IncentiveFactory, TransferFactory
- Add factory_tests.rs with 20 tests using only factory helpers
- Add docs/FACTORY_HELPERS_GUIDE.md with usage patterns and reference table

Closes #946

Closes #947 

Closes #948 
## Description

<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / Other

## Testing

- [ ] Unit tests pass (`cargo test` / `npm test`)
- [ ] Integration tests pass
- [ ] Manual testing done

## Review Checklist

- [ ] Code follows project style (clippy / ESLint clean)
- [ ] No debug logs or console statements left in
- [ ] Tests added or updated for changed behaviour
- [ ] Docs updated if needed
- [ ] Security implications considered

## Related Issues

Closes #
