### PR TITLE
refactor(backend): security boundaries, signing cleanup, explicit DI, structured WS errors

### DIFF
--- a/backend/src/api/signing_api.rs
+++ b/backend/src/api/signing_api.rs
@@ -1,73 +1,54 @@
+//! Signing API — server-side verification endpoint.
+//!
+//! # SDK migration note (#1090)
+//!
+//! Transaction *signing* (key generation, multi-sig orchestration, revocation) has
+//! been migrated entirely to the client-side SDK at
+//! `packages/scavenger-sdk/src/signing.ts`.  The Freighter wallet signs
+//! transaction XDRs in the browser; the server never handles private keys.
+//!
+//! ## What remains on the server
+//!
+//! | Endpoint | Reason kept server-side |
+//! |---|---|
+//! | `POST /api/v1/signing/verify` | Audit trail — webhook consumers and back-end services need to assert a signature without access to a browser wallet |
+//! | `GET /api/v1/signing/docs` | API documentation served to SDK integrators |
+//!
+//! ## What was removed
+//!
+//! * `POST /api/v1/signing/sign` — superseded by `signWithFreighter` / `signWithSecretKey` in the SDK.
+//! * `POST /api/v1/signing/multisig/create` — superseded by client-side multi-sig orchestration.
+//! * `POST /api/v1/signing/multisig/sign` — same.
+//! * `POST /api/v1/signing/revoke` — revocation is managed by the smart contract, not the backend.
+//! * `GET /api/v1/signing/events` — event log was tied to the in-process `TransactionSigningService`
+//!   which no longer runs on the server.
+//! * `GET /api/v1/signing/revocations` — same.
+
 use crate::validation::{error_response, sanitize_string, validate_required, ValidationError};
 use actix_web::{web, HttpResponse};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
-pub struct SignRequest {
-    pub transaction_id: String,
-    pub signer_id: String,
-    pub data: String,
-}
+// ── Request / Response types ──────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
 pub struct VerifyRequest {
     pub transaction_id: String,
+    /// Base-64 or hex-encoded signature bytes produced by the SDK.
     pub signature: String,
+    /// Identifier of the signer (Stellar public key or service-account ID).
     pub signer_id: String,
+    /// Original data that was signed, hex-encoded.
     pub data: String,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct MultiSigCreateRequest {
-    pub transaction_id: String,
-    pub required_signatures: u32,
-}
+// ── Handlers ──────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
-pub struct MultiSigSignRequest {
-    pub transaction_id: String,
-    pub signer_id: String,
-    pub data: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct RevokeRequest {
-    pub transaction_id: String,
-    pub revoked_by: String,
-    pub reason: String,
-}
-
-pub async fn sign_transaction(body: web::Json<SignRequest>) -> HttpResponse {
-    let mut errors = Vec::new();
-    let transaction_id = sanitize_string(&body.transaction_id);
-    let signer_id = sanitize_string(&body.signer_id);
-    let data = sanitize_string(&body.data);
-
-    if let Some(e) = validate_required(&transaction_id, "transaction_id") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&signer_id, "signer_id") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&data, "data") {
-        errors.push(e);
-    }
-
-    if !errors.is_empty() {
-        return error_response(&errors);
-    }
-
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": {
-            "transaction_id": transaction_id,
-            "signer_id": signer_id,
-            "timestamp": chrono::Utc::now().to_rfc3339(),
-        },
-        "message": "transaction signed"
-    }))
-}
-
+/// Verify a signature produced by the client-side SDK.
+///
+/// This endpoint is intentionally stateless: it re-computes the expected
+/// signature from `data` and `signer_id` and returns whether it matches.
+/// It does **not** store signatures — that responsibility belongs to the
+/// Stellar smart contract.
 pub async fn verify_signature(body: web::Json<VerifyRequest>) -> HttpResponse {
     let mut errors = Vec::new();
     let transaction_id = sanitize_string(&body.transaction_id);
@@ -103,190 +84,52 @@ pub async fn verify_signature(body: web::Json<VerifyRequest>) -> HttpResponse {
     }))
 }
 
-pub async fn create_multisig(body: web::Json<MultiSigCreateRequest>) -> HttpResponse {
-    let mut errors = Vec::new();
-    let transaction_id = sanitize_string(&body.transaction_id);
-
-    if let Some(e) = validate_required(&transaction_id, "transaction_id") {
-        errors.push(e);
-    }
-    if body.required_signatures == 0 {
-        errors.push(ValidationError {
-            field: "required_signatures".to_string(),
-            message: "required_signatures must be at least 1".to_string(),
-        });
-    }
-
-    if !errors.is_empty() {
-        return error_response(&errors);
-    }
-
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": {
-            "transaction_id": transaction_id,
-            "required_signatures": body.required_signatures,
-            "status": "pending"
-        },
-        "message": "multisig transaction created"
-    }))
-}
-
-pub async fn multisig_sign(body: web::Json<MultiSigSignRequest>) -> HttpResponse {
-    let mut errors = Vec::new();
-    let transaction_id = sanitize_string(&body.transaction_id);
-    let signer_id = sanitize_string(&body.signer_id);
-    let data = sanitize_string(&body.data);
-
-    if let Some(e) = validate_required(&transaction_id, "transaction_id") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&signer_id, "signer_id") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&data, "data") {
-        errors.push(e);
-    }
-
-    if !errors.is_empty() {
-        return error_response(&errors);
-    }
-
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": {
-            "transaction_id": transaction_id,
-            "signer_id": signer_id,
-            "signatures_collected": 1,
-            "status": "partial"
-        },
-        "message": "multisig signature recorded"
-    }))
-}
-
-pub async fn revoke_signature(body: web::Json<RevokeRequest>) -> HttpResponse {
-    let mut errors = Vec::new();
-    let transaction_id = sanitize_string(&body.transaction_id);
-    let revoked_by = sanitize_string(&body.revoked_by);
-    let reason = sanitize_string(&body.reason);
-
-    if let Some(e) = validate_required(&transaction_id, "transaction_id") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&revoked_by, "revoked_by") {
-        errors.push(e);
-    }
-    if let Some(e) = validate_required(&reason, "reason") {
-        errors.push(e);
-    }
-
-    if !errors.is_empty() {
-        return error_response(&errors);
-    }
-
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": {
-            "transaction_id": transaction_id,
-            "revoked_by": revoked_by,
-            "reason": reason,
-            "revoked_at": chrono::Utc::now().to_rfc3339()
-        },
-        "message": "signature revoked"
-    }))
-}
-
-pub async fn list_events() -> HttpResponse {
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": [],
-        "message": "signing events"
-    }))
-}
-
-pub async fn list_revocations() -> HttpResponse {
-    HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "data": [],
-        "message": "signature revocations"
-    }))
-}
-
+/// Return API documentation for the signing flow.
+///
+/// Describes the current client-side signing architecture so that SDK
+/// integrators know which steps happen in the browser vs on the server.
 pub async fn get_documentation() -> HttpResponse {
     HttpResponse::Ok().json(serde_json::json!({
         "success": true,
         "data": {
-            "scheme": "HMAC-SHA256",
-            "description": "Transaction signing and verification using HMAC-based signature scheme",
-            "capabilities": [
-                "Single signature creation and verification",
-                "Multi-signature support",
-                "Signature revocation",
-                "Event logging"
+            "signing_architecture": "client-side",
+            "sdk_module": "packages/scavenger-sdk/src/signing.ts",
+            "description": "Transaction signing is performed client-side using the Freighter browser wallet or a secret-key strategy via the scavenger-sdk. The server exposes only a stateless /verify endpoint for audit use-cases.",
+            "server_endpoints": [
+                {
+                    "method": "POST",
+                    "path": "/api/v1/signing/verify",
+                    "description": "Stateless signature verification for audit / webhook consumers"
+                },
+                {
+                    "method": "GET",
+                    "path": "/api/v1/signing/docs",
+                    "description": "This documentation endpoint"
+                }
+            ],
+            "client_functions": [
+                "signWithFreighter(txXdr, networkPassphrase)",
+                "signWithSecretKey(txXdr, secretKey, networkPassphrase)"
             ]
         },
         "message": "signing documentation"
     }))
 }
 
+// ── Regression tests for the retained flow ───────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ── sign_transaction ───────────────────────────────────────────────────
+    // ── verify_signature (retained flow) ─────────────────────────────────────
 
     #[actix_web::test]
-    async fn test_sign_transaction_valid() {
-        let body = web::Json(SignRequest {
-            transaction_id: "tx-001".to_string(),
-            signer_id: "signer-001".to_string(),
-            data: "deadbeef".to_string(),
-        });
-        let resp = sign_transaction(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
-    }
-
-    #[actix_web::test]
-    async fn test_sign_transaction_empty_transaction_id_returns_400() {
-        let body = web::Json(SignRequest {
-            transaction_id: "".to_string(),
-            signer_id: "signer-001".to_string(),
-            data: "deadbeef".to_string(),
-        });
-        let resp = sign_transaction(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    #[actix_web::test]
-    async fn test_sign_transaction_empty_signer_id_returns_400() {
-        let body = web::Json(SignRequest {
-            transaction_id: "tx-001".to_string(),
-            signer_id: "".to_string(),
-            data: "deadbeef".to_string(),
-        });
-        let resp = sign_transaction(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    #[actix_web::test]
-    async fn test_sign_transaction_empty_data_returns_400() {
-        let body = web::Json(SignRequest {
-            transaction_id: "tx-001".to_string(),
-            signer_id: "signer-001".to_string(),
-            data: "".to_string(),
-        });
-        let resp = sign_transaction(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    // ── verify_signature ───────────────────────────────────────────────────
-
-    #[actix_web::test]
-    async fn test_verify_signature_valid() {
+    async fn verify_signature_valid_inputs_returns_200() {
         let body = web::Json(VerifyRequest {
             transaction_id: "tx-001".to_string(),
             signature: "abc123sig".to_string(),
-            signer_id: "signer-001".to_string(),
+            signer_id: "GDQP2KPQGKIHYJGXNUIYOMHVKJSV".to_string(),
             data: "deadbeef".to_string(),
         });
         let resp = verify_signature(body).await;
@@ -294,81 +137,70 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_verify_signature_missing_signature_returns_400() {
+    async fn verify_signature_missing_transaction_id_returns_400() {
+        let body = web::Json(VerifyRequest {
+            transaction_id: "".to_string(),
+            signature: "abc123sig".to_string(),
+            signer_id: "GDQP2KPQGKIHYJGXNUIYOMHVKJSV".to_string(),
+            data: "deadbeef".to_string(),
+        });
+        let resp = verify_signature(body).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn verify_signature_missing_signature_returns_400() {
         let body = web::Json(VerifyRequest {
             transaction_id: "tx-001".to_string(),
             signature: "".to_string(),
-            signer_id: "signer-001".to_string(),
+            signer_id: "GDQP2KPQGKIHYJGXNUIYOMHVKJSV".to_string(),
             data: "deadbeef".to_string(),
         });
         let resp = verify_signature(body).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
     }
 
-    // ── create_multisig ────────────────────────────────────────────────────
+    #[actix_web::test]
+    async fn verify_signature_missing_signer_id_returns_400() {
+        let body = web::Json(VerifyRequest {
+            transaction_id: "tx-001".to_string(),
+            signature: "abc123sig".to_string(),
+            signer_id: "".to_string(),
+            data: "deadbeef".to_string(),
+        });
+        let resp = verify_signature(body).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
 
     #[actix_web::test]
-    async fn test_create_multisig_valid() {
-        let body = web::Json(MultiSigCreateRequest {
+    async fn verify_signature_missing_data_returns_400() {
+        let body = web::Json(VerifyRequest {
             transaction_id: "tx-001".to_string(),
-            required_signatures: 2,
+            signature: "abc123sig".to_string(),
+            signer_id: "GDQP2KPQGKIHYJGXNUIYOMHVKJSV".to_string(),
+            data: "".to_string(),
         });
-        let resp = create_multisig(body).await;
+        let resp = verify_signature(body).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn verify_signature_all_fields_whitespace_returns_400() {
+        let body = web::Json(VerifyRequest {
+            transaction_id: "   ".to_string(),
+            signature: "   ".to_string(),
+            signer_id: "   ".to_string(),
+            data: "   ".to_string(),
+        });
+        let resp = verify_signature(body).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    // ── get_documentation ────────────────────────────────────────────────────
+
+    #[actix_web::test]
+    async fn get_documentation_returns_200() {
+        let resp = get_documentation().await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
-    }
-
-    #[actix_web::test]
-    async fn test_create_multisig_empty_tx_id_returns_400() {
-        let body = web::Json(MultiSigCreateRequest {
-            transaction_id: "".to_string(),
-            required_signatures: 2,
-        });
-        let resp = create_multisig(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    #[actix_web::test]
-    async fn test_create_multisig_zero_signatures_returns_400() {
-        let body = web::Json(MultiSigCreateRequest {
-            transaction_id: "tx-001".to_string(),
-            required_signatures: 0,
-        });
-        let resp = create_multisig(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    // ── revoke_signature ───────────────────────────────────────────────────
-
-    #[actix_web::test]
-    async fn test_revoke_signature_valid() {
-        let body = web::Json(RevokeRequest {
-            transaction_id: "tx-001".to_string(),
-            revoked_by: "admin-001".to_string(),
-            reason: "Compromised key".to_string(),
-        });
-        let resp = revoke_signature(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
-    }
-
-    #[actix_web::test]
-    async fn test_revoke_signature_empty_reason_returns_400() {
-        let body = web::Json(RevokeRequest {
-            transaction_id: "tx-001".to_string(),
-            revoked_by: "admin-001".to_string(),
-            reason: "".to_string(),
-        });
-        let resp = revoke_signature(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
-    }
-
-    #[actix_web::test]
-    async fn test_revoke_signature_empty_revoked_by_returns_400() {
-        let body = web::Json(RevokeRequest {
-            transaction_id: "tx-001".to_string(),
-            revoked_by: "".to_string(),
-            reason: "Compromised key".to_string(),
-        });
-        let resp = revoke_signature(body).await;
-        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
     }
 }

--- a/backend/src/api/ws.rs
+++ b/backend/src/api/ws.rs
@@ -1,3 +1,11 @@
+//! WebSocket handler — structured error codes (#1092).
+//!
+//! All error frames emitted over the WebSocket connection use `WsErrorFrame`
+//! with a `WsErrorCode` variant so that clients can match on a stable,
+//! machine-readable code instead of parsing free-text messages.
+//!
+//! See `crate::errors::ws_errors` for the full code table and wire format.
+
 use actix_web::{web, HttpRequest, HttpResponse};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -5,7 +13,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
+use crate::errors::ws_errors::{WsErrorCode, WsErrorFrame};
 use crate::services::api::ApiBuilder;
+
+// ── Message types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
@@ -15,10 +26,12 @@ pub enum WsMessage {
     Event { channel: String, data: serde_json::Value },
     Authenticate { token: String },
     AuthSuccess,
-    AuthError { message: String },
+    /// Structured auth error — use `WsErrorFrame` for wire format.
+    AuthError { code: WsErrorCode, message: String },
     Pong,
     Ping,
-    Error { message: String },
+    /// Structured error — use `WsErrorFrame` for wire format.
+    Error { code: WsErrorCode, message: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +58,8 @@ pub struct ConnectionInfo {
     pub last_heartbeat: String,
 }
 
+// ── Connection manager ────────────────────────────────────────────────────────
+
 #[derive(Clone)]
 pub struct WsConnectionManager {
     pub shutdown_flag: Arc<AtomicBool>,
@@ -66,6 +81,20 @@ impl WsConnectionManager {
         info!("WebSocket server shutdown initiated");
     }
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Serialise a `WsErrorFrame` to a JSON string for sending over the socket.
+fn error_frame(code: WsErrorCode) -> String {
+    WsErrorFrame::new(code).to_json()
+}
+
+/// Serialise a `WsErrorFrame` with a custom message.
+fn error_frame_msg(code: WsErrorCode, message: &str) -> String {
+    WsErrorFrame::with_message(code, message).to_json()
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
 
 pub async fn ws_handler(
     req: HttpRequest,
@@ -101,6 +130,7 @@ pub async fn ws_handler(
                         Ok(actix_ws::Message::Text(text)) => {
                             match serde_json::from_str::<WsMessage>(&text) {
                                 Ok(WsMessage::Authenticate { token }) => {
+                                    // Minimal length check — replace with real JWT validation.
                                     if token.len() >= 8 {
                                         authenticated = true;
                                         user_id = Some(format!("user_{}", &token[..8]));
@@ -111,24 +141,14 @@ pub async fn ws_handler(
                                     } else {
                                         warn!("WebSocket authentication failed: invalid token");
                                         let _ = session
-                                            .text(
-                                                serde_json::to_string(&WsMessage::AuthError {
-                                                    message: "invalid token".to_string(),
-                                                })
-                                                .unwrap(),
-                                            )
+                                            .text(error_frame(WsErrorCode::AuthInvalidToken))
                                             .await;
                                     }
                                 }
                                 Ok(WsMessage::Subscribe { channel }) => {
                                     if !authenticated {
                                         let _ = session
-                                            .text(
-                                                serde_json::to_string(&WsMessage::Error {
-                                                    message: "authentication required".to_string(),
-                                                })
-                                                .unwrap(),
-                                            )
+                                            .text(error_frame(WsErrorCode::AuthTokenRequired))
                                             .await;
                                         continue;
                                     }
@@ -164,14 +184,16 @@ pub async fn ws_handler(
                                         .text(serde_json::to_string(&WsMessage::Pong).unwrap())
                                         .await;
                                 }
-                                _ => {
+                                // Unrecognised message type — structured error.
+                                Ok(_) => {
                                     let _ = session
-                                        .text(
-                                            serde_json::to_string(&WsMessage::Error {
-                                                message: "unknown message type".to_string(),
-                                            })
-                                            .unwrap(),
-                                        )
+                                        .text(error_frame(WsErrorCode::MessageUnknownType))
+                                        .await;
+                                }
+                                // Parse failure — structured error.
+                                Err(_) => {
+                                    let _ = session
+                                        .text(error_frame(WsErrorCode::MessageParseError))
                                         .await;
                                 }
                             }
@@ -199,19 +221,16 @@ pub async fn ws_handler(
 
                     if last_heartbeat.elapsed() > std::time::Duration::from_secs(30) {
                         warn!(connection_id = %connection_id, "Client heartbeat timeout, closing connection");
+                        let _ = session
+                            .text(error_frame(WsErrorCode::ServerHeartbeatTimeout))
+                            .await;
                         break;
                     }
 
                     if shutdown_flag.load(Ordering::Relaxed) {
                         info!(connection_id = %connection_id, "Server shutting down, closing WebSocket");
                         let _ = session
-                            .text(
-                                serde_json::to_string(&serde_json::json!({
-                                    "type": "shutdown",
-                                    "message": "server shutting down"
-                                }))
-                                .unwrap(),
-                            )
+                            .text(error_frame(WsErrorCode::ServerShuttingDown))
                             .await;
                         break;
                     }
@@ -233,13 +252,16 @@ pub async fn ws_health() -> HttpResponse {
     })))
 }
 
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::test;
+
+    // ── WsMessage serialisation ───────────────────────────────────────────────
 
     #[actix_web::test]
-    async fn test_ws_message_serialization() {
+    async fn subscribe_message_serialises_correctly() {
         let msg = WsMessage::Subscribe {
             channel: "waste:updates".to_string(),
         };
@@ -254,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn test_auth_message() {
+    fn auth_message_roundtrips() {
         let msg = WsMessage::Authenticate {
             token: "test_token_123".to_string(),
         };
@@ -267,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn test_event_message() {
+    fn event_message_roundtrips() {
         let msg = WsMessage::Event {
             channel: "test".to_string(),
             data: serde_json::json!({"key": "value"}),
@@ -284,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_connection_info() {
+    fn connection_info_roundtrips() {
         let info = ConnectionInfo {
             connection_id: "conn-1".to_string(),
             user_id: Some("user-1".to_string()),
@@ -296,5 +318,59 @@ mod tests {
         let deserialized: ConnectionInfo = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.connection_id, "conn-1");
         assert_eq!(deserialized.user_id, Some("user-1".to_string()));
+    }
+
+    // ── Structured error frame helpers ────────────────────────────────────────
+
+    #[test]
+    fn error_frame_helper_produces_valid_json_with_code() {
+        let json = error_frame(WsErrorCode::AuthTokenRequired);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "error");
+        assert_eq!(parsed["payload"]["code"], "auth.token_required");
+        assert!(parsed["payload"]["message"].is_string());
+    }
+
+    #[test]
+    fn error_frame_msg_helper_overrides_message() {
+        let json = error_frame_msg(WsErrorCode::ChannelNotFound, "channel 'events' not found");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "channel.not_found");
+        assert_eq!(parsed["payload"]["message"], "channel 'events' not found");
+    }
+
+    #[test]
+    fn auth_invalid_token_error_frame_has_correct_code() {
+        let json = error_frame(WsErrorCode::AuthInvalidToken);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "auth.invalid_token");
+    }
+
+    #[test]
+    fn server_shutting_down_error_frame_has_correct_code() {
+        let json = error_frame(WsErrorCode::ServerShuttingDown);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "server.shutting_down");
+    }
+
+    #[test]
+    fn heartbeat_timeout_error_frame_has_correct_code() {
+        let json = error_frame(WsErrorCode::ServerHeartbeatTimeout);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "server.heartbeat_timeout");
+    }
+
+    #[test]
+    fn parse_error_frame_has_correct_code() {
+        let json = error_frame(WsErrorCode::MessageParseError);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "message.parse_error");
+    }
+
+    #[test]
+    fn unknown_type_error_frame_has_correct_code() {
+        let json = error_frame(WsErrorCode::MessageUnknownType);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["payload"]["code"], "message.unknown_type");
     }
 }

--- a/backend/src/container.rs
+++ b/backend/src/container.rs
@@ -1,11 +1,33 @@
-//! Dependency injection container (#914).
+//! Dependency injection container (#914, #1091).
 //!
-//! `AppContainer` is the single place where every service is constructed and
-//! held behind an `Arc`.  Handlers receive individual `Arc<dyn Trait>` slices
-//! of the container via actix-web's `web::Data` — none of them construct their
-//! own dependencies.
+//! `AppContainer` is the single composition root. Every service dependency is
+//! expressed as an explicit constructor parameter — there are no implicit global
+//! singletons or hidden initialization-order dependencies.
+//!
+//! # Design rules
+//!
+//! 1. **All dependencies are constructor parameters.** `AppContainer::new` lists
+//!    every service as an argument. The compiler enforces that nothing is
+//!    accidentally omitted.
+//!
+//! 2. **`from_env` is the only place that reads environment variables.** It calls
+//!    `new(...)` after building each dependency. Adding a new env-var dependency
+//!    means adding it here and nowhere else.
+//!
+//! 3. **Handlers never construct their own dependencies.** They receive individual
+//!    `Arc<dyn Trait>` slices via actix-web's `web::Data`.
+//!
+//! # How to add a new service
+//!
+//! 1. Define your service type (struct + trait if it needs to be mockable).
+//! 2. Add an `Arc<dyn YourTrait>` (or `Arc<ConcreteType>`) field to `AppContainer`.
+//! 3. Add a matching parameter to `AppContainer::new`.
+//! 4. Construct the real implementation in `AppContainer::from_env` and pass it.
+//! 5. Add a `FakeYourService` in the `fakes` module below and use it in
+//!    `AppContainer::with_test_config` so existing DI tests keep compiling.
 //!
 //! # Usage (in `main.rs`)
+//!
 //! ```ignore
 //! let container = AppContainer::from_env()
 //!     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
@@ -33,6 +55,9 @@ use crate::{
 };
 
 /// Central DI container — built once at startup, then shared via `Arc`.
+///
+/// All fields are `pub` so that `main.rs` can extract individual `Arc`s for
+/// actix-web `web::Data` registration without cloning the whole container.
 pub struct AppContainer {
     pub email: Arc<dyn EmailService>,
     pub notification: Arc<dyn NotificationService>,
@@ -49,7 +74,52 @@ pub struct AppContainer {
 }
 
 impl AppContainer {
-    /// Construct the container from environment variables.
+    /// Construct the container with **explicit** dependencies.
+    ///
+    /// This is the canonical constructor.  Every dependency is a named
+    /// parameter — there is no implicit ordering; the compiler will reject
+    /// any attempt to call this with a missing argument.
+    ///
+    /// In production code, call [`AppContainer::from_env`] which reads
+    /// environment variables and delegates here.
+    /// In tests, call [`AppContainer::with_test_config`] or build fakes
+    /// manually and call this constructor directly.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        email: Arc<dyn EmailService>,
+        notification: Arc<dyn NotificationService>,
+        reporting: Arc<dyn ReportService>,
+        storage: Arc<dyn StorageService>,
+        webhook: Arc<WebhookManager>,
+        cache: Cache,
+        cache_invalidation: Arc<CacheInvalidationManager>,
+        audit: Arc<AuditService>,
+        verification: Arc<dyn VerificationService>,
+        search: Arc<SearchClient>,
+        archival: Arc<ArchivalService>,
+        stellar: Arc<StellarRpcClient>,
+    ) -> Self {
+        Self {
+            email,
+            notification,
+            reporting,
+            storage,
+            webhook,
+            cache,
+            cache_invalidation,
+            audit,
+            verification,
+            search,
+            archival,
+            stellar,
+        }
+    }
+
+    /// Construct the container by reading all configuration from environment variables.
+    ///
+    /// This is the production entry-point.  It builds each concrete service and
+    /// calls [`AppContainer::new`].  Every `unwrap_or*` has a documented fallback
+    /// value that is safe for local development.
     pub fn from_env() -> Result<Self, String> {
         let email_service: Arc<dyn EmailService> = Arc::new(SendGridEmailService::new(
             std::env::var("SENDGRID_API_KEY").unwrap_or_default(),
@@ -75,12 +145,12 @@ impl AppContainer {
         let audit_service = Arc::new(AuditService::new());
         let verification_service: Arc<dyn VerificationService> = Arc::new(DefaultVerificationService::new());
 
-        // Stellar RPC
+        // Stellar RPC — uses STELLAR_RPC_URL / CONTRACT_ID env vars.
         let stellar_rpc_config = StellarRpcConfig::from_env();
         let stellar_client =
             Arc::new(StellarRpcClient::new(stellar_rpc_config).map_err(|e| format!("Stellar RPC init failed: {e}"))?);
 
-        // Search client
+        // Elasticsearch search client.
         let search_config = SearchClientConfig {
             url: std::env::var("ELASTICSEARCH_URL").unwrap_or_else(|_| "http://localhost:9200".to_string()),
             username: std::env::var("ELASTICSEARCH_USERNAME").ok(),
@@ -91,7 +161,7 @@ impl AppContainer {
         let search_client =
             Arc::new(SearchClient::new(search_config).map_err(|e| format!("Search client init failed: {e}"))?);
 
-        // Archival service
+        // Archival service — file-system backed by default.
         let archival_storage_path =
             std::env::var("ARCHIVAL_STORAGE_PATH").unwrap_or_else(|_| "/tmp/archives".to_string());
         let archival_storage = Arc::new(FileSystemArchivalStorage::new(std::path::PathBuf::from(
@@ -99,20 +169,20 @@ impl AppContainer {
         )));
         let archival_service = Arc::new(ArchivalService::new(archival_storage));
 
-        Ok(Self {
-            email: email_service,
-            notification: notification_service,
-            reporting: reporting_service,
-            storage: storage_service,
-            webhook: webhook_manager,
+        Ok(Self::new(
+            email_service,
+            notification_service,
+            reporting_service,
+            storage_service,
+            webhook_manager,
             cache,
             cache_invalidation,
-            audit: audit_service,
-            verification: verification_service,
-            search: search_client,
-            archival: archival_service,
-            stellar: stellar_client,
-        })
+            audit_service,
+            verification_service,
+            search_client,
+            archival_service,
+            stellar_client,
+        ))
     }
 }
 
@@ -120,8 +190,11 @@ impl AppContainer {
 
 #[cfg(test)]
 pub mod fakes {
-    //! In-memory fakes for every service trait.  Import these in unit tests
-    //! instead of spinning up real connections.
+    //! In-memory fakes for every service trait.
+    //!
+    //! Import these in unit tests instead of spinning up real connections.
+    //! All fakes implement the same traits as the real services, so they can
+    //! be passed to `AppContainer::new` directly.
 
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -423,5 +496,94 @@ pub mod fakes {
         async fn send_rejection_notification(&self, _participant_id: String, _reason: String) -> Result<(), String> {
             Ok(())
         }
+    }
+}
+
+// ── Container construction tests ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod container_tests {
+    //! Verifies that `AppContainer::new` can be wired up with fake services
+    //! and that the trait objects satisfy the required bounds.
+
+    use std::sync::Arc;
+
+    use super::fakes::*;
+    use crate::{
+        cache::{Cache, CacheInvalidationManager},
+        rpc::{StellarRpcClient, StellarRpcConfig},
+        search::{SearchClient, SearchClientConfig},
+        services::{
+            AuditService, ArchivalService, FileSystemArchivalStorage,
+            EmailService, NotificationService, ReportService, StorageService, VerificationService,
+            WebhookManager,
+        },
+    };
+
+    /// Build a minimal test-only `AppContainer` using in-memory fakes for all
+    /// trait-object services and stub configurations for infrastructure clients.
+    ///
+    /// This test verifies:
+    /// * All service traits are `dyn`-compatible.
+    /// * `AppContainer::new` accepts them without implicit ordering.
+    /// * No panics occur during construction with test config values.
+    #[test]
+    fn container_builds_with_test_fakes() {
+        let email: Arc<dyn EmailService> = Arc::new(FakeEmailService::new());
+        let notification: Arc<dyn NotificationService> = Arc::new(FakeNotificationService::new());
+        let reporting: Arc<dyn ReportService> = Arc::new(FakeReportService::new());
+        let storage: Arc<dyn StorageService> = Arc::new(FakeStorageService::new());
+        let webhook = Arc::new(WebhookManager::new());
+        let cache = Cache::new(60);
+        let cache_invalidation = Arc::new(CacheInvalidationManager::new());
+        let audit = Arc::new(AuditService::new());
+        let verification: Arc<dyn VerificationService> = Arc::new(FakeVerificationService::new());
+
+        // Search client with a test URL (no real connection made at construction).
+        let search_config = SearchClientConfig {
+            url: "http://localhost:9200".to_string(),
+            username: None,
+            password: None,
+            timeout_seconds: 5,
+            validate_certificates: false,
+        };
+        let search = Arc::new(
+            SearchClient::new(search_config).expect("search client construction should not fail"),
+        );
+
+        // Archival service backed by /tmp.
+        let archival_storage = Arc::new(FileSystemArchivalStorage::new(
+            std::path::PathBuf::from("/tmp/test-archives"),
+        ));
+        let archival = Arc::new(ArchivalService::new(archival_storage));
+
+        // Stellar RPC with stub config (no real connection made at construction).
+        let stellar_config = StellarRpcConfig::from_env();
+        let stellar = Arc::new(
+            StellarRpcClient::new(stellar_config).expect("stellar client construction should not fail"),
+        );
+
+        // Exercise the explicit constructor — this is the assertion: it compiles
+        // and runs without panicking.
+        let container = super::AppContainer::new(
+            email,
+            notification,
+            reporting,
+            storage,
+            webhook,
+            cache,
+            cache_invalidation,
+            audit,
+            verification,
+            search,
+            archival,
+            stellar,
+        );
+
+        // Spot-check that the container fields are accessible.
+        // (No network calls are made; these are all in-memory fakes or stubs.)
+        let _ = container.audit.clone();
+        let _ = container.cache.clone();
+        let _ = container.webhook.clone();
     }
 }

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -3,6 +3,7 @@ pub mod conversion;
 pub mod format;
 pub mod serialization;
 pub mod types;
+pub mod ws_errors;
 
 #[cfg(test)]
 mod tests;
@@ -16,3 +17,4 @@ pub use types::{
     AnalyticsError, AppError, AuthError, ContractError, EmailError, ErrorCategory, ExportError, FieldError,
     NotificationError, SerializationError, StorageError, ValidationError, WebhookError,
 };
+pub use ws_errors::{WsErrorCode, WsErrorFrame};

--- a/backend/src/errors/ws_errors.rs
+++ b/backend/src/errors/ws_errors.rs
@@ -1,0 +1,209 @@
+//! Structured WebSocket error codes (#1092).
+//!
+//! All error frames sent over the WebSocket connection use a `WsErrorCode`
+//! variant so that clients can match on a stable machine-readable value
+//! instead of parsing free-text messages.
+//!
+//! # Wire format
+//!
+//! Every error frame is a JSON object with this shape:
+//!
+//! ```json
+//! {
+//!   "type": "error",
+//!   "payload": {
+//!     "code": "auth.token_required",
+//!     "message": "Authentication required before subscribing to channels"
+//!   }
+//! }
+//! ```
+//!
+//! The `code` field is the stable value clients should `switch` on.
+//! The `message` is a human-readable hint that may change between releases.
+//!
+//! # Code table
+//!
+//! | Code | When emitted |
+//! |---|---|
+//! | `auth.token_required` | Client sent a non-auth message before authenticating |
+//! | `auth.invalid_token` | Authenticate payload carried a token that failed validation |
+//! | `channel.not_found` | Subscribe/unsubscribe targeting an unknown channel name |
+//! | `message.unknown_type` | Incoming JSON message had an unrecognised `type` field |
+//! | `message.parse_error` | Incoming text frame was not valid JSON |
+//! | `server.shutting_down` | Server is draining connections |
+//! | `server.heartbeat_timeout` | Client missed heartbeats for too long |
+
+use serde::{Deserialize, Serialize};
+
+/// Stable, machine-readable WebSocket error codes.
+///
+/// All variants serialize to snake_case dot-separated strings so that
+/// TypeScript / JavaScript consumers can use a `switch` statement on the
+/// `code` field without importing the Rust enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WsErrorCode {
+    /// Client sent a non-authentication message before authenticating.
+    #[serde(rename = "auth.token_required")]
+    AuthTokenRequired,
+    /// The supplied authentication token is invalid or too short.
+    #[serde(rename = "auth.invalid_token")]
+    AuthInvalidToken,
+    /// Subscribe/unsubscribe referenced an unknown channel.
+    #[serde(rename = "channel.not_found")]
+    ChannelNotFound,
+    /// Message `type` field did not match any known variant.
+    #[serde(rename = "message.unknown_type")]
+    MessageUnknownType,
+    /// Incoming text frame was not valid JSON.
+    #[serde(rename = "message.parse_error")]
+    MessageParseError,
+    /// Server is shutting down and draining connections.
+    #[serde(rename = "server.shutting_down")]
+    ServerShuttingDown,
+    /// Client has not sent a heartbeat within the timeout window.
+    #[serde(rename = "server.heartbeat_timeout")]
+    ServerHeartbeatTimeout,
+}
+
+impl WsErrorCode {
+    /// Returns a default human-readable description for this code.
+    ///
+    /// This string is included as `message` in the error frame.  It is
+    /// informational only — clients must not key logic on it.
+    pub fn default_message(&self) -> &'static str {
+        match self {
+            Self::AuthTokenRequired => "Authentication required before subscribing to channels",
+            Self::AuthInvalidToken => "Invalid or malformed authentication token",
+            Self::ChannelNotFound => "The requested channel does not exist",
+            Self::MessageUnknownType => "Unrecognised message type",
+            Self::MessageParseError => "Message could not be parsed as JSON",
+            Self::ServerShuttingDown => "Server is shutting down",
+            Self::ServerHeartbeatTimeout => "Heartbeat timeout: connection closed",
+        }
+    }
+}
+
+/// A structured WebSocket error frame, ready to be serialised and sent.
+///
+/// ```rust
+/// # use backend::errors::ws_errors::{WsErrorCode, WsErrorFrame};
+/// let frame = WsErrorFrame::new(WsErrorCode::AuthTokenRequired);
+/// let json = serde_json::to_string(&frame).unwrap();
+/// // {"type":"error","payload":{"code":"auth.token_required","message":"..."}}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WsErrorFrame {
+    #[serde(rename = "type")]
+    pub frame_type: String,
+    pub payload: WsErrorPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WsErrorPayload {
+    pub code: WsErrorCode,
+    pub message: String,
+}
+
+impl WsErrorFrame {
+    /// Build a frame using the code's default message.
+    pub fn new(code: WsErrorCode) -> Self {
+        let message = code.default_message().to_string();
+        Self {
+            frame_type: "error".to_string(),
+            payload: WsErrorPayload { code, message },
+        }
+    }
+
+    /// Build a frame with a custom message.
+    pub fn with_message(code: WsErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            frame_type: "error".to_string(),
+            payload: WsErrorPayload {
+                code,
+                message: message.into(),
+            },
+        }
+    }
+
+    /// Serialise the frame to a JSON string, falling back to a plain-text
+    /// sentinel on serialisation failure (should never happen in practice).
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self)
+            .unwrap_or_else(|_| r#"{"type":"error","payload":{"code":"internal","message":"serialisation failure"}}"#.to_string())
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_serialise_to_dot_notation() {
+        let code = WsErrorCode::AuthTokenRequired;
+        let json = serde_json::to_value(&code).unwrap();
+        assert_eq!(json, serde_json::json!("auth.token_required"));
+
+        let code = WsErrorCode::MessageParseError;
+        let json = serde_json::to_value(&code).unwrap();
+        assert_eq!(json, serde_json::json!("message.parse_error"));
+
+        let code = WsErrorCode::ServerShuttingDown;
+        let json = serde_json::to_value(&code).unwrap();
+        assert_eq!(json, serde_json::json!("server.shutting_down"));
+    }
+
+    #[test]
+    fn error_codes_roundtrip_deserialise() {
+        let original = WsErrorCode::AuthInvalidToken;
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: WsErrorCode = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn ws_error_frame_new_has_type_error() {
+        let frame = WsErrorFrame::new(WsErrorCode::AuthTokenRequired);
+        assert_eq!(frame.frame_type, "error");
+        assert_eq!(frame.payload.code, WsErrorCode::AuthTokenRequired);
+        assert!(!frame.payload.message.is_empty());
+    }
+
+    #[test]
+    fn ws_error_frame_with_message_overrides_default() {
+        let frame = WsErrorFrame::with_message(WsErrorCode::ChannelNotFound, "channel 'foo' not found");
+        assert_eq!(frame.payload.message, "channel 'foo' not found");
+    }
+
+    #[test]
+    fn ws_error_frame_to_json_produces_valid_json() {
+        let frame = WsErrorFrame::new(WsErrorCode::MessageUnknownType);
+        let json = frame.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "error");
+        assert_eq!(parsed["payload"]["code"], "message.unknown_type");
+        assert!(parsed["payload"]["message"].is_string());
+    }
+
+    #[test]
+    fn all_codes_have_non_empty_default_messages() {
+        let codes = [
+            WsErrorCode::AuthTokenRequired,
+            WsErrorCode::AuthInvalidToken,
+            WsErrorCode::ChannelNotFound,
+            WsErrorCode::MessageUnknownType,
+            WsErrorCode::MessageParseError,
+            WsErrorCode::ServerShuttingDown,
+            WsErrorCode::ServerHeartbeatTimeout,
+        ];
+        for code in &codes {
+            assert!(
+                !code.default_message().is_empty(),
+                "code {:?} has empty default message",
+                code
+            );
+        }
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -249,20 +249,11 @@ async fn main() -> std::io::Result<()> {
                 "/api/v1/compliance/report",
                 web::post().to(compliance_api::generate_compliance_report),
             )
-            // Transaction Signing (Task 7)
-            .route("/api/v1/signing/sign", web::post().to(signing_api::sign_transaction))
+            // Transaction Signing (#1090)
+            // sign/multisig/revoke/events/revocations removed — superseded by
+            // packages/scavenger-sdk/src/signing.ts client-side signing.
+            // Only stateless verify and documentation remain server-side.
             .route("/api/v1/signing/verify", web::post().to(signing_api::verify_signature))
-            .route("/api/v1/signing/multisig", web::post().to(signing_api::create_multisig))
-            .route(
-                "/api/v1/signing/multisig/sign",
-                web::post().to(signing_api::multisig_sign),
-            )
-            .route("/api/v1/signing/revoke", web::post().to(signing_api::revoke_signature))
-            .route("/api/v1/signing/events", web::get().to(signing_api::list_events))
-            .route(
-                "/api/v1/signing/revocations",
-                web::get().to(signing_api::list_revocations),
-            )
             .route(
                 "/api/v1/signing/documentation",
                 web::get().to(signing_api::get_documentation),

--- a/backend/src/security/auth.rs
+++ b/backend/src/security/auth.rs
@@ -1,0 +1,241 @@
+//! Authentication and authorisation helpers.
+//!
+//! # Responsibility boundary
+//!
+//! | Module | Owns |
+//! |---|---|
+//! | `security/auth.rs` (this file) | Token validation logic, scope checking, permission rules, `AuthError` production |
+//! | `security/signing.rs` | Cryptographic signing / multi-sig for on-chain transactions |
+//! | `middleware/csrf.rs` | HTTP-layer CSRF token generation & validation (stateless, per-request) |
+//! | `middleware/rate_limit.rs` | Abuse-prevention throttling — unrelated to identity |
+//! | `middleware/request_id.rs` | Correlation-id injection — infrastructure concern |
+//! | `middleware/validation.rs` | Input-shape validation — not identity |
+//!
+//! The rule of thumb:
+//! * **security/** = pure logic about *who the caller is* and *what they may do*.
+//! * **middleware/** = HTTP-layer cross-cutting concerns that operate on the
+//!   actix-web request/response cycle.
+//!
+//! CSRF sits in `middleware/` because it is a per-request HTTP header check.
+//! If the CSRF *state* (e.g. token storage, rotation policy) ever grows beyond
+//! the current stateless hash scheme it should be extracted into a
+//! `security/csrf_state.rs` helper while `middleware/csrf.rs` keeps only the
+//! actix glue.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::errors::types::AuthError;
+
+// ── Token claims ──────────────────────────────────────────────────────────────
+
+/// Decoded claims extracted from a bearer token.
+///
+/// In production this would be parsed from a signed JWT.  The struct is kept
+/// framework-agnostic so the validation logic is testable without an HTTP server.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TokenClaims {
+    /// Subject — typically a user or service account ID.
+    pub sub: String,
+    /// Scopes granted to this token, e.g. `["waste:read", "waste:write"]`.
+    pub scopes: Vec<String>,
+    /// Absolute expiry instant (UTC).
+    pub expires_at: DateTime<Utc>,
+}
+
+impl TokenClaims {
+    /// Returns `true` if the token has not yet expired relative to `now`.
+    pub fn is_valid_at(&self, now: DateTime<Utc>) -> bool {
+        now < self.expires_at
+    }
+
+    /// Returns `true` if the token grants the requested scope.
+    pub fn has_scope(&self, required: &str) -> bool {
+        self.scopes.iter().any(|s| s == required)
+    }
+}
+
+// ── Verification ──────────────────────────────────────────────────────────────
+
+/// Errors that can arise during token verification.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VerifyError {
+    /// Token has passed its expiry instant.
+    Expired,
+    /// Token signature is invalid or the header/payload is malformed.
+    Malformed(String),
+    /// Token is structurally valid but does not carry the required scope.
+    InsufficientScope { required: String },
+}
+
+impl From<VerifyError> for AuthError {
+    fn from(e: VerifyError) -> Self {
+        match e {
+            VerifyError::Expired => AuthError::TokenExpired,
+            VerifyError::Malformed(msg) => AuthError::InvalidToken,
+            VerifyError::InsufficientScope { .. } => AuthError::Forbidden("insufficient scope".to_string()),
+        }
+    }
+}
+
+/// Validates a set of decoded `TokenClaims` against the current time.
+///
+/// Returns `Ok(claims)` when the token is live, `Err(VerifyError::Expired)`
+/// when it has expired.
+pub fn verify_token(claims: &TokenClaims, now: DateTime<Utc>) -> Result<&TokenClaims, VerifyError> {
+    if !claims.is_valid_at(now) {
+        return Err(VerifyError::Expired);
+    }
+    Ok(claims)
+}
+
+/// Asserts that `claims` carries the `required` scope.
+///
+/// Call this *after* `verify_token` so expiry is always checked first.
+///
+/// ```
+/// # use backend::security::auth::{TokenClaims, check_scope, VerifyError};
+/// # use chrono::Utc;
+/// let claims = TokenClaims {
+///     sub: "u1".into(),
+///     scopes: vec!["waste:read".into()],
+///     expires_at: Utc::now() + chrono::Duration::hours(1),
+/// };
+/// assert!(check_scope(&claims, "waste:read").is_ok());
+/// assert!(check_scope(&claims, "waste:write").is_err());
+/// ```
+pub fn check_scope(claims: &TokenClaims, required: &str) -> Result<(), VerifyError> {
+    if claims.has_scope(required) {
+        Ok(())
+    } else {
+        Err(VerifyError::InsufficientScope {
+            required: required.to_string(),
+        })
+    }
+}
+
+/// Convenience helper: verify token liveness *and* scope in one call.
+///
+/// Returns `Err(VerifyError::Expired)` before checking scope so the caller
+/// always gets the most actionable error first.
+pub fn verify_and_check_scope(
+    claims: &TokenClaims,
+    required: &str,
+    now: DateTime<Utc>,
+) -> Result<(), VerifyError> {
+    verify_token(claims, now)?;
+    check_scope(claims, required)?;
+    Ok(())
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn make_claims(scopes: Vec<&str>, offset: Duration) -> TokenClaims {
+        TokenClaims {
+            sub: "user-1".to_string(),
+            scopes: scopes.into_iter().map(str::to_string).collect(),
+            expires_at: Utc::now() + offset,
+        }
+    }
+
+    // ── verify_token ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_token_passes() {
+        let claims = make_claims(vec!["waste:read"], Duration::hours(1));
+        assert!(verify_token(&claims, Utc::now()).is_ok());
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        // Token expired 1 second ago.
+        let claims = make_claims(vec!["waste:read"], Duration::seconds(-1));
+        let err = verify_token(&claims, Utc::now()).unwrap_err();
+        assert_eq!(err, VerifyError::Expired);
+    }
+
+    #[test]
+    fn token_expiring_exactly_now_is_rejected() {
+        // expires_at == now  ⟹  NOT (now < expires_at)  ⟹  expired.
+        let now = Utc::now();
+        let claims = TokenClaims {
+            sub: "u".into(),
+            scopes: vec![],
+            expires_at: now,
+        };
+        let err = verify_token(&claims, now).unwrap_err();
+        assert_eq!(err, VerifyError::Expired);
+    }
+
+    // ── check_scope ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn correct_scope_passes() {
+        let claims = make_claims(vec!["waste:read", "waste:write"], Duration::hours(1));
+        assert!(check_scope(&claims, "waste:write").is_ok());
+    }
+
+    #[test]
+    fn wrong_scope_returns_insufficient_scope_error() {
+        let claims = make_claims(vec!["waste:read"], Duration::hours(1));
+        let err = check_scope(&claims, "admin:delete").unwrap_err();
+        assert_eq!(
+            err,
+            VerifyError::InsufficientScope {
+                required: "admin:delete".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn empty_scopes_always_fails_scope_check() {
+        let claims = make_claims(vec![], Duration::hours(1));
+        assert!(check_scope(&claims, "any:scope").is_err());
+    }
+
+    // ── verify_and_check_scope ────────────────────────────────────────────────
+
+    #[test]
+    fn expired_token_reported_before_scope_error() {
+        // Even if the scope would match, expiry takes priority.
+        let claims = make_claims(vec!["waste:read"], Duration::seconds(-60));
+        let err = verify_and_check_scope(&claims, "waste:read", Utc::now()).unwrap_err();
+        assert_eq!(err, VerifyError::Expired, "expiry must be checked before scope");
+    }
+
+    #[test]
+    fn valid_token_wrong_scope_reports_insufficient_scope() {
+        let claims = make_claims(vec!["waste:read"], Duration::hours(1));
+        let err = verify_and_check_scope(&claims, "admin:write", Utc::now()).unwrap_err();
+        assert!(
+            matches!(err, VerifyError::InsufficientScope { .. }),
+            "should be InsufficientScope, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn valid_token_correct_scope_succeeds() {
+        let claims = make_claims(vec!["waste:read", "waste:write"], Duration::hours(1));
+        assert!(verify_and_check_scope(&claims, "waste:write", Utc::now()).is_ok());
+    }
+
+    // ── AuthError conversion ──────────────────────────────────────────────────
+
+    #[test]
+    fn verify_error_converts_to_auth_error() {
+        let e: AuthError = VerifyError::Expired.into();
+        assert!(matches!(e, AuthError::TokenExpired));
+
+        let e: AuthError = VerifyError::InsufficientScope {
+            required: "x".into(),
+        }
+        .into();
+        assert!(matches!(e, AuthError::Forbidden(_)));
+    }
+}

--- a/backend/src/security/mod.rs
+++ b/backend/src/security/mod.rs
@@ -1,3 +1,47 @@
+//! Security module — pure identity and cryptographic concerns.
+//!
+//! # Responsibility boundary
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │  security/                                                      │
+//! │  ┌──────────────────┐  ┌────────────────────────────────────┐  │
+//! │  │  auth.rs         │  │  signing.rs                        │  │
+//! │  │                  │  │                                    │  │
+//! │  │  • TokenClaims   │  │  • TransactionSigningService       │  │
+//! │  │  • verify_token  │  │  • SignatureScheme / Request       │  │
+//! │  │  • check_scope   │  │  • MultiSignatureSupport           │  │
+//! │  │  • VerifyError   │  │  • SignatureRevocation             │  │
+//! │  └──────────────────┘  └────────────────────────────────────┘  │
+//! └─────────────────────────────────────────────────────────────────┘
+//!
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │  middleware/    (HTTP-layer cross-cutting concerns)              │
+//! │                                                                 │
+//! │  • csrf.rs         — stateless CSRF token check per request     │
+//! │  • rate_limit.rs   — throttling / abuse prevention              │
+//! │  • request_id.rs   — correlation-id injection                   │
+//! │  • validation.rs   — request-body shape validation              │
+//! │  • idempotency.rs  — idempotency-key replay protection          │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Decision rules
+//!
+//! * Put logic in **`security/`** when it is about *who the caller is*, *what
+//!   keys they hold*, or *what actions they are permitted to perform*.
+//! * Put logic in **`middleware/`** when it operates on the actix-web
+//!   `ServiceRequest` / `ServiceResponse` cycle and does not need to know about
+//!   user identity or cryptographic material.
+//!
+//! CSRF sits in `middleware/` because it is a per-request HTTP header check.
+//! If CSRF *state* (e.g. token storage, rotation policy) ever grows beyond the
+//! current stateless hash scheme it should be extracted into a
+//! `security/csrf_state.rs` helper while `middleware/csrf.rs` retains only the
+//! actix glue.
+
+pub mod auth;
 pub mod signing;
 
+pub use auth::{check_scope, verify_and_check_scope, verify_token, TokenClaims, VerifyError};
 pub use signing::*;

--- a/frontend/src/lib/__tests__/wsClient.test.ts
+++ b/frontend/src/lib/__tests__/wsClient.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the structured WebSocket client (#1092).
+ *
+ * Uses a minimal WebSocket mock — no real network connection is made.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  ScavengerWsClient,
+  type WsErrorCode,
+  type WsErrorFrame,
+  type ServerMessage,
+} from '../wsClient'
+
+// ── WebSocket mock ─────────────────────────────────────────────────────────────
+
+/** Minimal mock that captures sent messages and exposes trigger helpers. */
+class MockWebSocket {
+  static OPEN = 1
+  readyState = MockWebSocket.OPEN
+
+  private listeners: Record<string, ((...args: unknown[]) => void)[]> = {}
+
+  addEventListener(event: string, cb: (...args: unknown[]) => void): void {
+    if (!this.listeners[event]) this.listeners[event] = []
+    this.listeners[event].push(cb)
+  }
+
+  send = vi.fn()
+
+  close = vi.fn(() => {
+    this.readyState = 3 // CLOSED
+  })
+
+  /** Simulate the server sending a message. */
+  triggerMessage(data: unknown): void {
+    for (const cb of this.listeners['message'] ?? []) {
+      cb({ data: JSON.stringify(data) })
+    }
+  }
+
+  /** Simulate the connection opening. */
+  triggerOpen(): void {
+    for (const cb of this.listeners['open'] ?? []) {
+      cb({})
+    }
+  }
+
+  /** Simulate the connection closing. */
+  triggerClose(event = {}): void {
+    for (const cb of this.listeners['close'] ?? []) {
+      cb(event)
+    }
+  }
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+function makeErrorFrame(code: WsErrorCode, message = 'test error'): WsErrorFrame {
+  return { type: 'error', payload: { code, message } }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ScavengerWsClient', () => {
+  let mockWs: MockWebSocket
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket()
+    // Patch global WebSocket so ScavengerWsClient uses our mock.
+    vi.stubGlobal('WebSocket', vi.fn(() => mockWs))
+  })
+
+  it('sends Authenticate message on open', () => {
+    const client = new ScavengerWsClient({
+      url: 'ws://localhost:8080/ws',
+      token: 'my-test-token',
+    })
+    client.connect()
+    mockWs.triggerOpen()
+
+    expect(mockWs.send).toHaveBeenCalledOnce()
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0])
+    expect(sent.type).toBe('Authenticate')
+    expect(sent.payload.token).toBe('my-test-token')
+  })
+
+  it('calls onOpen callback after auth message sent', () => {
+    const onOpen = vi.fn()
+    const client = new ScavengerWsClient({
+      url: 'ws://localhost:8080/ws',
+      token: 'tok',
+      onOpen,
+    })
+    client.connect()
+    mockWs.triggerOpen()
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+
+  // ── Structured error handling ──────────────────────────────────────────────
+
+  it('routes auth.token_required error frame to onError', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('auth.token_required'))
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].code).toBe('auth.token_required')
+  })
+
+  it('routes auth.invalid_token error frame to onError', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('auth.invalid_token'))
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].code).toBe('auth.invalid_token')
+  })
+
+  it('routes server.shutting_down error frame to onError', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('server.shutting_down'))
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].code).toBe('server.shutting_down')
+  })
+
+  it('routes server.heartbeat_timeout error frame to onError', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('server.heartbeat_timeout'))
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].code).toBe('server.heartbeat_timeout')
+  })
+
+  it('routes message.parse_error error frame to onError', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('message.parse_error'))
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].code).toBe('message.parse_error')
+  })
+
+  it('does not call onMessage for error frames', () => {
+    const onMessage = vi.fn()
+    const client = new ScavengerWsClient({
+      url: 'ws://x',
+      token: 't',
+      onMessage,
+    })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('auth.token_required'))
+
+    // onMessage must NOT be called — error frames are routed to onError only.
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('error payload includes message string', () => {
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onError })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage(makeErrorFrame('channel.not_found', "channel 'events' not found"))
+
+    const payload = onError.mock.calls[0][0]
+    expect(payload.message).toBe("channel 'events' not found")
+  })
+
+  // ── Normal messages ────────────────────────────────────────────────────────
+
+  it('routes non-error messages to onMessage', () => {
+    const onMessage = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onMessage })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage({ type: 'AuthSuccess' })
+
+    expect(onMessage).toHaveBeenCalledOnce()
+    const msg = onMessage.mock.calls[0][0] as ServerMessage
+    expect(msg.type).toBe('AuthSuccess')
+  })
+
+  it('handles subscribed confirmation message', () => {
+    const onMessage = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onMessage })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerMessage({ type: 'subscribed', channel: 'waste:updates' })
+
+    const msg = onMessage.mock.calls[0][0] as { type: 'subscribed'; channel: string }
+    expect(msg.channel).toBe('waste:updates')
+  })
+
+  // ── Disconnect / close ─────────────────────────────────────────────────────
+
+  it('calls onClose when server closes connection', () => {
+    const onClose = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onClose })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.triggerClose({ code: 1000 })
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('disconnect closes the socket', () => {
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't' })
+    client.connect()
+    client.disconnect()
+
+    expect(mockWs.close).toHaveBeenCalledOnce()
+  })
+
+  // ── subscribe / unsubscribe ────────────────────────────────────────────────
+
+  it('subscribe sends Subscribe message', () => {
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't' })
+    client.connect()
+    mockWs.triggerOpen()
+    // Reset spy so we only see the subscribe call.
+    mockWs.send.mockClear()
+
+    client.subscribe('waste:updates')
+
+    expect(mockWs.send).toHaveBeenCalledOnce()
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0])
+    expect(sent.type).toBe('Subscribe')
+    expect(sent.payload.channel).toBe('waste:updates')
+  })
+
+  it('unsubscribe sends Unsubscribe message', () => {
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't' })
+    client.connect()
+    mockWs.triggerOpen()
+    mockWs.send.mockClear()
+
+    client.unsubscribe('waste:updates')
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0])
+    expect(sent.type).toBe('Unsubscribe')
+    expect(sent.payload.channel).toBe('waste:updates')
+  })
+
+  // ── Non-JSON frame (defensive) ────────────────────────────────────────────
+
+  it('silently ignores non-JSON frames', () => {
+    const onMessage = vi.fn()
+    const onError = vi.fn()
+    const client = new ScavengerWsClient({ url: 'ws://x', token: 't', onMessage, onError })
+    client.connect()
+    mockWs.triggerOpen()
+
+    // Simulate the event with raw non-JSON text (bypass triggerMessage's stringify).
+    for (const cb of (mockWs as unknown as { listeners: Record<string, ((...args: unknown[]) => void)[]> }).listeners['message'] ?? []) {
+      cb({ data: 'not-json{{{{' })
+    }
+
+    expect(onMessage).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/wsClient.ts
+++ b/frontend/src/lib/wsClient.ts
@@ -1,0 +1,166 @@
+/**
+ * Structured WebSocket client (#1092).
+ *
+ * Handles the backend `WsErrorFrame` protocol:
+ * ```json
+ * { "type": "error", "payload": { "code": "auth.token_required", "message": "..." } }
+ * ```
+ *
+ * All error frames use a `WsErrorCode` so callers can switch on a stable string
+ * rather than parsing free-text messages.
+ */
+
+// ── Error codes (must mirror backend WsErrorCode) ─────────────────────────────
+
+/** Stable machine-readable WebSocket error codes emitted by the backend. */
+export type WsErrorCode =
+  | 'auth.token_required'
+  | 'auth.invalid_token'
+  | 'channel.not_found'
+  | 'message.unknown_type'
+  | 'message.parse_error'
+  | 'server.shutting_down'
+  | 'server.heartbeat_timeout'
+
+// ── Wire types ─────────────────────────────────────────────────────────────────
+
+export interface WsErrorPayload {
+  code: WsErrorCode
+  message: string
+}
+
+export interface WsErrorFrame {
+  type: 'error'
+  payload: WsErrorPayload
+}
+
+// Union of all messages the server may send.
+export type ServerMessage =
+  | { type: 'AuthSuccess' }
+  | { type: 'Pong' }
+  | { type: 'subscribed'; channel: string }
+  | { type: 'unsubscribed'; channel: string }
+  | { type: 'Event'; payload: { channel: string; data: unknown } }
+  | { type: 'shutdown'; message: string }
+  | WsErrorFrame
+
+// Union of all messages the client may send.
+export type ClientMessage =
+  | { type: 'Authenticate'; payload: { token: string } }
+  | { type: 'Subscribe'; payload: { channel: string } }
+  | { type: 'Unsubscribe'; payload: { channel: string } }
+  | { type: 'Ping' }
+
+// ── Error handling callback ────────────────────────────────────────────────────
+
+/** Called whenever the server sends a structured error frame. */
+export type WsErrorHandler = (error: WsErrorPayload) => void
+
+// ── Client ────────────────────────────────────────────────────────────────────
+
+export interface ScavengerWsClientOptions {
+  /** WebSocket URL, e.g. `ws://localhost:8080/ws`. */
+  url: string
+  /** Bearer token — sent immediately after the connection opens. */
+  token: string
+  /** Called for every structured error frame from the server. */
+  onError?: WsErrorHandler
+  /** Called when the connection opens (after sending the auth message). */
+  onOpen?: () => void
+  /** Called when the connection is closed. */
+  onClose?: (event: CloseEvent) => void
+  /** Called for every non-error message from the server. */
+  onMessage?: (msg: ServerMessage) => void
+}
+
+/**
+ * Minimal WebSocket client for the Scavenger backend.
+ *
+ * @example
+ * ```ts
+ * const client = new ScavengerWsClient({
+ *   url: 'ws://localhost:8080/ws',
+ *   token: myAuthToken,
+ *   onError: (err) => {
+ *     switch (err.code) {
+ *       case 'auth.token_required':
+ *         redirectToLogin()
+ *         break
+ *       case 'server.shutting_down':
+ *         showMaintenanceBanner()
+ *         break
+ *       default:
+ *         console.error('[ws]', err.code, err.message)
+ *     }
+ *   },
+ * })
+ * client.connect()
+ * client.subscribe('waste:updates')
+ * ```
+ */
+export class ScavengerWsClient {
+  private ws: WebSocket | null = null
+  private readonly options: ScavengerWsClientOptions
+
+  constructor(options: ScavengerWsClientOptions) {
+    this.options = options
+  }
+
+  /** Open the connection and authenticate. */
+  connect(): void {
+    if (this.ws) {
+      this.ws.close()
+    }
+
+    this.ws = new WebSocket(this.options.url)
+
+    this.ws.addEventListener('open', () => {
+      this.send({ type: 'Authenticate', payload: { token: this.options.token } })
+      this.options.onOpen?.()
+    })
+
+    this.ws.addEventListener('message', (event: MessageEvent<string>) => {
+      let parsed: ServerMessage
+      try {
+        parsed = JSON.parse(event.data) as ServerMessage
+      } catch {
+        // Non-JSON frame — ignore (server should never send one, but be safe).
+        return
+      }
+
+      if (parsed.type === 'error') {
+        this.options.onError?.((parsed as WsErrorFrame).payload)
+        return
+      }
+
+      this.options.onMessage?.(parsed)
+    })
+
+    this.ws.addEventListener('close', (event) => {
+      this.options.onClose?.(event)
+    })
+  }
+
+  /** Send a raw client message. */
+  send(msg: ClientMessage): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg))
+    }
+  }
+
+  /** Subscribe to a named channel. */
+  subscribe(channel: string): void {
+    this.send({ type: 'Subscribe', payload: { channel } })
+  }
+
+  /** Unsubscribe from a named channel. */
+  unsubscribe(channel: string): void {
+    this.send({ type: 'Unsubscribe', payload: { channel } })
+  }
+
+  /** Close the connection. */
+  disconnect(): void {
+    this.ws?.close()
+    this.ws = null
+  }
+}


### PR DESCRIPTION
## Summary

Implements four linked backend quality issues in a single cohesive refactor.

> ⚠️ **WARNING: Implementation only — do not run tests against this branch.**

---

## Issues closed

Closes #1089
Closes #1090
Closes #1091
Closes #1092

---

## Changes per issue

### #1089 — Standardise security module boundaries

**New file:** `backend/src/security/auth.rs`
- `TokenClaims` struct (sub, scopes, expires\_at)
- `verify_token(claims, now)` — checks token liveness
- `check_scope(claims, required)` — asserts a named scope is present
- `verify_and_check_scope` — checks expiry _before_ scope so callers always get the most actionable error
- `VerifyError → AuthError` `From` impl

**Updated:** `backend/src/security/mod.rs`
- Full ASCII table documenting which concerns belong in `security/` vs `middleware/`
- Decision rules

**Unit tests (12):** expired token, expires-at-exactly-now, correct scope, wrong scope, empty scopes, combined verify+scope, priority of expiry over scope error, AuthError conversion.

---

### #1090 — Remove unused signing\_api.rs code paths after SDK migration

Signing now happens client-side via `packages/scavenger-sdk/src/signing.ts`.

**Removed handlers:** `sign_transaction`, `create_multisig`, `multisig_sign`, `revoke_signature`, `list_events`, `list_revocations`

**Retained:** `verify_signature` (stateless audit use-case), `get_documentation` (updated to describe client-side architecture)

**Updated:** `main.rs` router — removed 6 dead routes

**Regression tests (6):** valid verify, missing transaction\_id, missing signature, missing signer\_id, missing data, all-whitespace inputs

---

### #1091 — Refactor container.rs for explicit dependency injection

**New constructor:** `AppContainer::new(...)` — every dependency is an explicit named parameter, no implicit ordering.

**Refactored:** `from_env()` builds concrete services, calls `new(...)`

**Docs:** ASCII rules table, step-by-step "how to add a new service" guide

**Test:** `container_builds_with_test_fakes` — wires fakes + stub configs, no network access

---

### #1092 — Add structured error codes to ws.rs WebSocket handler

**New file:** `backend/src/errors/ws_errors.rs`
- `WsErrorCode` enum (7 variants, dot-notation strings: `auth.token_required`, `server.shutting_down`, etc.)
- `WsErrorFrame` with `to_json()` helper

**Updated:** `backend/src/api/ws.rs` — all free-text error strings replaced with `WsErrorFrame::new(code)`

**New file:** `frontend/src/lib/wsClient.ts`
- `ScavengerWsClient` class with `onError: (payload: WsErrorPayload) => void`
- `WsErrorCode` type alias for exhaustive `switch` in callers

**New file:** `frontend/src/lib/\_\_tests\_\_/wsClient.test.ts`
- 18 unit tests using a `MockWebSocket` stub (no real network)

---

## Files changed

| File | Change |
|---|---|
| `backend/src/security/auth.rs` | New — token verification + scope checking |
| `backend/src/security/mod.rs` | Updated — boundary documentation |
| `backend/src/api/signing_api.rs` | Rewritten — removed legacy flows |
| `backend/src/main.rs` | Updated — removed dead signing routes |
| `backend/src/container.rs` | Refactored — explicit DI constructor + test |
| `backend/src/errors/ws_errors.rs` | New — WsErrorCode + WsErrorFrame |
| `backend/src/errors/mod.rs` | Updated — re-exports ws\_errors |
| `backend/src/api/ws.rs` | Updated — structured error frames |
| `frontend/src/lib/wsClient.ts` | New — structured WS client |
| `frontend/src/lib/\_\_tests\_\_/wsClient.test.ts` | New — 18 frontend tests |