### PR TITLE
[Backend] Dependency cleanup, idempotency audit, notification/search boundary split

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,36 +5,28 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+# #1085: audited against actual `use`/path references in src/. Anything not
+# reachable that way was dropped; see the removed list below the table for
+# what was cut and why. `url` and `sha2` were added because search/client.rs
+# and services/archival_storage.rs already import them directly but they
+# were missing from this manifest (only reachable before as transitive deps
+# of elasticsearch/aws-sdk-s3, which does not make them usable via `use`).
 actix-web = "4.4"
-actix-rt = "2.9"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.6", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
-log = "0.4"
-env_logger = "0.11"
-dotenv = "0.15"
 reqwest = { version = "0.11", features = ["json"] }
-lettre = { version = "0.11", features = ["smtp-transport", "builder"] }
-handlebars = "4.4"
-aws-config = "1.0"
-aws-sdk-s3 = "1.0"
-tokio-util = "0.7"
 bytes = "1.5"
-image = "0.24"
-pdf = "0.9"
-csv = "1.3"
 async-trait = "0.1"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-actix-web = "0.7"
 futures = "0.3"
 printpdf = "0.7"
 actix-ws = "0.3"
-actix-web-actors = "4.2"
 rand = "0.8"
 hex = "0.4"
 actix-cors = "0.7"
@@ -42,11 +34,28 @@ elasticsearch = "8.5.0-alpha.1"
 flate2 = "1.0"
 base64 = "0.22"
 urlencoding = "2.1"
+url = "2"
+sha2 = "0.10"
+
+# Removed as confirmed-unused by #1085 (no `use`/path reference anywhere in
+# src/ — verified by grepping every crate root against the source tree):
+#   actix-rt        — actix-web's `#[actix_web::main]`/`#[actix_web::test]` macros
+#                      pull in their own runtime; nothing calls actix_rt directly.
+#   log, env_logger — superseded by tracing/tracing-subscriber; no `log::`/init call.
+#   dotenv          — no `dotenv::dotenv()` call; env vars are read via std::env.
+#   lettre          — email.rs sends via a raw reqwest::Client, not lettre.
+#   handlebars      — no template rendering call exists; only mentioned in a doc comment.
+#   aws-config, aws-sdk-s3 — storage.rs defines types only, no S3 client is built.
+#   tokio-util      — no reference.
+#   image, pdf, csv — reporting/export services build these formats by hand
+#                      (printpdf for PDFs, manual string building for CSV);
+#                      these crates are never called.
+#   tracing-actix-web — no TracingLogger/middleware usage.
+#   actix-web-actors  — actix-ws already covers the one websocket handler in use.
 
 [dev-dependencies]
-mockall = "0.12"
-tokio-test = "0.4"
-tempfile = "3"
+# mockall, tokio-test, tempfile removed by #1085: no `#[automock]`/`mock!`,
+# `tokio_test::`, or `tempfile::` reference anywhere in src/.
 wiremock = "0.6"
 
 [lib]

--- a/backend/src/api/contracts.rs
+++ b/backend/src/api/contracts.rs
@@ -1,3 +1,11 @@
+//! #1086: `invalidate_waste_cache` and `invalidate_all_cache` are the only
+//! write (POST) endpoints in this file — everything else is a read-only
+//! query. Both are already covered by the app-level `IdempotencyMiddleware`
+//! wired in `main.rs` via `.wrap()`, which intercepts every write method on
+//! every route before it reaches a handler, so no additional per-endpoint
+//! wiring belongs here. See `signing_api.rs` for the equivalent note on
+//! transaction-signing endpoints.
+
 use actix_web::{web, HttpRequest, HttpResponse};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};

--- a/backend/src/api/search.rs
+++ b/backend/src/api/search.rs
@@ -1,10 +1,19 @@
-use crate::search::{Facet, SearchClient, SearchFilter, SearchQueryBuilder, SearchRequest};
+use crate::search::{build_search_query, format_search_response, SearchClient};
 use actix_web::{web, HttpResponse, Result};
-use serde::{Deserialize, Serialize};
+use elasticsearch::SearchParts;
+use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 
-/// Search API handlers
+/// Search API handlers.
+///
+/// #1088: query-building (`crate::search::build_search_query`) and
+/// result-formatting (`crate::search::format_search_response`) live in
+/// `search/request.rs` and `search/response.rs` respectively, so both can be
+/// unit tested without an HTTP request or a live Elasticsearch cluster. This
+/// file is now just the glue: parse params, build the query, execute it,
+/// format the response.
+const SEARCHABLE_FIELDS: &[&str] = &["title", "description", "content"];
 
 #[derive(Debug, Deserialize)]
 pub struct SearchParams {
@@ -21,44 +30,37 @@ fn default_size() -> usize {
     20
 }
 
-#[derive(Debug, Serialize)]
-pub struct SearchResponse<T> {
-    pub total: u64,
-    pub hits: Vec<T>,
-    pub took_ms: u64,
-    pub facets: Option<serde_json::Value>,
-}
-
-/// Perform a search query
+/// Perform a search query.
 pub async fn search(client: web::Data<Arc<SearchClient>>, params: web::Query<SearchParams>) -> Result<HttpResponse> {
-    // Build the search query
-    let query = SearchQueryBuilder::new()
-        .multi_match(
-            vec!["title".to_string(), "description".to_string(), "content".to_string()],
-            &params.q,
-        )
-        .from(params.from)
-        .size(params.size)
-        .highlight(vec!["title".to_string(), "description".to_string()])
-        .build();
+    let fields: Vec<String> = SEARCHABLE_FIELDS.iter().map(|f| f.to_string()).collect();
+    let query_body = build_search_query(&params.q, params.from, params.size, &fields, &params.filters);
 
-    // Execute search
     let start = std::time::Instant::now();
 
-    // In a real implementation, you'd execute the query against Elasticsearch
-    // For now, return a mock response
-    let response = SearchResponse {
-        total: 0,
-        hits: Vec::<serde_json::Value>::new(),
-        took_ms: start.elapsed().as_millis() as u64,
-        facets: None,
-    };
+    let es_response = client
+        .client()
+        .search(SearchParts::None)
+        .body(query_body)
+        .send()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let es_body: serde_json::Value = es_response
+        .json()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let took_ms = start.elapsed().as_millis() as u64;
+    let response = format_search_response(&es_body, took_ms);
 
     Ok(HttpResponse::Ok().json(response))
 }
 
 /// Get search suggestions/autocomplete
-pub async fn suggest(client: web::Data<Arc<SearchClient>>, params: web::Query<SearchParams>) -> Result<HttpResponse> {
+pub async fn suggest(
+    _client: web::Data<Arc<SearchClient>>,
+    _params: web::Query<SearchParams>,
+) -> Result<HttpResponse> {
     let suggestions = vec!["waste type A", "waste type B", "participant name"];
 
     Ok(HttpResponse::Ok().json(json!({

--- a/backend/src/api/signing_api.rs
+++ b/backend/src/api/signing_api.rs
@@ -1,3 +1,15 @@
+//! #1086: every POST handler in this file is a write endpoint and is already
+//! covered by `IdempotencyMiddleware`, which is mounted once with `.wrap()`
+//! on the top-level `App` in `main.rs` — actix-web applies app-level
+//! middleware to every route regardless of which module registers it, so no
+//! per-handler wiring is needed (or possible) here. Duplicate-submission
+//! protection is opt-in from the caller's side: it only activates when the
+//! request carries an `Idempotency-Key` header. Callers that must guarantee
+//! at-most-once execution for `sign_transaction`, `create_multisig`,
+//! `multisig_sign`, and `revoke_signature` — the operations here where a
+//! retried request could otherwise double-sign or double-revoke — should
+//! always send that header.
+
 use crate::validation::{error_response, sanitize_string, validate_required, ValidationError};
 use actix_web::{web, HttpResponse};
 use serde::{Deserialize, Serialize};

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -4,6 +4,8 @@ pub mod filters;
 pub mod index;
 pub mod pipeline;
 pub mod query_builder;
+pub mod request;
+pub mod response;
 
 pub use client::{SearchClient, SearchClientConfig};
 pub use facets::{Facet, FacetResult, FacetedSearch};
@@ -11,6 +13,8 @@ pub use filters::{FilterType, SearchFilter};
 pub use index::{IndexConfig, IndexMapping, SearchIndex};
 pub use pipeline::{IndexingError, IndexingPipeline};
 pub use query_builder::{SearchQuery, SearchQueryBuilder};
+pub use request::{build_search_query, parse_filter};
+pub use response::{format_search_response, SearchResponse};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/backend/src/search/request.rs
+++ b/backend/src/search/request.rs
@@ -1,0 +1,142 @@
+//! #1088: query-building logic extracted from `api/search.rs` so it can be
+//! unit tested in isolation from the HTTP handler and the Elasticsearch
+//! client.
+
+use super::query_builder::{QueryType, SearchQueryBuilder};
+use serde_json::Value;
+
+/// Parse a raw `field:value` filter string (as sent by API clients via the
+/// `filters` query param) into a `(field, value)` pair. Malformed entries —
+/// missing separator, empty field, or empty value — are dropped rather than
+/// erroring, since they come from client-supplied query params and a bad
+/// filter shouldn't fail the whole search.
+pub fn parse_filter(raw: &str) -> Option<(String, String)> {
+    let (field, value) = raw.split_once(':')?;
+    let field = field.trim();
+    let value = value.trim();
+    if field.is_empty() || value.is_empty() {
+        return None;
+    }
+    Some((field.to_string(), value.to_string()))
+}
+
+/// Build the Elasticsearch query body for a free-text search request.
+///
+/// Pure function: given the raw request parameters it returns the JSON body
+/// to send to Elasticsearch, combining the free-text match across `fields`
+/// with any valid `field:value` filters as `term` clauses in a bool query.
+pub fn build_search_query(q: &str, from: usize, size: usize, fields: &[String], filters: &[String]) -> Value {
+    let mut must: Vec<QueryType> = Vec::new();
+
+    if !q.trim().is_empty() {
+        must.push(QueryType::MultiMatch {
+            fields: fields.to_vec(),
+            query: q.to_string(),
+        });
+    }
+
+    for (field, value) in filters.iter().filter_map(|f| parse_filter(f)) {
+        must.push(QueryType::Term {
+            field,
+            value: Value::String(value),
+        });
+    }
+
+    let query_type = match must.len() {
+        0 => QueryType::MatchAll,
+        1 => must.into_iter().next().unwrap(),
+        _ => QueryType::Bool {
+            must,
+            should: Vec::new(),
+            must_not: Vec::new(),
+        },
+    };
+
+    SearchQueryBuilder::new()
+        .query(query_type)
+        .from(from)
+        .size(size)
+        .highlight(fields.to_vec())
+        .to_elasticsearch_json()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_filter() {
+        assert_eq!(
+            parse_filter("status:active"),
+            Some(("status".to_string(), "active".to_string()))
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_around_filter_parts() {
+        assert_eq!(
+            parse_filter(" type : plastic "),
+            Some(("type".to_string(), "plastic".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_filter_without_separator() {
+        assert_eq!(parse_filter("no-colon-here"), None);
+    }
+
+    #[test]
+    fn rejects_filter_with_empty_field_or_value() {
+        assert_eq!(parse_filter(":value"), None);
+        assert_eq!(parse_filter("field:"), None);
+        assert_eq!(parse_filter(""), None);
+    }
+
+    #[test]
+    fn empty_query_and_no_filters_is_match_all() {
+        let body = build_search_query("", 0, 20, &["title".to_string()], &[]);
+        assert_eq!(body["query"], serde_json::json!({ "match_all": {} }));
+    }
+
+    #[test]
+    fn query_only_produces_multi_match() {
+        let fields = vec!["title".to_string(), "description".to_string()];
+        let body = build_search_query("waste bin", 0, 20, &fields, &[]);
+        assert_eq!(
+            body["query"],
+            serde_json::json!({
+                "multi_match": { "query": "waste bin", "fields": fields }
+            })
+        );
+    }
+
+    #[test]
+    fn query_with_filters_produces_bool_query() {
+        let fields = vec!["title".to_string()];
+        let filters = vec!["status:active".to_string()];
+        let body = build_search_query("bin", 5, 10, &fields, &filters);
+        assert_eq!(body["from"], 5);
+        assert_eq!(body["size"], 10);
+        let must = body["query"]["bool"]["must"].as_array().unwrap();
+        assert_eq!(must.len(), 2);
+    }
+
+    #[test]
+    fn invalid_filters_are_dropped_not_erroring() {
+        let fields = vec!["title".to_string()];
+        let filters = vec!["malformed".to_string(), "status:active".to_string()];
+        let body = build_search_query("", 0, 20, &fields, &filters);
+        // Only the valid filter survives, so this collapses to a single term query.
+        assert_eq!(
+            body["query"],
+            serde_json::json!({ "term": { "status": "active" } })
+        );
+    }
+
+    #[test]
+    fn special_characters_in_query_are_preserved_verbatim() {
+        let fields = vec!["title".to_string()];
+        let body = build_search_query("50% \"reduce\" & reuse", 0, 20, &fields, &[]);
+        assert_eq!(body["query"]["multi_match"]["query"], "50% \"reduce\" & reuse");
+    }
+}

--- a/backend/src/search/response.rs
+++ b/backend/src/search/response.rs
@@ -1,0 +1,117 @@
+//! #1088: result-formatting logic extracted from `api/search.rs`, separate
+//! from query building (`request.rs`) and from index/pipeline mechanics.
+//! Turns a raw Elasticsearch `_search` response body into the API-facing
+//! shape, tolerating a partial/malformed body rather than erroring — a
+//! missing field here should degrade to empty output, not fail the request.
+
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Serialize)]
+pub struct SearchResponse<T> {
+    pub total: u64,
+    pub hits: Vec<T>,
+    pub took_ms: u64,
+    pub facets: Option<Value>,
+}
+
+/// Format one Elasticsearch hit into the flattened shape returned by the
+/// API: the `_source` document plus `_id`, `_score`, and any `highlight`.
+fn format_hit(hit: &Value) -> Value {
+    let mut source = hit.get("_source").cloned().unwrap_or(Value::Null);
+
+    if let Some(obj) = source.as_object_mut() {
+        obj.insert("_id".to_string(), hit.get("_id").cloned().unwrap_or(Value::Null));
+        obj.insert("_score".to_string(), hit.get("_score").cloned().unwrap_or(Value::Null));
+        if let Some(highlight) = hit.get("highlight") {
+            obj.insert("_highlight".to_string(), highlight.clone());
+        }
+    }
+
+    source
+}
+
+/// Format a raw Elasticsearch `_search` response body into a `SearchResponse`.
+pub fn format_search_response(es_body: &Value, took_ms: u64) -> SearchResponse<Value> {
+    let total = es_body["hits"]["total"]["value"].as_u64().unwrap_or(0);
+
+    let hits = es_body["hits"]["hits"]
+        .as_array()
+        .map(|arr| arr.iter().map(format_hit).collect())
+        .unwrap_or_default();
+
+    let facets = es_body.get("aggregations").cloned();
+
+    SearchResponse {
+        total,
+        hits,
+        took_ms,
+        facets,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn formats_hits_with_id_score_and_source_merged() {
+        let body = json!({
+            "hits": {
+                "total": { "value": 1 },
+                "hits": [
+                    { "_id": "abc", "_score": 1.5, "_source": { "title": "Bin" } }
+                ]
+            }
+        });
+
+        let response = format_search_response(&body, 12);
+        assert_eq!(response.total, 1);
+        assert_eq!(response.took_ms, 12);
+        assert_eq!(response.hits.len(), 1);
+        assert_eq!(response.hits[0]["title"], "Bin");
+        assert_eq!(response.hits[0]["_id"], "abc");
+        assert_eq!(response.hits[0]["_score"], 1.5);
+    }
+
+    #[test]
+    fn includes_highlight_when_present() {
+        let body = json!({
+            "hits": {
+                "total": { "value": 1 },
+                "hits": [
+                    {
+                        "_id": "abc",
+                        "_score": 1.0,
+                        "_source": { "title": "Bin" },
+                        "highlight": { "title": ["<em>Bin</em>"] }
+                    }
+                ]
+            }
+        });
+
+        let response = format_search_response(&body, 0);
+        assert_eq!(response.hits[0]["_highlight"]["title"][0], "<em>Bin</em>");
+    }
+
+    #[test]
+    fn empty_or_malformed_body_degrades_to_empty_result() {
+        let response = format_search_response(&json!({}), 3);
+        assert_eq!(response.total, 0);
+        assert!(response.hits.is_empty());
+        assert!(response.facets.is_none());
+        assert_eq!(response.took_ms, 3);
+    }
+
+    #[test]
+    fn surfaces_aggregations_as_facets() {
+        let body = json!({
+            "hits": { "total": { "value": 0 }, "hits": [] },
+            "aggregations": { "status": { "buckets": [] } }
+        });
+
+        let response = format_search_response(&body, 0);
+        assert!(response.facets.is_some());
+    }
+}

--- a/backend/src/services/notification_delivery.rs
+++ b/backend/src/services/notification_delivery.rs
@@ -1,6 +1,12 @@
 use chrono::{DateTime, Utc};
 /// #802 - Notification Delivery Service
 /// Multi-channel (email, SMS, push) with retry logic, delivery tracking, and templates.
+///
+/// #1087: this module owns *how* a notification reaches a channel — the wire
+/// protocol / provider API call, retry policy, and delivery-status tracking
+/// for each `ChannelSender`. Deciding *what* to send and *when* (device
+/// registration, user preferences, scheduling) lives in `notifications.rs`,
+/// which delegates the actual send to a `ChannelSender` from this module.
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -175,9 +181,42 @@ impl ChannelSender for PushSender {
         if recipient.len() < 10 {
             return Err(DeliveryError::InvalidRecipient(recipient.to_string()));
         }
-        // In production: call FCM v1 API.
-        let _ = (&self.firebase_project_id, subject, body);
-        Ok(())
+
+        // #1087: moved from notifications.rs::FirebaseNotificationService,
+        // which now delegates here instead of calling FCM itself — this is
+        // the single place push notifications actually go out over the wire.
+        let client = reqwest::Client::new();
+        let payload = serde_json::json!({
+            "message": {
+                "token": recipient,
+                "notification": {
+                    "title": subject,
+                    "body": body
+                }
+            }
+        });
+
+        let response = client
+            .post(format!(
+                "https://fcm.googleapis.com/v1/projects/{}/messages:send",
+                self.firebase_project_id
+            ))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| DeliveryError::ChannelError {
+                channel: "push".to_string(),
+                msg: e.to_string(),
+            })?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(DeliveryError::ChannelError {
+                channel: "push".to_string(),
+                msg: format!("FCM request failed with status {}", response.status()),
+            })
+        }
     }
 }
 
@@ -443,14 +482,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_multichannel_send() {
+        // #1087: Push is intentionally excluded here — PushSender now makes a
+        // real FCM call (moved from notifications.rs, see the module doc
+        // comment above), so it needs network access/credentials and isn't
+        // exercised by this offline unit test. Email/Sms remain simulated
+        // sends and stay deterministic.
         let svc = make_service();
         let mut recipients = HashMap::new();
         recipients.insert(Channel::Email, "u@example.com".to_string());
         recipients.insert(Channel::Sms, "+12025550100".to_string());
-        recipients.insert(Channel::Push, "device_token_abcdefghij".to_string());
 
         let req = NotificationRequest {
-            channels: vec![Channel::Email, Channel::Sms, Channel::Push],
+            channels: vec![Channel::Email, Channel::Sms],
             recipients,
             template_id: None,
             template_vars: HashMap::new(),
@@ -458,7 +501,7 @@ mod tests {
             body: Some("Body".to_string()),
         };
         let result = svc.send(req).await.unwrap();
-        assert_eq!(result.records.len(), 3);
+        assert_eq!(result.records.len(), 2);
         assert!(result.records.iter().all(|r| r.status == DeliveryStatus::Sent));
     }
 

--- a/backend/src/services/notifications.rs
+++ b/backend/src/services/notifications.rs
@@ -1,6 +1,13 @@
+use crate::services::notification_delivery::{ChannelSender, PushSender};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use thiserror::Error;
+
+// #1087: this module owns *what* to notify and *when* — device registration,
+// user preferences, and scheduling decisions. The actual wire send (the
+// "how") is delegated to a `ChannelSender` from `notification_delivery.rs`,
+// which is also where retry/delivery-tracking logic for that send lives.
 
 #[derive(Debug, Error)]
 pub enum NotificationError {
@@ -54,12 +61,15 @@ pub trait NotificationService: Send + Sync {
 }
 
 pub struct FirebaseNotificationService {
-    project_id: String,
+    sender: Arc<dyn ChannelSender>,
 }
 
 impl FirebaseNotificationService {
     pub fn new(project_id: String) -> Self {
-        Self { project_id }
+        let sender = Arc::new(PushSender {
+            firebase_project_id: project_id,
+        });
+        Self { sender }
     }
 
     fn validate_token(&self, token: &str) -> Result<(), NotificationError> {
@@ -93,35 +103,14 @@ impl NotificationService for FirebaseNotificationService {
             return Err(NotificationError::ServiceError("Empty title".to_string()));
         }
 
-        let client = reqwest::Client::new();
-        let body = serde_json::json!({
-            "message": {
-                "token": device_token,
-                "notification": {
-                    "title": notification.title,
-                    "body": notification.body
-                },
-                "data": notification.data
-            }
-        });
-
-        let response = client
-            .post(format!(
-                "https://fcm.googleapis.com/v1/projects/{}/messages:send",
-                self.project_id
-            ))
-            .json(&body)
-            .send()
+        // "How" the push is actually delivered (the FCM call, retries at the
+        // channel level) lives in notification_delivery.rs's PushSender.
+        self.sender
+            .send(device_token, &notification.title, &notification.body)
             .await
             .map_err(|e| NotificationError::ServiceError(e.to_string()))?;
 
-        if response.status().is_success() {
-            Ok(uuid::Uuid::new_v4().to_string())
-        } else {
-            Err(NotificationError::ServiceError(
-                "Failed to send notification".to_string(),
-            ))
-        }
+        Ok(uuid::Uuid::new_v4().to_string())
     }
 
     async fn set_preferences(&self, preference: NotificationPreference) -> Result<(), NotificationError> {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,16 @@ This document provides a consolidated, OpenAPI-style reference for all API endpo
 | `X-Session-ID` | `string` | Client session identifier for audit tracing | Optional |
 | `X-Request-ID` | `UUIDv4` | Unique request tracking ID (auto-generated if omitted) | Injected in all responses |
 
+### Idempotency (`backend/src/middleware/idempotency.rs`)
+`IdempotencyMiddleware` is mounted once, app-wide, in `main.rs` — it inspects **every** `POST` / `PUT` / `PATCH` / `DELETE` request across **every** route (including `signing_api.rs` and `contracts.rs`), so SDK consumers do not need to check per-endpoint whether a given write is covered.
+
+- Send an `Idempotency-Key` header (max 128 bytes, typically a UUIDv4) on any mutating request you may need to safely retry — e.g. after a timeout or connection drop.
+- The key is scoped to the exact request; reusing it replays the **original** response rather than re-running the handler.
+- Response header `X-Idempotency-Status: created` marks the first (handler-executing) call for a key; `X-Idempotency-Status: replayed` marks a duplicate that returned the cached response.
+- Only 2xx/4xx responses are cached — a 5xx is never cached, so retrying after a server error re-runs the handler.
+- Cached entries expire after 24 hours; after that, the same key is treated as new.
+- Omitting the header is allowed (the request just isn't deduplicated) except where a specific endpoint's docs say otherwise — see the per-file notes in `signing_api.rs` for operations (signing, multisig, revocation) where a retried request without this header can double-execute a sensitive action.
+
 ### Rate Limiting Tiers
 Rate limiting is enforced at the middleware layer (`backend/src/middleware/rate_limit.rs`) with tier-based quotas and window headers:
 


### PR DESCRIPTION
## ⚠️ WARNING — implementation only, NOT built or tested

This PR was produced in an environment with no way to run `cargo build`, `cargo test`, or `cargo udeps` against the backend. **None of this code has been compiled or executed.** Please run the full backend test suite, `cargo udeps` (or equivalent), and a manual smoke test of `/api/v1/search` before merging. Treat this as a draft-quality starting point, not a verified change.

## Summary

Bundles four backend housekeeping issues into one PR since they touch non-overlapping files.

### #1085 — Clean up unused dependencies in backend Cargo.toml
- Audited every crate in `backend/Cargo.toml` against actual `use`/path references in `src/`.
- Removed 14 confirmed-unused dependencies: `actix-rt`, `log`, `env_logger`, `dotenv`, `lettre`, `handlebars`, `aws-config`, `aws-sdk-s3`, `tokio-util`, `image`, `pdf`, `csv`, `tracing-actix-web`, `actix-web-actors`.
- Removed 3 unused dev-dependencies: `mockall`, `tokio-test`, `tempfile`.
- **Found and fixed a latent bug while auditing**: `url` (used directly in `search/client.rs`) and `sha2` (used directly in `services/archival_storage.rs`) were never declared in the manifest — only reachable before as transitive deps, which does not make them usable via `use` on edition 2021. Added both.
- Build-time improvement not measured (can't build in this environment) — flagging per the warning above rather than guessing a number.

### #1086 — Consolidate idempotency handling for write endpoints
- Audited every POST/PUT/PATCH/DELETE handler in `signing_api.rs` and `contracts.rs`.
- Finding: `IdempotencyMiddleware` is already mounted once, app-wide, via `.wrap()` on the top-level `App` in `main.rs` — this covers every write route automatically, no per-endpoint wiring is missing or possible to add.
- Added doc comments to both files making this explicit for future readers, plus a dedicated "Idempotency" section in `docs/api-reference.md` documenting the header/response-header/TTL contract for SDK consumers.
- Did not add new integration tests (see warning above).

### #1087 — Refactor notification_delivery.rs / notifications.rs boundary
- Found the actual overlap: `notifications.rs`'s `FirebaseNotificationService` made its own FCM HTTP call inline, duplicating the `ChannelSender` abstraction that `notification_delivery.rs` already defines for exactly this.
- Moved the real FCM call into `notification_delivery.rs`'s `PushSender::send` (the "how"), and `notifications.rs` now delegates to it, keeping only device registration/preferences/scheduling (the "what/when").
- Updated `test_multichannel_send` (existing test) to drop the `Push` channel from its assertions, since `PushSender` now makes a live network call and can no longer be asserted as always-succeeding in an offline unit test.
- Did not add new retry/backoff tests (see warning above) — the existing retry loop in `NotificationDeliveryService::send` is unchanged.

### #1088 — Modularize search.rs by extracting query-building logic
- Extracted query-building into `search/request.rs::build_search_query` (pure function, unit tested with empty/whitespace/malformed-filter/special-character cases).
- Extracted result-formatting into `search/response.rs::format_search_response` (pure function, unit tested including partial/malformed ES response bodies).
- `api/search.rs`'s `search` handler now builds a query, executes it against Elasticsearch via `SearchClient`, and formats the response — previously it always returned a hardcoded empty mock response. This is the part most in need of a real integration test before merging (see warning above).

## Test plan
- [ ] `cargo build` (backend)
- [ ] `cargo test` (backend) — full suite
- [ ] `cargo udeps` (or equivalent) — confirm no further unused deps
- [ ] Manual smoke test of `GET /api/v1/search` against a real/test Elasticsearch instance
- [ ] Manual smoke test of push notification delivery (`FirebaseNotificationService::send_notification`)

Closes #1085
Closes #1086
Closes #1087
Closes #1088