### PR TITLE
Audit and address stellar-contract issues #1097-#1100

### DIFF
--- a/stellar-contract/src/errors.rs
+++ b/stellar-contract/src/errors.rs
@@ -1,5 +1,51 @@
 use soroban_sdk::contracterror;
 
+// ── Error consolidation audit (issue #1097) ────────────────────────────────────
+//
+// Scope of the audit: `waste.rs`, `incentive.rs`, `transfer_mgmt.rs`, and
+// `participant.rs`, as named in the issue.
+//
+// Findings:
+// - `waste.rs`, `incentive.rs`, and `participant.rs` all exist and already
+//   fully delegate error handling to this `Error` enum: every fallible
+//   function in those three files returns `Result<_, Error>`, and none of
+//   them define a local error enum or call `panic!`/`.expect()`. No
+//   migration was needed in these files.
+// - `transfer_mgmt.rs` does not exist in this codebase. Waste-transfer logic
+//   (`transfer_waste`, `transfer_waste_v2`, `batch_transfer_waste`, the
+//   auction functions, etc.) lives directly in `lib.rs`.
+// - The actual duplicate-error-definition problem is in `lib.rs` itself: it
+//   contains roughly 130 `panic!(...)`/`.expect(...)` call sites using ad hoc
+//   string messages (e.g. `panic!("Admin already initialized")`,
+//   `.expect("Waste not found")`) instead of the equivalent variant already
+//   defined below (`Error::AlreadyInitialized`, `Error::WasteNotFound`, …).
+//   This was not part of the issue's named file list, and is a much larger
+//   change: converting it means changing the signature of every affected
+//   `pub fn` in `ScavengerContract` from `T` to `Result<T, Error>` across an
+//   ~8,000-line file that over 100 test files exercise, several of them via
+//   `#[should_panic(expected = "<exact string>")]` on the current panic text.
+//   This environment has no Rust toolchain available to compile or run the
+//   test suite, so that migration was not attempted blind here — it needs to
+//   be done with a working `cargo test` loop to catch signature and
+//   string-assertion breakage as it happens.
+//
+// Migration note (no breaking change made in this PR): no `Error` variant
+// numbering changed here, and no `lib.rs` function signatures changed, so
+// existing on-chain event/error consumers are unaffected by this PR. The
+// recommended follow-up, once a toolchain is available: convert `lib.rs`'s
+// panics to `Result<_, Error>` one functional section at a time (Admin →
+// Participant → Waste → Incentive → …), reusing the existing variants below
+// wherever the condition already matches one (adding new variants, never
+// renumbering existing ones, if a truly new condition is found). Because
+// Soroban's generated contract client exposes both a panicking `foo()` and a
+// `try_foo()` returning `Result` for any function returning `Result<T, E>`
+// where `E` derives `#[contracterror]`, this does not change how off-chain
+// callers invoke the contract — only how they observe failures (a typed
+// error code via `try_foo()` instead of a free-text panic message). Any
+// existing `#[should_panic(expected = "...")]` test assertions on the
+// affected functions will need to become `assert_eq!(result, Err(Error::X))`
+// as part of that follow-up.
+
 /// Typed error codes for the Scavngr contract.
 ///
 /// Every public function that can fail returns `Result<T, Error>`.

--- a/stellar-contract/src/incentive.rs
+++ b/stellar-contract/src/incentive.rs
@@ -7,6 +7,12 @@
 //! - Reward calculation (flat-rate and tiered)
 //! - Scheduling guards (starts_at / ends_at)
 //! - Budget exhaustion logic
+//!
+//! # Error consolidation audit (issue #1097)
+//! Audited: every fallible function here already returns `Result<_,
+//! errors::Error>` and no local error enum or `panic!`/`.expect()` exists in
+//! this file. No migration was needed. See `errors.rs` for the full audit
+//! covering all four files named in issue #1097.
 
 use soroban_sdk::Env;
 

--- a/stellar-contract/src/key_rotation.rs
+++ b/stellar-contract/src/key_rotation.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Rotation procedure (admin-only)
 //!
-//! 1. Call `rotate_key(env, admin, purpose, new_key_hash)`.
+//! 1. Call `rotate_key(env, admin, current_admins, purpose, new_key_hash)`.
 //! 2. The current active key is archived (status → `Archived`).
 //! 3. The new key is stored with `version = old_version + 1`.
 //! 4. A `"key_rot"` event is emitted.
@@ -32,8 +32,43 @@
 //! Archived keys remain readable via `get_key_version` for audit purposes
 //! but are no longer returned by `get_active_key`.  Call `purge_key_version`
 //! to delete an archived entry and reclaim storage rent.
+//!
+//! ## Security review (issue #1099)
+//!
+//! This module has **no call sites in `lib.rs`** — it is not wired into any
+//! `ScavengerContract` entry point today, so there is no live on-chain
+//! exposure yet. It was however written to be wired in eventually, so it is
+//! reviewed and hardened as if it were:
+//!
+//! - **Authorization was previously only a doc comment.** Every mutating
+//!   function here used to accept an `admin: &Address` and simply *trust*
+//!   that the caller had already validated that address against the real
+//!   admin list before calling in ("Caller must ensure `admin.require_auth()`
+//!   was already called"). That is not enforcement — `require_auth()` only
+//!   proves the caller controls that specific address, not that the address
+//!   is an actual contract admin. A future call site that forgot the
+//!   membership check (or got it wrong) would let *any* address rotate,
+//!   revoke, or purge keys for itself. Every mutating function now takes the
+//!   authoritative `current_admins: &Vec<Address>` list and enforces both
+//!   `require_auth()` and admin membership internally via [`authorize`], so
+//!   the module can no longer be bypassed by a careless caller.
+//! - **Atomicity of rotation.** `rotate_key` performs its zero-hash check and
+//!   both storage reads *before* writing anything, and if any of those
+//!   fail (or the caller is unauthorized) the function returns `Err` before
+//!   any storage mutation occurs — so a rejected rotation can never leave the
+//!   old key archived without the new key active. Because Soroban only
+//!   commits a contract invocation's storage writes when the invocation
+//!   returns successfully, a rejected/panicking call is rolled back in full
+//!   by the host as well; this module additionally guarantees no partial
+//!   writes happen even *within* a single successful call. See the
+//!   `rotate_key_failure_leaves_old_key_untouched` test.
+//! - **Replay.** Once a key is rotated, `get_active_key` only ever returns
+//!   the newest version; archived/revoked versions are never promoted back
+//!   to active, so a stale key hash cannot be replayed as if it were still
+//!   current. See the `old_key_is_never_returned_as_active_after_rotation`
+//!   test.
 
-use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env};
+use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Vec};
 
 // ─── Key purpose ──────────────────────────────────────────────────────────────
 
@@ -144,25 +179,43 @@ pub enum KeyRotationError {
     CannotPurgeActive = 4,
     /// The supplied key hash is all-zeros (likely an accident).
     ZeroKeyHash = 5,
+    /// A key already exists for this purpose — use `rotate_key` instead.
+    AlreadyExists = 6,
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/// Verifies `caller` has signed the invocation **and** is a member of
+/// `current_admins`. Every mutating function in this module calls this before
+/// touching storage — authorization is enforced here, not left to callers.
+fn authorize(caller: &Address, current_admins: &Vec<Address>) -> Result<(), KeyRotationError> {
+    caller.require_auth();
+    if !current_admins.contains(caller) {
+        return Err(KeyRotationError::Unauthorized);
+    }
+    Ok(())
+}
+
 /// Installs the first key for a given `purpose`.
 ///
-/// Panics if a key for this purpose already exists — use `rotate_key` instead.
-/// Caller must ensure `admin.require_auth()` was already called.
+/// Returns `Err(KeyRotationError::AlreadyExists)` if a key for this purpose
+/// already exists — use `rotate_key` instead.
+///
+/// `current_admins` must be the caller's authoritative, up-to-date admin list
+/// (e.g. `ScavengerContract::get_admins`); `admin` is checked against it.
 pub fn install_key(
     env: &Env,
     admin: &Address,
+    current_admins: &Vec<Address>,
     purpose: KeyPurpose,
     key_hash: BytesN<32>,
 ) -> Result<u32, KeyRotationError> {
+    authorize(admin, current_admins)?;
     reject_zero_hash(&key_hash)?;
 
     let active_key_slot = KeyStorage::Active(purpose);
     if env.storage().instance().has::<KeyStorage>(&active_key_slot) {
-        panic!("key_rotation: use rotate_key to update an existing key");
+        return Err(KeyRotationError::AlreadyExists);
     }
 
     let version = 1u32;
@@ -192,13 +245,18 @@ pub fn install_key(
 /// The current active version is archived, and `new_key_hash` is stored as
 /// `version = old + 1`.  Returns the new version number.
 ///
-/// Caller must ensure `admin.require_auth()` was already called.
+/// `current_admins` must be the caller's authoritative, up-to-date admin list;
+/// `admin` is checked against it. All validation (authorization, zero-hash,
+/// existing-key lookups) happens before any storage write, so a rejected call
+/// never leaves the old key partially archived.
 pub fn rotate_key(
     env: &Env,
     admin: &Address,
+    current_admins: &Vec<Address>,
     purpose: KeyPurpose,
     new_key_hash: BytesN<32>,
 ) -> Result<u32, KeyRotationError> {
+    authorize(admin, current_admins)?;
     reject_zero_hash(&new_key_hash)?;
 
     // Fetch current active version
@@ -247,13 +305,16 @@ pub fn rotate_key(
 /// Revokes a specific version (marks it `Revoked`).
 ///
 /// Revoked keys are not returned by `get_active_key` and signal that the key
-/// material was compromised.  Caller must ensure `admin.require_auth()`.
+/// material was compromised. `current_admins` must be the caller's
+/// authoritative, up-to-date admin list; `admin` is checked against it.
 pub fn revoke_key_version(
     env: &Env,
     admin: &Address,
+    current_admins: &Vec<Address>,
     purpose: KeyPurpose,
     version: u32,
 ) -> Result<(), KeyRotationError> {
+    authorize(admin, current_admins)?;
     let slot = KeyStorage::Key(purpose, version);
     let mut record = env
         .storage()
@@ -306,14 +367,17 @@ pub fn active_version(env: &Env, purpose: KeyPurpose) -> Option<u32> {
 
 /// Purges an archived key version from storage, recovering the storage rent.
 ///
-/// Cannot purge the currently active version.
-/// Caller must ensure `admin.require_auth()`.
+/// Cannot purge the currently active version. `current_admins` must be the
+/// caller's authoritative, up-to-date admin list; `admin` is checked against
+/// it.
 pub fn purge_key_version(
     env: &Env,
     admin: &Address,
+    current_admins: &Vec<Address>,
     purpose: KeyPurpose,
     version: u32,
 ) -> Result<(), KeyRotationError> {
+    authorize(admin, current_admins)?;
     // Prevent purging the active version
     if let Some(active) = active_version(env, purpose) {
         if active == version {
@@ -370,14 +434,24 @@ mod tests {
         BytesN::from_array(env, &[0u8; 32])
     }
 
+    /// Test env with mocked auths, one admin address, and its singleton
+    /// admin list — mirrors how `lib.rs` would fetch `current_admins`.
+    fn setup(env: &Env) -> (Address, Vec<Address>) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let admins = Vec::from_array(env, [admin.clone()]);
+        (admin, admins)
+    }
+
     // ── install_key ───────────────────────────────────────────────────────────
 
     #[test]
     fn install_key_creates_version_1() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
+        let (admin, admins) = setup(&env);
         let hash = make_hash(&env, 0xAA);
-        let version = install_key(&env, &admin, KeyPurpose::WebhookSigning, hash.clone()).unwrap();
+        let version =
+            install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, hash.clone()).unwrap();
         assert_eq!(version, 1);
         let record = get_active_key(&env, KeyPurpose::WebhookSigning).unwrap();
         assert_eq!(record.key_hash, hash);
@@ -388,11 +462,35 @@ mod tests {
     #[test]
     fn install_key_rejects_zero_hash() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
+        let (admin, admins) = setup(&env);
         assert_eq!(
-            install_key(&env, &admin, KeyPurpose::WebhookSigning, zero_hash(&env)),
+            install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, zero_hash(&env)),
             Err(KeyRotationError::ZeroKeyHash)
         );
+    }
+
+    #[test]
+    fn install_key_twice_fails_instead_of_panicking() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 1)).unwrap();
+        assert_eq!(
+            install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 2)),
+            Err(KeyRotationError::AlreadyExists)
+        );
+    }
+
+    #[test]
+    fn install_key_rejects_non_admin_caller() {
+        let env = Env::default();
+        let (_admin, admins) = setup(&env);
+        let attacker = Address::generate(&env);
+        assert_eq!(
+            install_key(&env, &attacker, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 1)),
+            Err(KeyRotationError::Unauthorized)
+        );
+        // Confirm the rejected call left no state behind.
+        assert_eq!(active_version(&env, KeyPurpose::WebhookSigning), None);
     }
 
     // ── rotate_key ────────────────────────────────────────────────────────────
@@ -400,9 +498,10 @@ mod tests {
     #[test]
     fn rotate_key_increments_version() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 0x01)).unwrap();
-        let v2 = rotate_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 0x02)).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 0x01)).unwrap();
+        let v2 = rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 0x02))
+            .unwrap();
         assert_eq!(v2, 2);
         let active = get_active_key(&env, KeyPurpose::ApiKeyHash).unwrap();
         assert_eq!(active.version, 2);
@@ -412,9 +511,9 @@ mod tests {
     #[test]
     fn rotate_key_archives_previous_version() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 0x01)).unwrap();
-        rotate_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 0x02)).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 0x01)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 0x02)).unwrap();
         let old = get_key_version(&env, KeyPurpose::ApiKeyHash, 1).unwrap();
         assert_eq!(old.status, KeyStatus::Archived);
         assert_ne!(old.archived_at, 0);
@@ -423,9 +522,9 @@ mod tests {
     #[test]
     fn rotate_without_existing_key_fails() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
+        let (admin, admins) = setup(&env);
         assert_eq!(
-            rotate_key(&env, &admin, KeyPurpose::PiiEncryption, make_hash(&env, 0x10)),
+            rotate_key(&env, &admin, &admins, KeyPurpose::PiiEncryption, make_hash(&env, 0x10)),
             Err(KeyRotationError::NoActiveKey)
         );
     }
@@ -433,10 +532,10 @@ mod tests {
     #[test]
     fn multiple_rotations_track_history() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::ZkpVerification, make_hash(&env, 1)).unwrap();
-        rotate_key(&env, &admin, KeyPurpose::ZkpVerification, make_hash(&env, 2)).unwrap();
-        rotate_key(&env, &admin, KeyPurpose::ZkpVerification, make_hash(&env, 3)).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ZkpVerification, make_hash(&env, 1)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ZkpVerification, make_hash(&env, 2)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ZkpVerification, make_hash(&env, 3)).unwrap();
 
         assert_eq!(active_version(&env, KeyPurpose::ZkpVerification), Some(3));
 
@@ -449,15 +548,73 @@ mod tests {
         assert_eq!(v3.status, KeyStatus::Active);
     }
 
+    #[test]
+    fn rotate_key_rejects_non_admin_caller() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        let attacker = Address::generate(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+
+        assert_eq!(
+            rotate_key(&env, &attacker, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 2)),
+            Err(KeyRotationError::Unauthorized)
+        );
+        // Unauthorized attempt must not have touched the active key.
+        let active = get_active_key(&env, KeyPurpose::ApiKeyHash).unwrap();
+        assert_eq!(active.version, 1);
+        assert_eq!(active.key_hash, make_hash(&env, 1));
+    }
+
+    /// Partial-failure / atomicity: a rotation rejected for a *content* reason
+    /// (zero hash) must not have archived the old key first. Regression test
+    /// for the class of bug where validation and mutation are interleaved.
+    #[test]
+    fn rotate_key_failure_leaves_old_key_untouched() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+
+        assert_eq!(
+            rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, zero_hash(&env)),
+            Err(KeyRotationError::ZeroKeyHash)
+        );
+
+        let still_active = get_active_key(&env, KeyPurpose::ApiKeyHash).unwrap();
+        assert_eq!(still_active.version, 1);
+        assert_eq!(still_active.status, KeyStatus::Active);
+        assert_eq!(still_active.key_hash, make_hash(&env, 1));
+        // Only one version should exist — no half-installed "version 2".
+        assert_eq!(
+            get_key_version(&env, KeyPurpose::ApiKeyHash, 2),
+            Err(KeyRotationError::VersionNotFound)
+        );
+    }
+
+    /// Replay: an old key hash must never be returned as active again once a
+    /// newer version has been installed.
+    #[test]
+    fn old_key_is_never_returned_as_active_after_rotation() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 2)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 3)).unwrap();
+
+        let active = get_active_key(&env, KeyPurpose::ApiKeyHash).unwrap();
+        assert_ne!(active.key_hash, make_hash(&env, 1));
+        assert_ne!(active.key_hash, make_hash(&env, 2));
+        assert_eq!(active.key_hash, make_hash(&env, 3));
+    }
+
     // ── revoke_key_version ────────────────────────────────────────────────────
 
     #[test]
     fn revoke_marks_version_revoked() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::WebhookSigning, make_hash(&env, 0xA0)).unwrap();
-        rotate_key(&env, &admin, KeyPurpose::WebhookSigning, make_hash(&env, 0xB0)).unwrap();
-        revoke_key_version(&env, &admin, KeyPurpose::WebhookSigning, 1).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 0xA0)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 0xB0)).unwrap();
+        revoke_key_version(&env, &admin, &admins, KeyPurpose::WebhookSigning, 1).unwrap();
         let v1 = get_key_version(&env, KeyPurpose::WebhookSigning, 1).unwrap();
         assert_eq!(v1.status, KeyStatus::Revoked);
     }
@@ -465,11 +622,26 @@ mod tests {
     #[test]
     fn revoke_nonexistent_version_fails() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
+        let (admin, admins) = setup(&env);
         assert_eq!(
-            revoke_key_version(&env, &admin, KeyPurpose::WebhookSigning, 99),
+            revoke_key_version(&env, &admin, &admins, KeyPurpose::WebhookSigning, 99),
             Err(KeyRotationError::VersionNotFound)
         );
+    }
+
+    #[test]
+    fn revoke_key_version_rejects_non_admin_caller() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        let attacker = Address::generate(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::WebhookSigning, make_hash(&env, 1)).unwrap();
+
+        assert_eq!(
+            revoke_key_version(&env, &attacker, &admins, KeyPurpose::WebhookSigning, 1),
+            Err(KeyRotationError::Unauthorized)
+        );
+        let v1 = get_key_version(&env, KeyPurpose::WebhookSigning, 1).unwrap();
+        assert_eq!(v1.status, KeyStatus::Active);
     }
 
     // ── purge_key_version ─────────────────────────────────────────────────────
@@ -477,10 +649,10 @@ mod tests {
     #[test]
     fn purge_archived_version_removes_storage() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
-        rotate_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 2)).unwrap();
-        purge_key_version(&env, &admin, KeyPurpose::ApiKeyHash, 1).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 2)).unwrap();
+        purge_key_version(&env, &admin, &admins, KeyPurpose::ApiKeyHash, 1).unwrap();
         assert_eq!(
             get_key_version(&env, KeyPurpose::ApiKeyHash, 1),
             Err(KeyRotationError::VersionNotFound)
@@ -490,12 +662,28 @@ mod tests {
     #[test]
     fn purge_active_version_is_forbidden() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::generate(&env);
-        install_key(&env, &admin, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+        let (admin, admins) = setup(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
         assert_eq!(
-            purge_key_version(&env, &admin, KeyPurpose::ApiKeyHash, 1),
+            purge_key_version(&env, &admin, &admins, KeyPurpose::ApiKeyHash, 1),
             Err(KeyRotationError::CannotPurgeActive)
         );
+    }
+
+    #[test]
+    fn purge_key_version_rejects_non_admin_caller() {
+        let env = Env::default();
+        let (admin, admins) = setup(&env);
+        let attacker = Address::generate(&env);
+        install_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 1)).unwrap();
+        rotate_key(&env, &admin, &admins, KeyPurpose::ApiKeyHash, make_hash(&env, 2)).unwrap();
+
+        assert_eq!(
+            purge_key_version(&env, &attacker, &admins, KeyPurpose::ApiKeyHash, 1),
+            Err(KeyRotationError::Unauthorized)
+        );
+        // Attacker must not have been able to purge the archived version.
+        assert!(get_key_version(&env, KeyPurpose::ApiKeyHash, 1).is_ok());
     }
 
     // ── get_active_key ────────────────────────────────────────────────────────

--- a/stellar-contract/src/lib.rs
+++ b/stellar-contract/src/lib.rs
@@ -15,6 +15,11 @@ mod storage_optimizer;
 mod query_optimizer;
 
 // ── Issue #759: extracted functional modules ──────────────────────────────────
+// Audited under issues #1097/#1100: `participant`, `waste`, and `incentive`
+// are not currently called from any function in this file — `lib.rs` keeps
+// its own inline implementation of the equivalent logic. Each module's own
+// doc comment records what was verified (error handling, storage-key
+// duplication, etc.) and why full rewiring is left as a follow-up.
 /// Participant registration, role checks, and reputation helpers.
 pub mod participant;
 /// Waste lifecycle state guards and transfer-route validation.
@@ -221,6 +226,16 @@ pub struct RewardConfig {
 }
 
 /// On-chain record for a registered supply-chain participant.
+///
+/// Responsibility boundary (audited under issue #1100): this struct and the
+/// participant-related functions on `ScavengerContract` below (
+/// `register_participant`, `update_role`, `deregister_participant`,
+/// `get_participant`, storage helpers like `set_participant` /
+/// `is_participant_registered`, …) are the **live** implementation — this is
+/// what every deployed entry point actually calls. `participant.rs` is a
+/// separate, currently-unwired helper module extracted under issue #759;
+/// see its module doc for the full audit of the gap between the two and why
+/// closing it is left as a follow-up rather than attempted in this change.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Participant {

--- a/stellar-contract/src/participant.rs
+++ b/stellar-contract/src/participant.rs
@@ -9,22 +9,46 @@
 //! - Role-based permission checks
 //! - Reputation score helpers
 //! - Location validation
+//!
+//! # Integration status (audited under issue #1100)
+//!
+//! `ScavengerContract`'s public entry points in `lib.rs` (`register_participant`,
+//! `update_role`, `deregister_participant`, `get_participant`, …) currently do
+//! **not** call into this module — they keep an independent, inlined
+//! implementation of storage access and lifecycle logic. This module is not
+//! dead code by design; it was extracted from `lib.rs` under issue #759 as the
+//! target shape for that logic, but the follow-up wiring was never done.
+//!
+//! Consequences audited here:
+//! - The storage key/tier used below now matches `lib.rs`'s real scheme (see
+//!   [`participant_key`]) — previously this module used a different key
+//!   (`("PART", address)` in *persistent* storage) than `lib.rs`'s actual
+//!   `(address,)` key in *instance* storage, which would have silently missed
+//!   all real participant data had anything ever called into this module.
+//! - [`certification_from_weight`] and [`tier_from_tokens`] used to duplicate
+//!   `types::CertificationLevel`/`types::ParticipantTier` with *different*
+//!   thresholds and input semantics (item-count/weight vs. weight/tokens).
+//!   They now delegate to the canonical implementations in `types.rs` so the
+//!   two can no longer drift apart.
+//!
+//! Fully rewiring `lib.rs` to call through this module (instead of its inline
+//! implementation) touches every participant code path in an ~8,000-line file
+//! with no local build/test verification available in this change, so it is
+//! intentionally left as a follow-up rather than attempted blind here. Tracked
+//! as a migration note for the next pass.
 
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, Env};
 
 use crate::errors::Error;
 use crate::types::{CertificationLevel, Participant, ParticipantRole, ParticipantTier};
 
-// Storage key prefix for participant records (matches lib.rs usage).
-pub const PARTICIPANT_PREFIX: &str = "PART";
-
 /// Returns `true` if `address` is currently registered and active.
 pub fn is_registered(env: &Env, address: &Address) -> bool {
-    let key = participant_key(env, address);
+    let key = participant_key(address);
     if let Some(p) = env
         .storage()
-        .persistent()
-        .get::<(Symbol, Address), Participant>(&key)
+        .instance()
+        .get::<(Address,), Participant>(&key)
     {
         p.is_registered
     } else {
@@ -34,18 +58,18 @@ pub fn is_registered(env: &Env, address: &Address) -> bool {
 
 /// Loads a participant or returns `Error::NotRegistered`.
 pub fn require_participant(env: &Env, address: &Address) -> Result<Participant, Error> {
-    let key = participant_key(env, address);
+    let key = participant_key(address);
     env.storage()
-        .persistent()
-        .get::<(Symbol, Address), Participant>(&key)
+        .instance()
+        .get::<(Address,), Participant>(&key)
         .filter(|p| p.is_registered)
         .ok_or(Error::NotRegistered)
 }
 
 /// Persists updated participant data.
 pub fn save_participant(env: &Env, participant: &Participant) {
-    let key = participant_key(env, &participant.address);
-    env.storage().persistent().set(&key, participant);
+    let key = participant_key(&participant.address);
+    env.storage().instance().set(&key, participant);
 }
 
 /// Validates GPS coordinates (microdegrees).
@@ -58,25 +82,22 @@ pub fn validate_coordinates(lat: i128, lon: i128) -> Result<(), Error> {
     Ok(())
 }
 
-/// Derives the `CertificationLevel` from total waste processed (in grams).
-pub fn certification_from_weight(total_grams: u128) -> CertificationLevel {
-    let kg = total_grams / 1_000;
-    match kg {
-        0..=999 => CertificationLevel::Beginner,
-        1_000..=9_999 => CertificationLevel::Intermediate,
-        10_000..=99_999 => CertificationLevel::Advanced,
-        _ => CertificationLevel::Expert,
-    }
+/// Derives the `CertificationLevel` from total waste items processed.
+///
+/// Delegates to `types::CertificationLevel::from_waste_count`, the
+/// implementation `lib.rs` actually calls, so this helper cannot drift from
+/// production behavior (issue #1100 — the two previously used different
+/// thresholds and input units).
+pub fn certification_from_weight(total_waste_count: u128) -> CertificationLevel {
+    CertificationLevel::from_waste_count(total_waste_count)
 }
 
-/// Derives the `ParticipantTier` from total reward tokens earned.
-pub fn tier_from_tokens(total_tokens: u128) -> ParticipantTier {
-    match total_tokens {
-        0..=999 => ParticipantTier::Bronze,
-        1_000..=9_999 => ParticipantTier::Silver,
-        10_000..=99_999 => ParticipantTier::Gold,
-        _ => ParticipantTier::Platinum,
-    }
+/// Derives the `ParticipantTier` from total waste processed (in grams).
+///
+/// Delegates to `types::ParticipantTier::from_total_waste`, the
+/// implementation `lib.rs` actually calls (issue #1100).
+pub fn tier_from_tokens(total_waste_grams: u128) -> ParticipantTier {
+    ParticipantTier::from_total_waste(total_waste_grams)
 }
 
 /// Checks that `role` is allowed to submit waste.
@@ -87,8 +108,10 @@ pub fn can_submit_waste(role: ParticipantRole) -> bool {
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
-/// Constructs the persistent-storage key for a participant.
-/// Mirrors the key scheme used in `lib.rs`: `("PART", address)`.
-fn participant_key(env: &Env, address: &Address) -> (Symbol, Address) {
-    (Symbol::new(env, PARTICIPANT_PREFIX), address.clone())
+/// Constructs the instance-storage key for a participant.
+/// Matches the key scheme actually used by `lib.rs`: a bare `(address,)`
+/// tuple in *instance* storage (not persistent storage — see the module-level
+/// "Integration status" note for why this matters).
+fn participant_key(address: &Address) -> (Address,) {
+    (address.clone(),)
 }

--- a/stellar-contract/src/query_optimizer.rs
+++ b/stellar-contract/src/query_optimizer.rs
@@ -1,5 +1,21 @@
 // Query Optimization Engine
 // Implements query analysis, optimization rules, plan caching, and cost estimation
+//
+// ## Resource-cost audit (issue #1098)
+//
+// This module has no call sites in `lib.rs` (verified via repo-wide search),
+// so it currently has no effect on the deployed contract's resource costs —
+// see the equivalent note in `storage_optimizer.rs` for the full context and
+// the documented per-operation budget. `QueryPlan`/`QueryOptimizer` values
+// here are in-memory only (no ledger storage I/O of their own); the
+// optimization they model is about which *other* storage calls a caller
+// should make (cache vs. index vs. full scan), not storage they perform
+// themselves.
+//
+// Fixed here: `QueryPlan::new` used to construct a throwaway
+// `Env::default()` purely to obtain an empty `Vec` for `execution_order`,
+// which spins up an entire host environment for no reason on every call.
+// It now takes the caller's existing `&Env` instead.
 
 use soroban_sdk::{Env, Vec, Map, Symbol, symbol_short};
 
@@ -28,13 +44,13 @@ pub struct QueryPlan {
 }
 
 impl QueryPlan {
-    pub fn new(query_type: QueryType) -> Self {
+    pub fn new(env: &Env, query_type: QueryType) -> Self {
         Self {
             query_type,
             use_cache: false,
             use_index: false,
             estimated_cost: 0,
-            execution_order: Vec::new(&Env::default()),
+            execution_order: Vec::new(env),
         }
     }
 
@@ -75,7 +91,7 @@ impl QueryOptimizer {
         }
 
         // Build optimization plan based on query type
-        let mut plan = QueryPlan::new(query_type.clone());
+        let mut plan = QueryPlan::new(env, query_type.clone());
         
         match query_type {
             QueryType::GetParticipant => {
@@ -218,7 +234,8 @@ mod tests {
 
     #[test]
     fn test_query_plan_with_cache() {
-        let plan = QueryPlan::new(QueryType::GetParticipant).with_cache();
+        let env = Env::default();
+        let plan = QueryPlan::new(&env, QueryType::GetParticipant).with_cache();
         assert!(plan.use_cache);
     }
 

--- a/stellar-contract/src/storage_optimizer.rs
+++ b/stellar-contract/src/storage_optimizer.rs
@@ -1,5 +1,38 @@
 // Storage Optimization Module
 // Implements storage batching, prefetching, indexes, and caching for improved performance
+//
+// ## Resource-cost audit (issue #1098)
+//
+// Neither this module nor `query_optimizer.rs` is called from `lib.rs` today
+// (verified: no `storage_optimizer::` or `query_optimizer::` references exist
+// outside these two files' own tests). They therefore have **zero effect** on
+// the deployed contract's instruction or resource-fee costs — every ledger
+// read/write in `ScavengerContract`'s real entry points goes through the
+// inline storage calls in `lib.rs`, not through here. Any bench numbers
+// collected against these modules in isolation would not reflect production
+// cost, which is why no such numbers are asserted in this change; running
+// `cargo bench` against the *actual* contract entry points remains the right
+// way to validate a resource-cost claim, and this environment has no Rust
+// toolchain available to do that.
+//
+// What was still worth fixing here, self-contained within this file:
+// - `optimize_waste_storage` used to write a duplicate "hot" copy of a waste
+//   record to temporary storage on *every* call, even when the cached hot
+//   data was already identical and only its TTL needed bumping. It now skips
+//   the redundant write (see `optimize_waste_storage` below).
+//
+// ## Expected resource-cost budget (documented, not bench-verified here)
+//
+// If/when these helpers are wired into a real entry point, the intended
+// per-operation ledger footprint is:
+// - `StorageCache::get`/`contains`: 1 temporary-storage read.
+// - `StorageCache::set`: 1 temporary-storage write + 1 TTL extension (skip
+//   both when the value is already current — see note above).
+// - `StorageIndex::add`/`get`/`remove`: 1 instance-storage read or write.
+// - `prefetch_participant_data`: up to 2 instance-storage reads (participant,
+//   stats) + up to 2 temporary-storage writes, only on a cache miss.
+// - `optimize_waste_storage`: 1 instance-storage read + at most 1
+//   temporary-storage write (0 when the hot copy is already current).
 
 use soroban_sdk::{Env, Vec, Address, Symbol};
 
@@ -128,13 +161,25 @@ pub fn optimize_waste_storage(env: &Env, waste_id: u128) {
     // Implement hot/cold data separation
     // Hot data: frequently accessed (status, owner)
     // Cold data: rarely accessed (full history, documents)
-    
+
     let waste_key = ("waste_v2", waste_id);
     if let Some(waste) = env.storage().instance().get::<_, crate::Waste>(&waste_key) {
-        // Cache hot data
         let hot_key = ("waste_hot", waste_id);
         let hot_data = (waste.is_active, waste.current_owner.clone(), waste.waste_type);
-        env.storage().temporary().set(&hot_key, &hot_data);
+
+        // Skip the write (and TTL bump) entirely when the cached hot copy is
+        // already up to date — avoids a redundant temporary-storage write on
+        // every call for waste items whose hot fields haven't changed.
+        let already_current = env
+            .storage()
+            .temporary()
+            .get::<_, (bool, Address, crate::WasteType)>(&hot_key)
+            .map(|cached| cached == hot_data)
+            .unwrap_or(false);
+
+        if !already_current {
+            env.storage().temporary().set(&hot_key, &hot_data);
+        }
         env.storage().temporary().extend_ttl(&hot_key, 5000, 5000);
     }
 }

--- a/stellar-contract/src/waste.rs
+++ b/stellar-contract/src/waste.rs
@@ -9,6 +9,12 @@
 //! - State-transition guards (active, confirmed, frozen, expired)
 //! - Transfer-route validation between participant roles
 //! - Batch operation helpers
+//!
+//! # Error consolidation audit (issue #1097)
+//! Audited: every fallible function here already returns `Result<_,
+//! errors::Error>` and no local error enum or `panic!`/`.expect()` exists in
+//! this file. No migration was needed. See `errors.rs` for the full audit
+//! covering all four files named in issue #1097.
 
 use crate::errors::Error;
 use crate::types::{ParticipantRole, Waste};


### PR DESCRIPTION
## ⚠️ WARNING: Implementation only — not tested

This change was written and reviewed by reading the code only. **No build or test run was performed** — this environment has no Rust/Cargo toolchain available, so none of this has been compiled, run through `cargo test`, or benchmarked with `cargo bench`. Please run the full test suite (and the benches for the #1098 section) before merging, and treat this as a draft-quality starting point rather than a verified fix.

Closes #1097
Closes #1098
Closes #1099
Closes #1100

## Summary

Each issue's premise was checked against the actual current state of `stellar-contract/src` before making changes — several of the named files described in the issues don't exist, and the real problems turned out to be different from (and in a couple of cases more serious than) what the issue descriptions assumed. Findings and rationale are documented inline as module/file doc comments so the audit trail stays with the code.

### #1097 — Consolidate duplicate error definitions
- Audited `waste.rs`, `incentive.rs`, and `participant.rs` (the files named in the issue): all three already fully delegate to `errors::Error` — no local error enums, no `panic!`/`.expect()`. No migration needed there.
- `transfer_mgmt.rs` does not exist; transfer logic lives inline in `lib.rs`.
- The actual duplication is in `lib.rs` itself: ~130 `panic!`/`.expect()` call sites with ad hoc string messages instead of the matching `Error` variant that often already exists. Converting these means changing ~dozens of `pub fn` signatures across an ~8,000-line file that 100+ test files exercise (some via `#[should_panic(expected = "...")]` on the exact panic text) — not something to do blind with zero compiler/test feedback. Documented as a migration note in `errors.rs` with a recommended incremental approach for a follow-up PR done with a working toolchain.
- No `Error` variant was renumbered and no `lib.rs` signatures changed, so this PR itself makes no breaking change to error codes.

### #1098 — Gas/resource optimization pass
- Neither `storage_optimizer.rs` nor `query_optimizer.rs` is called from `lib.rs` — verified via repo-wide search. They currently have **zero effect** on the deployed contract's resource costs, so no before/after bench claim would mean anything for them; documented this plus a static per-operation resource-cost budget in each file.
- Fixed two self-contained inefficiencies found while reading the code: `optimize_waste_storage` was writing a duplicate "hot" cache entry to temporary storage on every call even when unchanged (now skips the redundant write); `QueryPlan::new` was spinning up a whole throwaway `Env::default()` just to get an empty `Vec` (now takes the caller's `&Env`).
- Benches were not run (no toolchain in this environment, and they wouldn't reflect production cost anyway given the above).

### #1099 — Security review of key_rotation.rs
- Found a real gap: `install_key`/`rotate_key`/`revoke_key_version`/`purge_key_version` took an `admin: &Address` and only documented ("caller must ensure...") that it should be checked against the real admin list — `require_auth()` alone only proves the caller controls that address, not that it's an admin. (No live exposure today — this module has no call sites in `lib.rs` yet — but it was written to be wired in, so it's hardened now rather than left as a footgun for whoever wires it in later.)
- Fixed: every mutating function now takes `current_admins: &Vec<Address>` and enforces auth + membership internally via a new `authorize()` helper.
- Replaced the one `panic!` (`install_key` on an existing key) with a typed `KeyRotationError::AlreadyExists`.
- Reviewed atomicity: all reads/validation happen before any write, so a rejected call can't leave a half-completed rotation. Added tests: unauthorized-caller rejection for all four mutating functions, a rotation-failure-leaves-old-key-untouched (partial-failure) test, and a replay test confirming an old key hash is never returned as active again after rotation.

### #1100 — Consolidate participant management
- `participant_mgmt.rs` and `participant_storage.rs` don't exist. The real split is `participant.rs` (extracted under #759) vs. inline logic in `lib.rs` — and `participant.rs` turned out to be **entirely unused dead code** (confirmed via repo-wide search).
- Worse, it was silently broken: its storage key (`("PART", address)` in *persistent* storage) didn't match `lib.rs`'s real scheme (`(address,)` in *instance* storage), so if anything had ever called into it, it would have read/written the wrong location. Fixed to match reality.
- Also found `certification_from_weight`/`tier_from_tokens` duplicated `types::CertificationLevel`/`types::ParticipantTier` with *different* thresholds and input units (item-count vs. weight, weight vs. tokens) — a real drift risk. Now they delegate to the canonical `types.rs` implementations.
- Documented responsibility boundaries in both files' doc comments. Full rewiring of `lib.rs` to call through `participant.rs` (or `waste.rs`/`incentive.rs`, which are in the same unwired situation) touches dozens of functions across the whole contract and is left as a follow-up given the no-toolchain constraint on this change.

## Files changed
`errors.rs`, `incentive.rs`, `key_rotation.rs`, `lib.rs`, `participant.rs`, `query_optimizer.rs`, `storage_optimizer.rs`, `waste.rs`